### PR TITLE
Dockerfiles for .NET Core builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ There will be a need for modifying existing Dockerfiles or creating new ones.  F
     - Add/Update the Dockerfile(s)
     - If new Dockerfile(s) were added, then update the [manifest](#manifest)
 
-2. Validate the changes locally by running [build.ps1](./src/build.ps1).  It is strongly suggested to specify the `-DockerfilePath` option to avoid the overhead of building all the images.
+2. Validate the changes locally by running [build.ps1](./build.ps1).  It is strongly suggested to specify the `-DockerfilePath` option to avoid the overhead of building all the images.
 
     For example, if editing the [Fedora 24 Dockerfile](./src/fedora/24/Dockerfile), then run the following command to build just that Dockerfile.
 
@@ -57,7 +57,7 @@ The folder structure used in [src](./src) aligns with the tagging convention - `
 
 ### Manifest
 
-The [manifest.json](./src/manifest.json) contains metadata used by the build infrastructure to produce the Docker images.  The metadata describes which Dockerfiles to build, what tags to produce, and where to publish the images.  It is critical that the manifest gets updated appropriately when Dockerfiles are added/removed.  Each Dockerfile will have an entry that looks like the following.
+The [manifest.json](./manifest.json) contains metadata used by the build infrastructure to produce the Docker images.  The metadata describes which Dockerfiles to build, what tags to produce, and where to publish the images.  It is critical that the manifest gets updated appropriately when Dockerfiles are added/removed.  Each Dockerfile will have an entry that looks like the following.
 
 ```json
 "platforms": [

--- a/README.md
+++ b/README.md
@@ -1,2 +1,112 @@
-# dotnet-buildtools-prereqs-docker
-Used to maintain the docker images hosted at https://hub.docker.com/r/microsoft/dotnet-buildtools-prereqs/
+# Dockerfiles for .NET Core Builds
+
+The Dockerfiles in this repository are used for building the .NET Core product.  As such there are Dockerfiles for the various supported Linux distributions which setup the necessary prerequisites to build the .NET Core product.
+
+## Where are the published images
+
+The images produced from the Dockerfiles are published to the [microsoft/dotnet-buildtools-prereqs](https://hub.docker.com/r/microsoft/dotnet-buildtools-prereqs/) Docker Hub repository.
+
+- [Most recent tags](https://hub.docker.com/r/microsoft/dotnet-buildtools-prereqs/tags/)
+- [Full list of tags](https://registry.hub.docker.com/v1/repositories/microsoft/dotnet-buildtools-prereqs/tags)
+
+## How to identify an image
+
+The tag format used by an image is `microsoft/dotnet-buildtools-prereqs:<linux-distribution-name>-<version>-<variant>-<dockerfile-commit-sha>-<date-time>`
+
+- `<linux-distribution-name>` - name of the Linux distribution the image is based on
+- `<version>` - version of the Linux distribution
+- `<variant>` - name describing the specialization purpose of the image.  Often special dependencies are needed for certain parts of the product.  It can be beneficial to separate these dependencies into a separate Dockerfile/image.
+- `<dockerfile-commit-sha>` - Git commit SHA of the folder containing the Dockerfile the image was produced from
+- `<date-time>` - UTC timestamp (`yyyyMMddhhmmss`) of when the image was built
+
+## How to modify or create a new image
+
+There will be a need for modifying existing Dockerfiles or creating new ones.  For example, when a new Linux distribution/version needs to be supported, a corresponding Dockerfile will need to be created.  The following steps are a guideline for modifying/creating Dockerfiles.
+
+1. Edit Dockerfiles
+    - Add/Update the Dockerfile(s)
+    - If new Dockerfile(s) were added, then update the [manifest](#manifest)
+
+2. Validate the changes locally by running [build.ps1](./src/build.ps1).  It is strongly suggested to specify the `-DockerfilePath` option to avoid the overhead of building all the images.
+
+    For example, if editing the [Fedora 24 Dockerfile](./src/fedora/24/Dockerfile), then run the following command to build just that Dockerfile.
+
+    ```powershell
+    .\build.ps1 -DockerfilePath "fedora/24"
+    ```
+
+    It is a good practice to use `--dry-run` option on the first attempt to verify what commands will get run.
+
+    ```powershell
+    .\build.ps1 -DockerfilePath "fedora/24" -ImageBuilderCustomArgs "--dry-run"
+    ```
+
+    Partial paths and wildcards in the `-DockerfilePath` option are also supported.  The following example will build all the Fedora Dockerfiles.
+
+    ```powershell
+    .\build.ps1 -DockerfilePath "fedora/*"
+    ```
+
+3. Prepare a PR
+
+## Additional Info
+
+### Source Folder Structure
+
+The folder structure used in [src](./src) aligns with the tagging convention - `<linux-distribution-name>-<version>-<variant>`.  For example, the Dockerfile used to produce the `microsoft/dotnet-buildtools-prereqs:ubuntu-17.04-debpkg-c4fd48a-20171610061631` image is stored in the [src/ubuntu/17.04/debpkg](./src/ubuntu/17.04/debpkg) folder.
+
+### Manifest
+
+The [manifest.json](./src/manifest.json) contains metadata used by the build infrastructure to produce the Docker images.  The metadata describes which Dockerfiles to build, what tags to produce, and where to publish the images.  It is critical that the manifest gets updated appropriately when Dockerfiles are added/removed.  Each Dockerfile will have an entry that looks like the following.
+
+```json
+"platforms": [
+    {
+        "dockerfile": "alpine/3.6",
+        "os": "linux",
+        "tags": {
+            "alpine-3.6-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
+        }
+    }
+]
+```
+
+- `dockerfile` - relative path to the Dockerfile to build
+- `os` - (linux/windows) the OS type the Docker image is based on
+- `tags` - the collection of tags to create for the image
+- `$(System:DockerfileGitCommitSha)` and `$(System:TimeStamp)` - built in variable references that are evaluated at build time and substituted
+
+**Note:** The position in manifest determines the sequence in which the image will be built.
+
+### Image Dependency
+
+A precondition for building an image is to ensure that the base image specified in the [FROM]((https://docs.docker.com/engine/reference/builder/#from)) statement of the Dockerfile is available either locally or can be pulled from a Docker registry.  Some of the microsoft/dotnet-buildtools-prereqs Dockerfiles depend on other microsoft/dotnet-buildtools-prereqs Dockerfiles (e.g. [src/ubuntu/16.04/debpkg](./src/ubuntu/16.04/debpkg)).  In these cases, the `FROM` reference should not include the `<dockerfile-commit-sha>-<date-time>` portion of the tags.  This is referred to as a stable tag as it does not change from build to build.  This pattern is used so that the Dockerfiles do not need constant updating as new versions of the base images are built.  To support this scenario, the manifest entry for the base image must be defined to produce the stable tag.
+
+```json
+"platforms": [
+    {
+        "dockerfile": "ubuntu/16.04",
+        "os": "linux",
+        "tags": {
+            "ubuntu-16.04-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {},
+            "ubuntu-16.04": {
+                "isLocal": true
+            }
+        }
+    }
+]
+```
+
+### Hooks
+
+In certain cases, it is necessary to run custom logic before and after the Dockerfiles are built.  For example, to build the Dockerfiles that are used for cross-gen builds, the rootfs that gets copied into the Docker image needs to be built on the host OS.  To support these scenarios a `pre-build` or `post-build` bash or PowerShell script can be placed in a `hooks` folder next to the Dockerfile.  The scripts will get invoked by the build process.
+
+**Warning:** It is generally recommended to avoid the need to use hooks whenever possible.
+
+### Image-Builder
+
+The underlying tool used to build the Dockerfiles is called Image-Builder.  Its source is located at [dotnet/docker-tools](https://github.com/dotnet/docker-tools)
+
+----------
+
+For any questions, please contact dotnetdocker@microsoft.com

--- a/build.ps1
+++ b/build.ps1
@@ -35,14 +35,13 @@ function ExecuteWithRetry($Command) {
 }
 
 ExecuteWithRetry docker pull $ImageBuilderImageName
-$repoRoot = Split-Path -Path "$PSScriptRoot" -Parent
 
 & docker run --rm `
     -v /var/run/docker.sock:/var/run/docker.sock `
-    -v "${repoRoot}:/repo" `
-    -w /repo/src `
+    -v "${PSScriptRoot}:/repo" `
+    -w /repo `
     $ImageBuilderImageName `
-    build --manifest "/repo/src/manifest.json" --path "$DockerfilePath" "$ImageBuilderCustomArgs"
+    build --manifest "manifest.json" --path "$DockerfilePath" "$ImageBuilderCustomArgs"
 
 if ($LastExitCode -ne 0) {
     throw "Failed executing ImageBuilder."

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         {
           "platforms": [
             {
-              "dockerfile": "alpine/3.6",
+              "dockerfile": "src/alpine/3.6",
               "os": "linux",
               "tags": {
                 "alpine-3.6-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
@@ -17,7 +17,7 @@
         {
           "platforms": [
             {
-              "dockerfile": "centos/7",
+              "dockerfile": "src/centos/7",
               "os": "linux",
               "tags": {
                 "centos-7-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
@@ -28,7 +28,7 @@
         {
           "platforms": [
             {
-              "dockerfile": "centos/6",
+              "dockerfile": "src/centos/6",
               "os": "linux",
               "tags": {
                 "centos-6-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
@@ -39,7 +39,7 @@
         {
           "platforms": [
             {
-              "dockerfile": "debian/8.2/coredeps",
+              "dockerfile": "src/debian/8.2/coredeps",
               "os": "linux",
               "tags": {
                 "debian-8.2-coredeps-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {},
@@ -53,7 +53,7 @@
         {
           "platforms": [
             {
-              "dockerfile": "debian/8.2",
+              "dockerfile": "src/debian/8.2",
               "os": "linux",
               "tags": {
                 "debian-8.2-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {},
@@ -67,7 +67,7 @@
         {
           "platforms": [
             {
-              "dockerfile": "debian/8.2/debpkg",
+              "dockerfile": "src/debian/8.2/debpkg",
               "os": "linux",
               "tags": {
                 "debian-8.2-debpkg-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
@@ -78,7 +78,7 @@
         {
           "platforms": [
             {
-              "dockerfile": "debian/8.2/corert",
+              "dockerfile": "src/debian/8.2/corert",
               "os": "linux",
               "tags": {
                 "debian-8.2-corert-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
@@ -89,7 +89,7 @@
         {
           "platforms": [
             {
-              "dockerfile": "fedora/24",
+              "dockerfile": "src/fedora/24",
               "os": "linux",
               "tags": {
                 "fedora-24-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
@@ -100,7 +100,7 @@
         {
           "platforms": [
             {
-              "dockerfile": "fedora/23",
+              "dockerfile": "src/fedora/23",
               "os": "linux",
               "tags": {
                 "fedora-23-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
@@ -111,7 +111,7 @@
         {
           "platforms": [
             {
-              "dockerfile": "opensuse/42.1",
+              "dockerfile": "src/opensuse/42.1",
               "os": "linux",
               "tags": {
                 "opensuse-42.1-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
@@ -122,7 +122,7 @@
         {
           "platforms": [
             {
-              "dockerfile": "ubuntu/14.04",
+              "dockerfile": "src/ubuntu/14.04",
               "os": "linux",
               "tags": {
                 "ubuntu-14.04-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {},
@@ -136,7 +136,7 @@
         {
           "platforms": [
             {
-              "dockerfile": "ubuntu/14.04/debpkg",
+              "dockerfile": "src/ubuntu/14.04/debpkg",
               "os": "linux",
               "tags": {
                 "ubuntu-14.04-debpkg-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
@@ -147,7 +147,7 @@
         {
           "platforms": [
             {
-              "dockerfile": "ubuntu/14.04/coredeps",
+              "dockerfile": "src/ubuntu/14.04/coredeps",
               "os": "linux",
               "tags": {
                 "ubuntu-14.04-coredeps-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {},
@@ -161,7 +161,7 @@
         {
           "platforms": [
             {
-              "dockerfile": "ubuntu/14.04/crossdeps",
+              "dockerfile": "src/ubuntu/14.04/crossdeps",
               "os": "linux",
               "tags": {
                 "ubuntu-14.04-crossdeps-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {},
@@ -175,7 +175,7 @@
         {
           "platforms": [
             {
-              "dockerfile": "ubuntu/14.04/cross",
+              "dockerfile": "src/ubuntu/14.04/cross",
               "os": "linux",
               "tags": {
                 "ubuntu-14.04-cross-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
@@ -186,7 +186,7 @@
         {
           "platforms": [
             {
-              "dockerfile": "ubuntu/16.04",
+              "dockerfile": "src/ubuntu/16.04",
               "os": "linux",
               "tags": {
                 "ubuntu-16.04-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {},
@@ -200,7 +200,7 @@
         {
           "platforms": [
             {
-              "dockerfile": "ubuntu/16.04/debpkg",
+              "dockerfile": "src/ubuntu/16.04/debpkg",
               "os": "linux",
               "tags": {
                 "ubuntu-16.04-debpkg-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
@@ -211,7 +211,7 @@
         {
           "platforms": [
             {
-              "dockerfile": "ubuntu/16.04/coredeps",
+              "dockerfile": "src/ubuntu/16.04/coredeps",
               "os": "linux",
               "tags": {
                 "ubuntu-16.04-coredeps-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {},
@@ -225,7 +225,7 @@
         {
           "platforms": [
             {
-              "dockerfile": "ubuntu/16.04/crossdeps",
+              "dockerfile": "src/ubuntu/16.04/crossdeps",
               "os": "linux",
               "tags": {
                 "ubuntu-16.04-crossdeps-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {},
@@ -239,7 +239,7 @@
         {
           "platforms": [
             {
-              "dockerfile": "ubuntu/16.04/cross",
+              "dockerfile": "src/ubuntu/16.04/cross",
               "os": "linux",
               "tags": {
                 "ubuntu-16.04-cross-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
@@ -250,7 +250,7 @@
         {
           "platforms": [
             {
-              "dockerfile": "ubuntu/16.10",
+              "dockerfile": "src/ubuntu/16.10",
               "os": "linux",
               "tags": {
                 "ubuntu-16.10-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {},
@@ -264,7 +264,7 @@
         {
           "platforms": [
             {
-              "dockerfile": "ubuntu/16.10/debpkg",
+              "dockerfile": "src/ubuntu/16.10/debpkg",
               "os": "linux",
               "tags": {
                 "ubuntu-16.10-debpkg-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
@@ -275,7 +275,7 @@
         {
           "platforms": [
             {
-              "dockerfile": "ubuntu/17.04",
+              "dockerfile": "src/ubuntu/17.04",
               "os": "linux",
               "tags": {
                 "ubuntu-17.04-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {},
@@ -289,7 +289,7 @@
         {
           "platforms": [
             {
-              "dockerfile": "ubuntu/17.04/debpkg",
+              "dockerfile": "src/ubuntu/17.04/debpkg",
               "os": "linux",
               "tags": {
                 "ubuntu-17.04-debpkg-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
@@ -300,7 +300,7 @@
         {
           "platforms": [
             {
-              "dockerfile": "ubuntu/17.10",
+              "dockerfile": "src/ubuntu/17.10",
               "os": "linux",
               "tags": {
                 "ubuntu-17.10-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {},
@@ -314,7 +314,7 @@
         {
           "platforms": [
             {
-              "dockerfile": "ubuntu/17.10/debpkg",
+              "dockerfile": "src/ubuntu/17.10/debpkg",
               "os": "linux",
               "tags": {
                 "ubuntu-17.10-debpkg-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}

--- a/src/alpine/3.6/Dockerfile
+++ b/src/alpine/3.6/Dockerfile
@@ -1,0 +1,36 @@
+FROM alpine:3.6
+
+RUN apk update
+
+RUN apk add --no-cache \
+        autoconf \
+        bash \
+        build-base \
+        clang \
+        clang-dev \
+        cmake \
+        coreutils \
+        curl-dev \
+        gcc \
+        gettext-dev \
+        git \
+        icu-dev \
+        krb5-dev \
+        libtool \
+        libunwind-dev \
+        linux-headers \
+        llvm \
+        make \
+        openssl \
+        openssl-dev \
+        paxctl \
+        python \
+        util-linux-dev \
+        zlib-dev
+
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache \
+        userspace-rcu-dev \
+        lttng-ust-dev
+
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/testing add --no-cache \
+        lldb-dev

--- a/src/build.ps1
+++ b/src/build.ps1
@@ -40,9 +40,9 @@ $repoRoot = Split-Path -Path "$PSScriptRoot" -Parent
 & docker run --rm `
     -v /var/run/docker.sock:/var/run/docker.sock `
     -v "${repoRoot}:/repo" `
-    -w /repo/dockerfiles `
+    -w /repo/src `
     $ImageBuilderImageName `
-    build --manifest "/repo/dockerfiles/manifest.json" --path "$DockerfilePath" "$ImageBuilderCustomArgs"
+    build --manifest "/repo/src/manifest.json" --path "$DockerfilePath" "$ImageBuilderCustomArgs"
 
 if ($LastExitCode -ne 0) {
     throw "Failed executing ImageBuilder."

--- a/src/build.ps1
+++ b/src/build.ps1
@@ -1,0 +1,49 @@
+[cmdletbinding()]
+param(
+    [string]$DockerfilePath = "*",
+    [string]$ImageBuilderCustomArgs,
+    [string]$ImageBuilderImageName = 'microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20180117125404'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function ExecuteWithRetry($Command) {
+
+    $attempt = 0
+    $maxRetries = 5
+    $waitFactor = 6
+    while ($attempt -lt $maxRetries) {
+        try {
+            & $Command @args
+            break
+        }
+        catch {
+            Write-Warning "$_"
+        }
+
+        $attempt++
+        if ($attempt -ne $maxRetries) {
+            $waitTime = $attempt * $waitFactor
+            Write-Host "Retry ${attempt}/${maxRetries} failed, retrying in $waitTime seconds..."
+            Start-Sleep -Seconds ($waitTime)
+        }
+        else {
+            throw "Retry ${attempt}/${maxRetries} failed, no more retries left."
+        }
+    }
+}
+
+ExecuteWithRetry docker pull $ImageBuilderImageName
+$repoRoot = Split-Path -Path "$PSScriptRoot" -Parent
+
+& docker run --rm `
+    -v /var/run/docker.sock:/var/run/docker.sock `
+    -v "${repoRoot}:/repo" `
+    -w /repo/dockerfiles `
+    $ImageBuilderImageName `
+    build --manifest "/repo/dockerfiles/manifest.json" --path "$DockerfilePath" "$ImageBuilderCustomArgs"
+
+if ($LastExitCode -ne 0) {
+    throw "Failed executing ImageBuilder."
+}

--- a/src/centos/6/Dockerfile
+++ b/src/centos/6/Dockerfile
@@ -1,0 +1,147 @@
+FROM centos:6
+
+# Install dependencies
+
+RUN yum install -y \
+        wget \
+        epel-release \
+        centos-release-SCL \
+    && \
+    rpm --import http://linuxsoft.cern.ch/cern/slc6X/x86_64/RPM-GPG-KEY-cern && \
+    wget -O /etc/yum.repos.d/slc6-devtoolset.repo http://linuxsoft.cern.ch/cern/devtoolset/slc6-devtoolset.repo && \
+    yum install -y \
+        "perl(Time::HiRes)" \
+        autoconf \
+        cmake \
+        cmake3 \
+        devtoolset-2-toolchain \
+        doxygen \
+        expat-devel \
+        gcc \
+        gcc-c++ \
+        gettext-devel \
+        krb5-devel \
+        libedit-devel \
+        libidn-devel \
+        libmetalink-devel \
+        libnghttp2-devel \
+        libssh2-devel \
+        libunwind-devel \
+        libuuid-devel \
+        lttng-ust-devel \
+        lzma \
+        ncurses-devel \
+        openssl-devel \
+        perl-devel \
+        python-argparse \
+        python27 \
+        readline-devel \
+        swig \
+        wget \
+        xz \
+        zlib-devel \
+    && \
+    yum clean all
+
+# Build and install clang and lldb 3.9.1
+
+RUN wget ftp://sourceware.org/pub/binutils/snapshots/binutils-2.29.1.tar.xz && \
+    wget http://releases.llvm.org/3.9.1/cfe-3.9.1.src.tar.xz && \
+    wget http://releases.llvm.org/3.9.1/llvm-3.9.1.src.tar.xz && \
+    wget http://releases.llvm.org/3.9.1/lldb-3.9.1.src.tar.xz && \
+    wget http://releases.llvm.org/3.9.1/compiler-rt-3.9.1.src.tar.xz && \
+    \
+    tar -xf binutils-2.29.1.tar.xz && \
+    tar -xf llvm-3.9.1.src.tar.xz && \
+    mkdir llvm-3.9.1.src/tools/clang && \
+    mkdir llvm-3.9.1.src/tools/lldb && \
+    mkdir llvm-3.9.1.src/projects/compiler-rt && \
+    tar -xf cfe-3.9.1.src.tar.xz --strip 1 -C llvm-3.9.1.src/tools/clang && \
+    tar -xf lldb-3.9.1.src.tar.xz --strip 1 -C llvm-3.9.1.src/tools/lldb && \
+    tar -xf compiler-rt-3.9.1.src.tar.xz --strip 1 -C llvm-3.9.1.src/projects/compiler-rt && \
+    rm binutils-2.29.1.tar.xz && \
+    rm cfe-3.9.1.src.tar.xz && \
+    rm lldb-3.9.1.src.tar.xz && \
+    rm llvm-3.9.1.src.tar.xz && \
+    rm compiler-rt-3.9.1.src.tar.xz && \
+    \
+    mkdir llvmbuild && \
+    cd llvmbuild && \
+    scl enable python27 devtoolset-2 \
+    ' \
+        cmake3 \
+            -DCMAKE_CXX_COMPILER=/opt/rh/devtoolset-2/root/usr/bin/g++ \
+            -DCMAKE_C_COMPILER=/opt/rh/devtoolset-2/root/usr/bin/gcc \
+            -DCMAKE_LINKER=/opt/rh/devtoolset-2/root/usr/bin/ld \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DLLVM_LIBDIR_SUFFIX=64 \
+            -DLLVM_BINUTILS_INCDIR=../binutils-2.29.1/include \
+            ../llvm-3.9.1.src \
+        && \
+        make -j $(($(getconf _NPROCESSORS_ONLN)+1)) && \
+        make install \
+    ' && \
+    cd .. && \
+    rm -r llvmbuild && \
+    rm -r llvm-3.9.1.src && \
+    rm -r binutils-2.29.1
+
+# Build and install curl 7.45.0
+
+RUN wget https://curl.haxx.se/download/curl-7.45.0.tar.lzma && \
+    tar -xf curl-7.45.0.tar.lzma && \
+    rm curl-7.45.0.tar.lzma && \
+    cd curl-7.45.0 && \
+    scl enable python27 devtoolset-2 \
+    ' \
+        ./configure \
+            --disable-dict \
+            --disable-ftp \
+            --disable-gopher \
+            --disable-imap \
+            --disable-ldap \
+            --disable-ldaps \
+            --disable-libcurl-option \
+            --disable-manual \
+            --disable-pop3 \
+            --disable-rtsp \
+            --disable-smb \
+            --disable-smtp \
+            --disable-telnet \
+            --disable-tftp \
+            --enable-ipv6 \
+            --enable-optimize \
+            --enable-symbol-hiding \
+            --with-ca-bundle=/etc/pki/tls/certs/ca-bundle.crt \
+            --with-nghttp2 \
+            --with-gssapi \
+            --with-ssl \
+            --without-librtmp \
+        && \
+        make install \
+    ' && \
+    cd .. && \
+    rm -r curl-7.45.0
+
+# Install ICU 57.1
+
+RUN wget http://download.icu-project.org/files/icu4c/57.1/icu4c-57_1-RHEL6-x64.tgz && \
+    tar -xf icu4c-57_1-RHEL6-x64.tgz -C / && \
+    rm icu4c-57_1-RHEL6-x64.tgz
+
+# Compile and install a version of the git that supports the features that cli repo build needs
+# NOTE: The git needs to be built after the curl so that it can use the libcurl to add https
+# protocol support.
+RUN \
+    wget https://www.kernel.org/pub/software/scm/git/git-2.9.5.tar.gz && \
+    tar -xf git-2.9.5.tar.gz && \
+    rm git-2.9.5.tar.gz && \
+    cd  git-2.9.5 && \
+    make configure && \
+    ./configure --prefix=/usr/local --without-tcltk && \
+    make -j $(nproc --all) all && \
+    make install && \
+    cd .. && \
+    rm -r git-2.9.5
+
+ENV LD_LIBRARY_PATH=/usr/local/lib

--- a/src/centos/7/Dockerfile
+++ b/src/centos/7/Dockerfile
@@ -1,0 +1,80 @@
+FROM centos:7
+
+# Install dependencies
+
+RUN yum install -y \
+        centos-release-SCL \
+        epel-release \
+    && \
+    yum install -y \
+        "perl(Time::HiRes)" \
+        cmake \
+        cmake3 \
+        doxygen \
+        gcc \
+        gcc-c++ \
+        git \
+        krb5-devel \
+        libcurl-devel \
+        libedit-devel \
+        libicu-devel \
+        libidn-devel \
+        libmetalink-devel \
+        libnghttp2-devel \
+        libssh2-devel \
+        libunwind-devel \
+        libuuid-devel \
+        libxml2-devel \
+        lttng-ust-devel \
+        lzma \
+        make \
+        ncurses-devel \
+        openssl-devel \
+        python-argparse \
+        python27 \
+        python-devel \
+        readline-devel \
+        swig \
+        wget \
+        which \
+        xz \
+        zlib-devel \
+    && \
+    yum clean all
+
+# Build and install clang and lldb 3.9.1
+
+RUN wget ftp://sourceware.org/pub/binutils/snapshots/binutils-2.29.1.tar.xz && \
+    wget http://releases.llvm.org/3.9.1/cfe-3.9.1.src.tar.xz && \
+    wget http://releases.llvm.org/3.9.1/llvm-3.9.1.src.tar.xz && \
+    wget http://releases.llvm.org/3.9.1/lldb-3.9.1.src.tar.xz && \
+    wget http://releases.llvm.org/3.9.1/compiler-rt-3.9.1.src.tar.xz && \
+    \
+    tar -xf binutils-2.29.1.tar.xz && \
+    tar -xf llvm-3.9.1.src.tar.xz && \
+    mkdir llvm-3.9.1.src/tools/clang && \
+    mkdir llvm-3.9.1.src/tools/lldb && \
+    mkdir llvm-3.9.1.src/projects/compiler-rt && \
+    tar -xf cfe-3.9.1.src.tar.xz --strip 1 -C llvm-3.9.1.src/tools/clang && \
+    tar -xf lldb-3.9.1.src.tar.xz --strip 1 -C llvm-3.9.1.src/tools/lldb && \
+    tar -xf compiler-rt-3.9.1.src.tar.xz --strip 1 -C llvm-3.9.1.src/projects/compiler-rt && \
+    rm binutils-2.29.1.tar.xz && \
+    rm cfe-3.9.1.src.tar.xz && \
+    rm lldb-3.9.1.src.tar.xz && \
+    rm llvm-3.9.1.src.tar.xz && \
+    rm compiler-rt-3.9.1.src.tar.xz && \
+    \
+    mkdir llvmbuild && \
+    cd llvmbuild && \
+    cmake3 \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DLLVM_LIBDIR_SUFFIX=64\
+        -DLLVM_BINUTILS_INCDIR=../binutils-2.29.1/include \
+        ../llvm-3.9.1.src \
+    && \
+    make -j $(($(getconf _NPROCESSORS_ONLN)+1)) && \
+    make install && \
+    cd .. && \
+    rm -r llvmbuild && \
+    rm -r llvm-3.9.1.src && \
+    rm -r binutils-2.29.1

--- a/src/debian/8.2/Dockerfile
+++ b/src/debian/8.2/Dockerfile
@@ -1,0 +1,21 @@
+FROM microsoft/dotnet-buildtools-prereqs:debian-8.2-coredeps
+
+# Install the base toolchain we need to build anything (clang, cmake, make and the like)
+# this does not include libraries that we need to compile different projects, we'd like
+# them in a different layer.
+RUN apt-get update \
+    && apt-get install -y wget \
+    && echo "deb http://llvm.org/apt/jessie/ llvm-toolchain-jessie main" | tee /etc/apt/sources.list.d/llvm.list \
+    && echo "deb http://llvm.org/apt/jessie/ llvm-toolchain-jessie-3.9 main" | tee -a /etc/apt/sources.list.d/llvm.list \
+    && wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | apt-key add - \
+    && apt-get update \
+    && apt-get install -y \
+               clang-3.5 \
+               clang-3.9 \
+               cmake \
+               liblldb-3.9-dev \
+               lldb-3.9 \
+               llvm-3.5 \
+               llvm-3.9 \
+               make \
+    && rm -rf /var/lib/apt/lists/*

--- a/src/debian/8.2/coredeps/Dockerfile
+++ b/src/debian/8.2/coredeps/Dockerfile
@@ -1,0 +1,29 @@
+FROM debian:8.2
+
+# Install tools used by the VSO build automation.  nodejs-legacy is a Debian specific
+# package that provides `node' on the path (which azure cli needs).
+RUN apt-get update \
+    && apt-get install -y \
+            git \
+            nodejs \
+            nodejs-legacy \
+            npm \
+            tar \
+            zip \
+    && rm -rf /var/lib/apt/lists/* \
+    && npm install -g azure-cli@0.10.2 \
+    && npm cache clean
+
+# Dependencies for generic .NET Core builds
+RUN apt-get update \
+    && apt-get install -y \
+            curl \
+            gettext \
+            libcurl4-openssl-dev \
+            libgdiplus \
+            libicu-dev \
+            liblttng-ust-dev \
+            libssl-dev \
+            libunwind8-dev \
+            uuid-dev \
+    && rm -rf /var/lib/apt/lists/*

--- a/src/debian/8.2/corert/Dockerfile
+++ b/src/debian/8.2/corert/Dockerfile
@@ -1,0 +1,17 @@
+FROM microsoft/dotnet-buildtools-prereqs:debian-8.2-coredeps
+
+# Install tools needs to build CoreRT.
+RUN apt-get update \
+    && apt-get install -y wget \
+    && echo "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.6 main" | tee /etc/apt/sources.list.d/llvm36.list \
+    && echo "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.9 main" | tee /etc/apt/sources.list.d/llvm39.list \
+    && wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | apt-key add - \
+    && apt-get update \
+    && apt-get install -y \
+               clang-3.9 \
+               cmake \
+               lldb-3.6 \
+               lldb-3.6-dev \
+               llvm-3.9-dev \
+               make \
+    && rm -rf /var/lib/apt/lists/*

--- a/src/debian/8.2/debpkg/Dockerfile
+++ b/src/debian/8.2/debpkg/Dockerfile
@@ -1,0 +1,15 @@
+FROM microsoft/dotnet-buildtools-prereqs:debian-8.2
+
+# Install the deb packaging toolchain we need to build debs
+RUN apt-get update \
+    && apt-get -y install \
+        debhelper \
+        build-essential \
+        devscripts \
+    && rm -rf /var/lib/apt/lists/*
+
+# liblldb is needed so deb package build does not throw missing library info errors
+RUN echo "deb http://llvm.org/apt/jessie/ llvm-toolchain-jessie-3.9 main" > /etc/apt/sources.list.d/llvm-toolchain.list \
+    && apt-get update \
+    && apt-get -y install liblldb-3.9 \
+    && rm -rf /var/lib/apt/lists/*

--- a/src/fedora/23/Dockerfile
+++ b/src/fedora/23/Dockerfile
@@ -1,0 +1,32 @@
+FROM fedora:23
+
+# Install the base toolchain we need to build anything (clang, cmake, make and the like)
+# this does not include libraries that we need to compile different projects, we'd like
+# them in a different layer.
+RUN dnf install -y cmake \
+        clang \
+        lldb-devel \
+        make \
+        which && \
+    dnf clean all
+
+# Install tools used by the VSO build automation.
+RUN dnf install -y git \
+        zip \
+        tar \
+        nodejs \
+        npm && \
+    dnf clean all && \
+    npm install -g azure-cli@0.9.20 && \
+    npm cache clean
+
+# Dependencies of CoreCLR and CoreFX.
+RUN dnf install -y \
+        libcurl-devel \
+        libgdiplus \
+        libicu-devel \
+        libunwind-devel \
+        libuuid-devel \
+        lttng-ust-devel \
+        openssl-devel \
+    && dnf clean all

--- a/src/fedora/24/Dockerfile
+++ b/src/fedora/24/Dockerfile
@@ -1,0 +1,42 @@
+FROM fedora:24
+
+# Workaround to avoid NuGet restore timeout
+RUN dnf upgrade -y nss \
+    && dnf clean all
+
+# Install the base toolchain we need to build anything (clang, cmake, make and the like)
+# this does not include libraries that we need to compile different projects, we'd like
+# them in a different layer.
+RUN dnf install -y \
+        clang \
+        cmake \
+        lldb-devel \
+        llvm-devel \
+        make \
+        python \
+        which \
+    && dnf clean all
+
+# Install tools used by the VSO build automation.
+RUN dnf install -y \
+        git \
+        npm \
+        nodejs \
+        tar \
+        zip \
+    && dnf clean all \
+    && npm install -g azure-cli \
+    && npm cache clean
+
+# Dependencies of CoreCLR and CoreFX.
+RUN dnf install -y \
+        glibc-locale-source \
+        libcurl-devel \
+        libgdiplus \
+        libicu-devel \
+        libunwind-devel \
+        libuuid-devel \
+        lttng-ust-devel \
+        openssl-devel \
+        uuid-devel \
+    && dnf clean all

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,0 +1,328 @@
+{
+  "repos": [
+    {
+      "name": "microsoft/dotnet-buildtools-prereqs",
+      "images": [
+        {
+          "platforms": [
+            {
+              "dockerfile": "alpine/3.6",
+              "os": "linux",
+              "tags": {
+                "alpine-3.6-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "centos/7",
+              "os": "linux",
+              "tags": {
+                "centos-7-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "centos/6",
+              "os": "linux",
+              "tags": {
+                "centos-6-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "debian/8.2/coredeps",
+              "os": "linux",
+              "tags": {
+                "debian-8.2-coredeps-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {},
+                "debian-8.2-coredeps": {
+                  "isLocal": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "debian/8.2",
+              "os": "linux",
+              "tags": {
+                "debian-8.2-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {},
+                "debian-8.2": {
+                  "isLocal": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "debian/8.2/debpkg",
+              "os": "linux",
+              "tags": {
+                "debian-8.2-debpkg-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "debian/8.2/corert",
+              "os": "linux",
+              "tags": {
+                "debian-8.2-corert-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "fedora/24",
+              "os": "linux",
+              "tags": {
+                "fedora-24-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "fedora/23",
+              "os": "linux",
+              "tags": {
+                "fedora-23-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "opensuse/42.1",
+              "os": "linux",
+              "tags": {
+                "opensuse-42.1-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "ubuntu/14.04",
+              "os": "linux",
+              "tags": {
+                "ubuntu-14.04-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {},
+                "ubuntu-14.04": {
+                  "isLocal": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "ubuntu/14.04/debpkg",
+              "os": "linux",
+              "tags": {
+                "ubuntu-14.04-debpkg-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "ubuntu/14.04/coredeps",
+              "os": "linux",
+              "tags": {
+                "ubuntu-14.04-coredeps-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {},
+                "ubuntu-14.04-coredeps": {
+                  "isLocal": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "ubuntu/14.04/crossdeps",
+              "os": "linux",
+              "tags": {
+                "ubuntu-14.04-crossdeps-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {},
+                "ubuntu-14.04-crossdeps": {
+                  "isLocal": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "ubuntu/14.04/cross",
+              "os": "linux",
+              "tags": {
+                "ubuntu-14.04-cross-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "ubuntu/16.04",
+              "os": "linux",
+              "tags": {
+                "ubuntu-16.04-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {},
+                "ubuntu-16.04": {
+                  "isLocal": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "ubuntu/16.04/debpkg",
+              "os": "linux",
+              "tags": {
+                "ubuntu-16.04-debpkg-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "ubuntu/16.04/coredeps",
+              "os": "linux",
+              "tags": {
+                "ubuntu-16.04-coredeps-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {},
+                "ubuntu-16.04-coredeps": {
+                  "isLocal": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "ubuntu/16.04/crossdeps",
+              "os": "linux",
+              "tags": {
+                "ubuntu-16.04-crossdeps-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {},
+                "ubuntu-16.04-crossdeps": {
+                  "isLocal": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "ubuntu/16.04/cross",
+              "os": "linux",
+              "tags": {
+                "ubuntu-16.04-cross-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "ubuntu/16.10",
+              "os": "linux",
+              "tags": {
+                "ubuntu-16.10-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {},
+                "ubuntu-16.10": {
+                  "isLocal": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "ubuntu/16.10/debpkg",
+              "os": "linux",
+              "tags": {
+                "ubuntu-16.10-debpkg-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "ubuntu/17.04",
+              "os": "linux",
+              "tags": {
+                "ubuntu-17.04-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {},
+                "ubuntu-17.04": {
+                  "isLocal": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "ubuntu/17.04/debpkg",
+              "os": "linux",
+              "tags": {
+                "ubuntu-17.04-debpkg-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "ubuntu/17.10",
+              "os": "linux",
+              "tags": {
+                "ubuntu-17.10-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {},
+                "ubuntu-17.10": {
+                  "isLocal": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "ubuntu/17.10/debpkg",
+              "os": "linux",
+              "tags": {
+                "ubuntu-17.10-debpkg-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/opensuse/42.1/Dockerfile
+++ b/src/opensuse/42.1/Dockerfile
@@ -1,0 +1,40 @@
+FROM opensuse:42.1
+
+# Install the base toolchain we need to build anything (clang, cmake, make and the like)
+# this does not include libraries that we need to compile different projects, we'd like
+# them in a different layer.
+RUN zypper -n install \
+        cmake \
+        hostname \
+        lldb-devel \
+        llvm-clang \
+        python-xml \
+        which \
+        wget \
+    && ln -s /usr/bin/clang++ /usr/bin/clang++-3.5 \
+    && zypper clean -a
+
+# Install tools used by the VSO build automation.
+RUN zypper -n install \
+        git \
+        npm \
+        nodejs \
+        tar \
+        zip \
+    && zypper clean -a \
+    && npm install -g azure-cli \
+    && npm cache clean
+
+# Dependencies of CoreCLR and CoreFX.
+RUN zypper -n install --force-resolution \
+        glibc-locale \
+        krb5-devel \
+        libcurl-devel \
+        libgdiplus0 \
+        libicu-devel \
+        libunwind-devel \
+        libuuid-devel \
+        lttng-ust-devel \
+        libopenssl-devel \
+        uuid-devel \
+    && zypper clean -a

--- a/src/ubuntu/14.04/Dockerfile
+++ b/src/ubuntu/14.04/Dockerfile
@@ -1,0 +1,45 @@
+FROM ubuntu:14.04
+
+# Install the base toolchain we need to build anything (clang, cmake, make and the like)
+# this does not include libraries that we need to compile different projects, we'd like
+# them in a different layer.
+RUN apt-get update && \
+    apt-get install -y wget && \
+    echo "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty main" | tee /etc/apt/sources.list.d/llvm.list && \
+    echo "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.9 main" | tee -a /etc/apt/sources.list.d/llvm.list && \
+    wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | apt-key add - && \
+    apt-get update && \
+    apt-get install -y \
+            clang-3.5 \
+            clang-3.9 \
+            cmake \
+            liblldb-3.9-dev \
+            lldb-3.9 \
+            llvm-3.5 \
+            llvm-3.9 \
+            make && \
+    apt-get clean
+
+# Install tools used by the VSO build automation.  nodejs-legacy is a Debian specific
+# package that provides `node' on the path (which azure cli needs).
+RUN apt-get install -y git \
+            zip \
+            tar \
+            nodejs \
+            nodejs-legacy \
+            npm && \
+    apt-get clean && \
+    npm install -g azure-cli@0.9.15 && \
+    npm cache clean
+
+# Dependencies for CoreCLR and CoreFX
+RUN apt-get install -y gettext \
+            libcurl4-openssl-dev \
+            libgdiplus \
+            libicu-dev \
+            liblttng-ust-dev \
+            libssl-dev \
+            libunwind8-dev \
+            libunwind8 \
+            uuid-dev \
+    && apt-get clean

--- a/src/ubuntu/14.04/coredeps/Dockerfile
+++ b/src/ubuntu/14.04/coredeps/Dockerfile
@@ -1,0 +1,29 @@
+FROM ubuntu:14.04
+
+# Install tools used by the VSO build automation.  nodejs-legacy is a Debian specific
+# package that provides 'node' on the path (which azure cli needs).
+RUN apt-get update \
+    && apt-get install -y \
+        git \
+        nodejs \
+        nodejs-legacy \
+        npm \
+        tar \
+        zip \
+    && rm -rf /var/lib/apt/lists/* \
+    && npm install -g azure-cli@0.9.15 \
+    && npm cache clean
+
+# Dependencies for CoreCLR and CoreFX
+RUN apt-get update \
+    && apt-get install -y \
+        gettext \
+        libcurl4-openssl-dev \
+        libgdiplus \
+        libicu-dev \
+        liblttng-ust-dev \
+        libssl-dev \
+        libunwind8 \
+        libunwind8-dev \
+        uuid-dev \
+    && rm -rf /var/lib/apt/lists/*

--- a/src/ubuntu/14.04/cross/Dockerfile
+++ b/src/ubuntu/14.04/cross/Dockerfile
@@ -1,0 +1,3 @@
+FROM microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-crossdeps
+
+ADD rootfs crossrootfs

--- a/src/ubuntu/14.04/cross/hooks/post-build
+++ b/src/ubuntu/14.04/cross/hooks/post-build
@@ -1,0 +1,1 @@
+../../../build-scripts/build-rootfs-cleanup.sh

--- a/src/ubuntu/14.04/cross/hooks/pre-build
+++ b/src/ubuntu/14.04/cross/hooks/pre-build
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+$(dirname ${BASH_SOURCE[0]})/../../../build-scripts/build-rootfs.sh ubuntu-14.04 trusty

--- a/src/ubuntu/14.04/crossdeps/Dockerfile
+++ b/src/ubuntu/14.04/crossdeps/Dockerfile
@@ -1,0 +1,31 @@
+FROM microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-coredeps
+
+# Install the base toolchain we need to build anything (clang, cmake, make and the like).
+RUN apt-get update \
+    && apt-get install -y wget \
+    && echo "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.6 main" | tee /etc/apt/sources.list.d/llvm.list \
+    && wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | apt-key add - \
+    && apt-get update \
+    && apt-get install -y \
+        binfmt-support \
+        binutils-arm-linux-gnueabihf \
+        clang-3.6 \
+        cmake \
+        debootstrap \
+        llvm-3.6 \
+        make \
+        qemu \
+        qemu-user-static \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update \
+    && echo "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main" >> /etc/apt/sources.list.d/llvm.list \
+    && echo "deb-src http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main" >> /etc/apt/sources.list.d/llvm.list \
+    && wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
+    && apt-get update \
+    && apt-get install -y \
+        llvm-3.9 \
+        clang-3.9 \
+        liblldb-3.9-dev \
+        lldb-3.9 \
+    && rm -rf /var/lib/apt/lists/*

--- a/src/ubuntu/14.04/debpkg/Dockerfile
+++ b/src/ubuntu/14.04/debpkg/Dockerfile
@@ -1,0 +1,15 @@
+FROM microsoft/dotnet-buildtools-prereqs:ubuntu-14.04
+
+# Install the deb packaging toolchain we need to build debs
+RUN apt-get update \
+    && apt-get -y install \
+        debhelper \
+        build-essential \
+        devscripts \
+    && rm -rf /var/lib/apt/lists/*
+
+# liblldb is needed so deb package build does not throw missing library info errors
+RUN echo "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.9 main" > /etc/apt/sources.list.d/llvm-toolchain.list \
+    && apt-get update \
+    && apt-get -y install liblldb-3.9 \
+    && rm -rf /var/lib/apt/lists/*

--- a/src/ubuntu/16.04/Dockerfile
+++ b/src/ubuntu/16.04/Dockerfile
@@ -1,0 +1,46 @@
+FROM ubuntu:16.04
+
+# Install the base toolchain we need to build anything (clang, cmake, make and the like)
+# this does not include libraries that we need to compile different projects, we'd like
+# them in a different layer.
+RUN apt-get update && \
+    apt-get install -y wget && \
+    echo "deb http://llvm.org/apt/xenial/ llvm-toolchain-xenial main" | tee /etc/apt/sources.list.d/llvm.list && \
+    echo "deb http://llvm.org/apt/xenial/ llvm-toolchain-xenial-3.9 main" | tee -a /etc/apt/sources.list.d/llvm.list && \
+    wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | apt-key add - && \
+    apt-get update && \
+    apt-get install -y \
+            cmake \
+            clang-3.5 \
+            clang-3.9 \
+            liblldb-3.9-dev && \
+            lldb-3.9 \
+            llvm-3.5 \
+            llvm-3.9 \
+            make \
+    apt-get clean
+
+# Install tools used by the VSO build automation.  nodejs-legacy is a Debian specific
+# package that provides `node' on the path (which azure cli needs).
+RUN apt-get install -y git \
+            zip \
+            tar \
+            nodejs \
+            nodejs-legacy \
+            npm && \
+    apt-get clean && \
+    npm install -g azure-cli@0.9.20 && \
+    npm cache clean
+
+# Dependencies for CoreCLR and CoreFX
+RUN apt-get install -y gettext \
+            libcurl4-openssl-dev \
+            libgdiplus \
+            libicu-dev \
+            libkrb5-dev \
+            liblttng-ust-dev \
+            libssl-dev \
+            libunwind8-dev \
+            libunwind8 \
+            uuid-dev \
+    && apt-get clean

--- a/src/ubuntu/16.04/coredeps/Dockerfile
+++ b/src/ubuntu/16.04/coredeps/Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:16.04
+
+# Install tools used by the VSO build automation.  nodejs-legacy is a Debian specific
+# package that provides `node' on the path (which azure cli needs).
+RUN apt-get update \
+    && apt-get install -y \
+        git \
+        nodejs \
+        nodejs-legacy \
+        npm \
+        tar \
+        zip \
+    && rm -rf /var/lib/apt/lists/* \
+    && npm install -g azure-cli@0.9.20 \
+    && npm cache clean
+
+# Dependencies for CoreCLR and CoreFX
+RUN apt-get update \
+    && apt-get install -y \
+        gettext \
+        libcurl4-openssl-dev \
+        libgdiplus \
+        libicu-dev \
+        libkrb5-dev \
+        liblttng-ust-dev \
+        libssl-dev \
+        libunwind8 \
+        libunwind8-dev \
+        uuid-dev \
+    && rm -rf /var/lib/apt/lists/*

--- a/src/ubuntu/16.04/cross/Dockerfile
+++ b/src/ubuntu/16.04/cross/Dockerfile
@@ -1,0 +1,3 @@
+FROM microsoft/dotnet-buildtools-prereqs:ubuntu-16.04-crossdeps
+
+ADD rootfs crossrootfs

--- a/src/ubuntu/16.04/cross/hooks/post-build
+++ b/src/ubuntu/16.04/cross/hooks/post-build
@@ -1,0 +1,1 @@
+../../../build-scripts/build-rootfs-cleanup.sh

--- a/src/ubuntu/16.04/cross/hooks/pre-build
+++ b/src/ubuntu/16.04/cross/hooks/pre-build
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+$(dirname ${BASH_SOURCE[0]})/../../../build-scripts/build-rootfs.sh ubuntu-16.04 xenial

--- a/src/ubuntu/16.04/crossdeps/Dockerfile
+++ b/src/ubuntu/16.04/crossdeps/Dockerfile
@@ -1,0 +1,32 @@
+FROM microsoft/dotnet-buildtools-prereqs:ubuntu-16.04-coredeps
+
+# Install the base toolchain we need to build anything (clang, cmake, make and the like).
+RUN apt-get update \
+    && apt-get install -y wget \
+    && echo "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.6 main" | tee /etc/apt/sources.list.d/llvm.list \
+    && wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | apt-key add - \
+    && apt-get update \
+    && apt-get install -y \
+        binfmt-support \
+        binutils-arm-linux-gnueabihf \
+        clang-3.6 \
+        cmake \
+        debootstrap \
+        llvm-3.6 \
+        make \
+        qemu \
+        qemu-user-static \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update \
+    && echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-3.9 main" >> /etc/apt/sources.list.d/llvm.list \
+    && echo "deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-3.9 main" >> /etc/apt/sources.list.d/llvm.list \
+    && wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
+    && apt-get update \
+    && apt-get install -y \
+        llvm-3.9 \
+        clang-3.9 \
+        liblldb-3.9-dev \
+        lldb-3.9 \
+        python-lldb-3.9 \
+    && rm -rf /var/lib/apt/lists/*

--- a/src/ubuntu/16.04/debpkg/Dockerfile
+++ b/src/ubuntu/16.04/debpkg/Dockerfile
@@ -1,0 +1,15 @@
+FROM microsoft/dotnet-buildtools-prereqs:ubuntu-16.04
+
+# Install the deb packaging toolchain we need to build debs
+RUN apt-get update \
+    && apt-get -y install \
+        debhelper \
+        build-essential \
+        devscripts \
+    && rm -rf /var/lib/apt/lists/*
+
+# liblldb is needed so deb package build does not throw missing library info errors
+RUN echo "deb http://llvm.org/apt/xenial/ llvm-toolchain-xenial-3.9 main" > /etc/apt/sources.list.d/llvm-toolchain.list \
+    && apt-get update \
+    && apt-get -y install liblldb-3.9 \
+    && rm -rf /var/lib/apt/lists/*

--- a/src/ubuntu/16.10/Dockerfile
+++ b/src/ubuntu/16.10/Dockerfile
@@ -1,0 +1,50 @@
+FROM ubuntu:16.10
+
+# Install the base toolchain we need to build anything (clang, cmake, make and the like)
+# this does not include libraries that we need to compile different projects, we'd like
+# them in a different layer.
+RUN apt-get update \
+    && apt-get install -y wget \
+    && echo "deb http://llvm.org/apt/yakkety/ llvm-toolchain-yakkety main" | tee /etc/apt/sources.list.d/llvm.list \
+    && echo "deb http://llvm.org/apt/yakkety/ llvm-toolchain-yakkety-3.9 main" | tee -a /etc/apt/sources.list.d/llvm.list \
+    && wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | apt-key add - \
+    && apt-get update \
+    && apt-get install -y \
+        clang-3.5 \
+        clang-3.9 \
+        cmake \
+        liblldb-3.9-dev \
+        lldb-3.9 \
+        llvm-3.5 \
+        llvm-3.9 \
+        make \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install tools used by the VSO build automation.  nodejs-legacy is a Debian specific
+# package that provides `node' on the path (which azure cli needs).
+RUN apt-get update \
+    && apt-get install -y \
+        git \
+        nodejs \
+        nodejs-legacy \
+        npm \
+        tar \
+        zip \
+    && rm -rf /var/lib/apt/lists/* \
+    && npm install -g azure-cli@0.10.15 \
+    && npm cache clean
+
+# Dependencies for CoreCLR and CoreFX
+RUN apt-get update \
+    && apt-get install -y \
+        gettext \
+        libcurl4-openssl-dev \
+        libgdiplus \
+        libicu-dev \
+        libkrb5-dev \
+        liblttng-ust-dev \
+        libssl-dev \
+        libunwind8 \
+        libunwind8-dev \
+        uuid-dev \
+    && rm -rf /var/lib/apt/lists/*

--- a/src/ubuntu/16.10/debpkg/Dockerfile
+++ b/src/ubuntu/16.10/debpkg/Dockerfile
@@ -1,0 +1,15 @@
+FROM microsoft/dotnet-buildtools-prereqs:ubuntu-16.10
+
+# Install the deb packaging toolchain we need to build debs
+RUN apt-get update \
+    && apt-get -y install \
+        debhelper \
+        build-essential \
+        devscripts \
+    && rm -rf /var/lib/apt/lists/*
+
+# liblldb is needed so deb package build does not throw missing library info errors
+RUN echo "deb http://llvm.org/apt/yakkety/ llvm-toolchain-yakkety-3.9 main" > /etc/apt/sources.list.d/llvm-toolchain.list \
+    && apt-get update \
+    && apt-get -y install liblldb-3.9 \
+    && rm -rf /var/lib/apt/lists/*

--- a/src/ubuntu/17.04/Dockerfile
+++ b/src/ubuntu/17.04/Dockerfile
@@ -1,0 +1,48 @@
+FROM ubuntu:17.04
+
+# Install the base toolchain we need to build anything (clang, cmake, make and the like)
+# this does not include libraries that we need to compile different projects, we'd like
+# them in a different layer.
+RUN apt-get update \
+    && apt-get install -y wget \
+    && echo "deb http://llvm.org/apt/zesty/ llvm-toolchain-zesty main" | tee /etc/apt/sources.list.d/llvm.list \
+    && echo "deb http://llvm.org/apt/zesty/ llvm-toolchain-zesty-3.9 main" | tee -a /etc/apt/sources.list.d/llvm.list \
+    && wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | apt-key add - \
+    && apt-get update \
+    && apt-get install -y \
+        clang-3.9 \
+        cmake \
+        liblldb-3.9-dev \
+        lldb-3.9 \
+        llvm-3.9 \
+        make \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install tools used by the VSO build automation.  nodejs-legacy is a Debian specific
+# package that provides `node' on the path (which azure cli needs).
+RUN apt-get update \
+    && apt-get install -y \
+        git \
+        nodejs \
+        nodejs-legacy \
+        npm \
+        tar \
+        zip \
+    && rm -rf /var/lib/apt/lists/* \
+    && npm install -g azure-cli@0.10.15 \
+    && npm cache clean
+
+# Dependencies for CoreCLR and CoreFX
+RUN apt-get update \
+    && apt-get install -y \
+        gettext \
+        libcurl4-openssl-dev \
+        libgdiplus \
+        libicu-dev \
+        libkrb5-dev \
+        liblttng-ust-dev \
+        libssl-dev \
+        libunwind8 \
+        libunwind8-dev \
+        uuid-dev \
+    && rm -rf /var/lib/apt/lists/*

--- a/src/ubuntu/17.04/debpkg/Dockerfile
+++ b/src/ubuntu/17.04/debpkg/Dockerfile
@@ -1,0 +1,15 @@
+FROM microsoft/dotnet-buildtools-prereqs:ubuntu-17.04
+
+# Install the deb packaging toolchain we need to build debs
+RUN apt-get update \
+    && apt-get -y install \
+        debhelper \
+        build-essential \
+        devscripts \
+    && rm -rf /var/lib/apt/lists/*
+
+# liblldb is needed so deb package build does not throw missing library info errors
+# Package resource list is already set in the base Image /etc/apt/sources.list.d/llvm.list
+RUN apt-get update \
+    && apt-get -y install liblldb-3.9 \
+    && rm -rf /var/lib/apt/lists/*

--- a/src/ubuntu/17.10/Dockerfile
+++ b/src/ubuntu/17.10/Dockerfile
@@ -1,0 +1,47 @@
+FROM ubuntu:17.10
+
+# Install the base toolchain we need to build anything (clang, cmake, make and the like)
+# this does not include libraries that we need to compile different projects, we'd like
+# them in a different layer.
+RUN apt-get update \
+    && apt-get install -y wget \
+    && echo "deb http://llvm.org/apt/artful/ llvm-toolchain-artful main" | tee /etc/apt/sources.list.d/llvm.list \
+    && echo "deb http://llvm.org/apt/artful/ llvm-toolchain-artful-3.9 main" | tee -a /etc/apt/sources.list.d/llvm.list \
+    && wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | apt-key add - \
+    && apt-get update \
+    && apt-get install -y \
+        clang-3.9 \
+        cmake \
+        liblldb-3.9-dev \
+        lldb-3.9 \
+        llvm-3.9 \
+        make \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install tools used by the VSO build automation.  nodejs-legacy is a Debian specific
+# package that provides `node' on the path (which azure cli needs).
+RUN apt-get update \
+    && apt-get install -y \
+        git \
+        nodejs \
+        npm \
+        tar \
+        zip \
+    && rm -rf /var/lib/apt/lists/* \
+    && npm install -g azure-cli@0.10.15 \
+    && npm cache clean
+
+# Dependencies for CoreCLR and CoreFX
+RUN apt-get update \
+    && apt-get install -y \
+        gettext \
+        libcurl4-openssl-dev \
+        libgdiplus \
+        libicu-dev \
+        libkrb5-dev \
+        liblttng-ust-dev \
+        libssl-dev \
+        libunwind8 \
+        libunwind8-dev \
+        uuid-dev \
+    && rm -rf /var/lib/apt/lists/*

--- a/src/ubuntu/17.10/debpkg/Dockerfile
+++ b/src/ubuntu/17.10/debpkg/Dockerfile
@@ -1,0 +1,15 @@
+FROM microsoft/dotnet-buildtools-prereqs:ubuntu-17.10
+
+# Install the deb packaging toolchain we need to build debs
+RUN apt-get update \
+    && apt-get -y install \
+        debhelper \
+        build-essential \
+        devscripts \
+    && rm -rf /var/lib/apt/lists/*
+
+# liblldb is needed so deb package build does not throw missing library info errors
+# Package resource list is already set in the base Image /etc/apt/sources.list.d/llvm.list
+RUN apt-get update \
+    && apt-get -y install liblldb-3.9 \
+    && rm -rf /var/lib/apt/lists/*

--- a/src/ubuntu/build-scripts/build-rootfs-cleanup.sh
+++ b/src/ubuntu/build-scripts/build-rootfs-cleanup.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+rm -rf $PWD/rootfs

--- a/src/ubuntu/build-scripts/build-rootfs.sh
+++ b/src/ubuntu/build-scripts/build-rootfs.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Stop script on NZEC
+set -e
+# Stop script if unbound variable found (use ${var:-} if intentional)
+set -u
+
+os=$1
+crossToolset=$2
+
+scriptsVolume="scripts$(date +%s)"
+dockerCrossDepsTag="microsoft/dotnet-buildtools-prereqs:${os}-crossdeps"
+
+echo "Using $dockerCrossDepsTag to clone core-setup to fetch scripts used to build cross-toolset"
+docker run --rm -v $scriptsVolume:/scripts $dockerCrossDepsTag git clone https://github.com/dotnet/core-setup /scripts
+
+rm -rf $PWD/rootfs
+mkdir rootfs
+
+# To support additional architectures for which cross toolset needs to be setup,
+# simply add it to crossArchArray below.
+crossArchArray=("arm")
+for arch in $crossArchArray
+do
+    echo "Using $dockerCrossDepsTag to set up cross-toolset for $arch for $crossToolset"
+    buildRootFSContainer="rootfs-$arch-$crossToolset"
+    docker run --privileged --rm --name $buildRootFSContainer -e ROOTFS_DIR=/rootfs/$arch \
+        -v $PWD/rootfs:/rootfs -v $scriptsVolume:/scripts \
+        $dockerCrossDepsTag /scripts/cross/build-rootfs.sh $arch $crossToolset --skipunmount
+done


### PR DESCRIPTION
These Dockerfiles are used to prepare the images needed for .NET Core official builds that are performed in a Docker container.

Fixes https://github.com/dotnet/core-eng/issues/2440