### PR TITLE
Copy repo into ImageBuilder image

### DIFF
--- a/Dockerfile.linux.imagebuilder
+++ b/Dockerfile.linux.imagebuilder
@@ -1,0 +1,7 @@
+# Use this Dockerfile to create an image containing this repo and ImageBuilder
+# Usage: docker run --rm -v /var/run/docker.sock:/var/run/docker.sock imagebuilder <imagebuilder_args> .
+
+FROM microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20180126094141
+
+WORKDIR /repo
+COPY . .

--- a/build.ps1
+++ b/build.ps1
@@ -2,47 +2,36 @@
 param(
     [string]$DockerfilePath = "*",
     [string]$ImageBuilderCustomArgs,
-    [string]$ImageBuilderImageName = 'microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20180117125404'
+    [switch]$CleanupDocker
 )
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-function ExecuteWithRetry($Command) {
-
-    $attempt = 0
-    $maxRetries = 5
-    $waitFactor = 6
-    while ($attempt -lt $maxRetries) {
-        try {
-            & $Command @args
-            break
-        }
-        catch {
-            Write-Warning "$_"
-        }
-
-        $attempt++
-        if ($attempt -ne $maxRetries) {
-            $waitTime = $attempt * $waitFactor
-            Write-Host "Retry ${attempt}/${maxRetries} failed, retrying in $waitTime seconds..."
-            Start-Sleep -Seconds ($waitTime)
-        }
-        else {
-            throw "Retry ${attempt}/${maxRetries} failed, no more retries left."
-        }
+function Invoke-CleanupDocker()
+{
+    if ($CleanupDocker) {
+        docker system prune -a -f
     }
 }
 
-ExecuteWithRetry docker pull $ImageBuilderImageName
+Invoke-CleanupDocker
 
-& docker run --rm `
-    -v /var/run/docker.sock:/var/run/docker.sock `
-    -v "${PSScriptRoot}:/repo" `
-    -w /repo `
-    $ImageBuilderImageName `
-    build --manifest "manifest.json" --path "$DockerfilePath" "$ImageBuilderCustomArgs"
+try {
+    & docker build -t imagebuilder -f ./Dockerfile.linux.imagebuilder .
+    if ($LastExitCode -ne 0) {
+        throw "Failed building ImageBuilder."
+    }
 
-if ($LastExitCode -ne 0) {
-    throw "Failed executing ImageBuilder."
+    & docker run --rm `
+        -v /var/run/docker.sock:/var/run/docker.sock `
+        imagebuilder `
+        build --manifest "manifest.json" --path "$DockerfilePath" "$ImageBuilderCustomArgs"
+
+    if ($LastExitCode -ne 0) {
+        throw "Failed executing ImageBuilder."
+    }
+}
+finally {
+    Invoke-CleanupDocker
 }


### PR DESCRIPTION
`build.ps1` bind mounts a volume to make the repository available in the container running _ImageBuilder_. This option will not work in a Docker-in-Docker scenario.  Hence, prepare an _ImageBuilder_ image with the repository copied into it.

Two other changes:

- Removed the retry logic.  It is not critical, and such logic should go into a helper module that can be imported as needed in this and other repos.

- Using a new image of _ImageBuilder_
