### PR TITLE
ImageBuilder image with TimeStamp fix

### DIFF
--- a/Dockerfile.linux.imagebuilder
+++ b/Dockerfile.linux.imagebuilder
@@ -1,7 +1,7 @@
 # Use this Dockerfile to create an image containing this repo and ImageBuilder
 # Usage: docker run --rm -v /var/run/docker.sock:/var/run/docker.sock imagebuilder <imagebuilder_args> .
 
-FROM microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20180126094141
+FROM microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20180126144139
 
 WORKDIR /repo
 COPY . .


### PR DESCRIPTION
Switch to the version of _ImageBuilder_ that contains fix for `TimeStamp`. Refer to https://github.com/dotnet/docker-tools/pull/81