### PR TITLE
Split ImageBuilderCustomArgs

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -26,7 +26,7 @@ try {
     & docker run --rm `
         -v /var/run/docker.sock:/var/run/docker.sock `
         imagebuilder `
-        build --manifest "manifest.json" --path "$DockerfilePath" "$ImageBuilderCustomArgs"
+        build --manifest manifest.json --path "$DockerfilePath" ${ImageBuilderCustomArgs}.Split()
 
     if ($LastExitCode -ne 0) {
         throw "Failed executing ImageBuilder."

--- a/build.ps1
+++ b/build.ps1
@@ -23,10 +23,12 @@ try {
         throw "Failed building ImageBuilder."
     }
 
-    & docker run --rm `
-        -v /var/run/docker.sock:/var/run/docker.sock `
-        imagebuilder `
-        build --manifest manifest.json --path "$DockerfilePath" ${ImageBuilderCustomArgs}.Split()
+    $expression = "docker run --rm " +
+        "-v /var/run/docker.sock:/var/run/docker.sock " +
+        "imagebuilder " +
+        "build --manifest manifest.json --path $DockerfilePath $ImageBuilderCustomArgs"
+
+    Invoke-Expression $expression
 
     if ($LastExitCode -ne 0) {
         throw "Failed executing ImageBuilder."


### PR DESCRIPTION
ImageBuilder is parsing `ImageBuilderCustomArgs` as a string.   `ImageBuilderCustomArgs` is a collection of argument.  Hence split the string.