### PR TITLE
ubuntu-16.04-cross-arm64:Install binutils-aarch64-linux-gnu

### DIFF
--- a/src/ubuntu/16.04/cross/arm64/Dockerfile
+++ b/src/ubuntu/16.04/cross/arm64/Dockerfile
@@ -1,3 +1,9 @@
 FROM microsoft/dotnet-buildtools-prereqs:ubuntu-16.04-crossdeps
 
+# Install binutils-aarch64-linux-gnu
+RUN apt-get update \
+    && apt-get install -y \
+        binutils-aarch64-linux-gnu \
+    && rm -rf /var/lib/apt/lists/*
+
 ADD rootfs crossrootfs


### PR DESCRIPTION
@janvorli @MichaelSimons Towards fixing https://github.com/dotnet/coreclr/issues/16890