### PR TITLE
Add OpenSuse 423 docker file

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -143,6 +143,16 @@
         {
           "platforms": [
             {
+              "dockerfile": "src/opensuse/42.3",
+              "os": "linux",
+              "tags": {
+                "opensuse-42.3-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
+              }
+            }
+          ]
+        },        {
+          "platforms": [
+            {
               "dockerfile": "src/opensuse/42.1",
               "os": "linux",
               "tags": {

--- a/manifest.json
+++ b/manifest.json
@@ -150,7 +150,8 @@
               }
             }
           ]
-        },        {
+        },        
+        {
           "platforms": [
             {
               "dockerfile": "src/opensuse/42.1",

--- a/src/opensuse/42.3/Dockerfile
+++ b/src/opensuse/42.3/Dockerfile
@@ -5,11 +5,11 @@ FROM opensuse:42.3
 # them in a different layer.
 RUN zypper -n install \
         cmake \
+        gcc-c++ \
         hostname \
         lldb-devel \
         llvm-clang \
         llvm-devel \
-        gcc-c++ \
         python-xml \
         which \
         wget \

--- a/src/opensuse/42.3/Dockerfile
+++ b/src/opensuse/42.3/Dockerfile
@@ -1,0 +1,45 @@
+FROM opensuse:42.3
+
+# Install the base toolchain we need to build anything (clang, cmake, make and the like)
+# this does not include libraries that we need to compile different projects, we'd like
+# them in a different layer.
+RUN zypper -n install \
+        cmake \
+        hostname \
+        lldb-devel \
+        llvm-clang \
+        llvm-devel \
+        gcc-c++ \
+        python-xml \
+        which \
+        wget \
+    && ln -s /usr/bin/clang++ /usr/bin/clang++-3.5 \
+    && zypper clean -a
+
+# Install tools used by the VSO build automation.
+RUN zypper -n install \
+        git \
+        npm \
+        nodejs \
+        tar \
+        zip \
+    && zypper clean -a
+
+RUN npm install -g azure-cli
+
+# Dependencies of CoreCLR and CoreFX.
+RUN zypper -n install --force-resolution \
+        glibc-locale \
+        krb5-devel \
+        libcurl-devel \
+        libgdiplus0 \
+        libicu-devel \
+        libunwind-devel \
+        libuuid-devel \
+        lttng-ust-devel \
+        libopenssl-devel \
+        uuid-devel \
+    && zypper clean -a
+
+# Until OpenSuse.42.3 official packages are available, we have to restore the ubuntu ones instead.
+ENV __PUBLISH_RID=ubuntu.14.04-x64


### PR DESCRIPTION
depends on https://github.com/dotnet/dotnet-buildtools-prereqs-docker

cc: @dagood @joperezr @livarcocc @janvorli

opensuse 42.3 does not contain the headers for lldb, which is a problem. There is no lldb-devel package available at all for opensuse 42.3 unless I use the one from tumbleweed which is marked as "experimental". That's probably not great, so we'll just have to disable the lldb plugin from being built in coreclr.