### PR TITLE
Adding tzdata to fix Globalization tests

### DIFF
--- a/src/alpine/3.6-ForHelix/Dockerfile
+++ b/src/alpine/3.6-ForHelix/Dockerfile
@@ -32,6 +32,7 @@ RUN apk add --no-cache \
         python \
         python-dev \
         sudo \
+        tzdata \
         util-linux-dev \
         wget \
         zlib-dev


### PR DESCRIPTION
cc: @MichaelSimons @tarekgh

Adding dependency tzdata in order to fix the failing Globalization tests.