### PR TITLE
Add missing Fedora27 dependency

### DIFF
--- a/src/fedora/27/Dockerfile
+++ b/src/fedora/27/Dockerfile
@@ -32,6 +32,7 @@ RUN npm install -g azure-cli --unsafe-perm
 RUN dnf install -y \
         compat-openssl10-devel \
         glibc-locale-source \
+        krb5-devel \
         libcurl-devel \
         libgdiplus \
         libicu-devel \


### PR DESCRIPTION
I missed one somehow. I verified twice that I've got them all now.

PTAL @MichaelSimons 