### PR TITLE
use clang 5.0 for arm32 builds

### DIFF
--- a/src/ubuntu/14.04/crossdeps/Dockerfile
+++ b/src/ubuntu/14.04/crossdeps/Dockerfile
@@ -19,15 +19,15 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 RUN apt-get update \
-    && echo "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main" >> /etc/apt/sources.list.d/llvm.list \
-    && echo "deb-src http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main" >> /etc/apt/sources.list.d/llvm.list \
+    && echo "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main" >> /etc/apt/sources.list.d/llvm.list \
+    && echo "deb-src http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main" >> /etc/apt/sources.list.d/llvm.list \
     && wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
     && apt-get update \
     && apt-get install -y \
-        llvm-3.9 \
-        clang-3.9 \
-        liblldb-3.9-dev \
-        lldb-3.9 \
+        llvm-5.0 \
+        clang-5.0 \
+        liblldb-5.0-dev \
+        lldb-5.0 \
     && rm -rf /var/lib/apt/lists/*
 
 # Install x86_arm crossgen dependencies

--- a/src/ubuntu/16.04/crossdeps/Dockerfile
+++ b/src/ubuntu/16.04/crossdeps/Dockerfile
@@ -14,16 +14,16 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 RUN apt-get update \
-    && echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-3.9 main" >> /etc/apt/sources.list.d/llvm.list \
-    && echo "deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-3.9 main" >> /etc/apt/sources.list.d/llvm.list \
+    && echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-5.0 main" >> /etc/apt/sources.list.d/llvm.list \
+    && echo "deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-5.0 main" >> /etc/apt/sources.list.d/llvm.list \
     && wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
     && apt-get update \
     && apt-get install -y \
-        llvm-3.9 \
-        clang-3.9 \
-        liblldb-3.9-dev \
-        lldb-3.9 \
-        python-lldb-3.9 \
+        llvm-5.0 \
+        clang-5.0 \
+        liblldb-5.0-dev \
+        lldb-5.0 \
+        python-lldb-5.0 \
     && rm -rf /var/lib/apt/lists/*
 
 # Install x86_arm crossgen dependencies


### PR DESCRIPTION
There is a known issue with CompareExchange with clang3.9 for arm (dotnet/coreclr#15074), so update docker to use last supported and stable version for arm32. Fixes dotnet/coreclr#16995 and several tests from dotnet/coreclr#16996 .