### PR TITLE
Upgrade npm (and node) to get new registry cert

### DIFF
--- a/src/ubuntu/14.04/Dockerfile
+++ b/src/ubuntu/14.04/Dockerfile
@@ -20,17 +20,18 @@ RUN apt-get update && \
             make && \
     apt-get clean
 
-# Install tools used by the VSO build automation.  nodejs-legacy is a Debian specific
-# package that provides `node' on the path (which azure cli needs).
-RUN apt-get install -y git \
+# Install tools used by the VSO build automation. Set up a new apt-get source to
+# get a new version of node and npm: the built-in old cert is no longer valid.
+RUN wget -O - https://deb.nodesource.com/setup_8.x | bash && \
+    apt-get install -y \
+            git \
             zip \
             tar \
-            nodejs \
-            nodejs-legacy \
-            npm && \
+            nodejs && \
     apt-get clean && \
-    npm install -g azure-cli@0.9.15 && \
-    npm cache clean
+    # Set unsafe-perm to true to avoid EACCES.
+    npm install -g azure-cli@0.9.15 --unsafe-perm=true && \
+    npm cache clean -f
 
 # Dependencies for CoreCLR and CoreFX
 RUN apt-get install -y gettext \

--- a/src/ubuntu/14.04/coredeps/Dockerfile
+++ b/src/ubuntu/14.04/coredeps/Dockerfile
@@ -1,18 +1,19 @@
 FROM ubuntu:14.04
 
-# Install tools used by the VSO build automation.  nodejs-legacy is a Debian specific
-# package that provides 'node' on the path (which azure cli needs).
+# Install tools used by the VSO build automation. Set up a new apt-get source to
+# get a new version of node and npm: the built-in old cert is no longer valid.
 RUN apt-get update \
+    && apt-get install -y wget \
+    && wget -O - https://deb.nodesource.com/setup_8.x | bash \
     && apt-get install -y \
         git \
-        nodejs \
-        nodejs-legacy \
-        npm \
-        tar \
         zip \
+        tar \
+        nodejs \
     && rm -rf /var/lib/apt/lists/* \
-    && npm install -g azure-cli@0.9.15 \
-    && npm cache clean
+    # Set unsafe-perm to true to avoid EACCES.
+    && npm install -g azure-cli@0.9.15 --unsafe-perm=true \
+    && npm cache clean -f
 
 # Dependencies for CoreCLR and CoreFX
 RUN apt-get update \


### PR DESCRIPTION
The new version seems to have node on PATH, so nodejs-legacy might not be needed anymore.

`--unsafe-perm=true` prevents this:

```
gyp WARN EACCES attempting to reinstall using temporary dev dir "/usr/lib/node_modules/azure-cli/node_modules/fibers/.node-gyp"
gyp WARN EACCES user "nobody" does not have permission to access the dev dir "/usr/lib/node_modules/azure-cli/node_modules/fibers/.node-gyp/8.11.1"
```

The `-f` in `npm cache clean -f` makes the clean happen. `npm cache clean` [isn't needed anymore for "normal" scenarios](https://docs.npmjs.com/cli/cache#details), so it was changed to just error out. It's still valid to run the command to free up disk space, though, which is what we're doing.

https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/43