### PR TITLE
Add libgdiplus to centos7 docker image

### DIFF
--- a/src/centos/7/Dockerfile
+++ b/src/centos/7/Dockerfile
@@ -18,6 +18,7 @@ RUN yum install -y \
         krb5-devel \
         libcurl-devel \
         libedit-devel \
+        libgdiplus \
         libicu-devel \
         libidn-devel \
         libmetalink-devel \


### PR DESCRIPTION
We need this for dotnet/machinlearning CI since it tests some libraries that depend on libgdiplus being installed.

cc: @eerhardt @mmitche @MichaelSimons 

Once merged, how long would it take to have an updated image in the docker hub? 