### PR TITLE
Add RHEL 7.5 Dockerfile and infrastructure

### DIFF
--- a/Dockerfile.linux.imagebuilder
+++ b/Dockerfile.linux.imagebuilder
@@ -1,7 +1,7 @@
 # Use this Dockerfile to create an image containing this repo and ImageBuilder
 # Usage: docker run --rm -v /var/run/docker.sock:/var/run/docker.sock imagebuilder <imagebuilder_args> .
 
-FROM microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20180126144139
+FROM microsoft/dotnet-buildtools-prereqs:image-builder-debian-20180723194508
 
 WORKDIR /repo
 COPY . .

--- a/README.md
+++ b/README.md
@@ -4,15 +4,19 @@ The Dockerfiles in this repository are used for building the .NET Core product. 
 
 ## Where are the published images
 
-The images produced from the Dockerfiles are published to the [microsoft/dotnet-buildtools-prereqs](https://hub.docker.com/r/microsoft/dotnet-buildtools-prereqs/) Docker Hub repository.
+Each image produced from the Dockerfiles is published based on its repository in the [manifest](#manifest):
 
-- [Most recent tags](https://hub.docker.com/r/microsoft/dotnet-buildtools-prereqs/tags/)
-- [Full list of tags](https://registry.hub.docker.com/v1/repositories/microsoft/dotnet-buildtools-prereqs/tags)
+- [microsoft/dotnet-buildtools-prereqs](https://hub.docker.com/r/microsoft/dotnet-buildtools-prereqs/) is a Docker Hub repository.
+  - [Most recent tags](https://hub.docker.com/r/microsoft/dotnet-buildtools-prereqs/tags/)
+  - [Full list of tags](https://registry.hub.docker.com/v1/repositories/microsoft/dotnet-buildtools-prereqs/tags)
+- **dotnet-buildtools-prereqs** is a repository in the *DotnetDocker* private Azure Container Registry.
+  - This repository is used to host images that can't be published to Docker Hub.
 
 ## How to identify an image
 
-The tag format used by an image is `microsoft/dotnet-buildtools-prereqs:<linux-distribution-name>-<version>-<variant>-<dockerfile-commit-sha>-<date-time>`
+The tag format used by an image is `<repository>:<linux-distribution-name>-<version>-<variant>-<dockerfile-commit-sha>-<date-time>`
 
+- `<repository>` - name of the repository this image is part of, almost always `microsoft/dotnet-buildtools-prereqs`
 - `<linux-distribution-name>` - name of the Linux distribution the image is based on
 - `<version>` - version of the Linux distribution
 - `<variant>` - name describing the specialization purpose of the image.  Often special dependencies are needed for certain parts of the product.  It can be beneficial to separate these dependencies into a separate Dockerfile/image.
@@ -76,7 +80,9 @@ The [manifest.json](./manifest.json) contains metadata used by the build infrast
 - `tags` - the collection of tags to create for the image
 - `$(System:DockerfileGitCommitSha)` and `$(System:TimeStamp)` - built in variable references that are evaluated at build time and substituted
 
-**Note:** The position in manifest determines the sequence in which the image will be built.
+> **Note:** The position in manifest determines the sequence in which the image will be built.
+
+> **Note:** The entry is placed inside a repository in the `repos` list: the repository's `name` determines [where the image will be published](#where-are-the-published-images). Use `microsoft/dotnet-buildtools-prereqs` unless it is impossible to push the image to Docker Hub.
 
 ### Image Dependency
 

--- a/build.ps1
+++ b/build.ps1
@@ -2,7 +2,12 @@
 param(
     [string]$DockerfilePath = "*",
     [string]$ImageBuilderCustomArgs,
-    [switch]$CleanupDocker
+    [switch]$CleanupDocker,
+
+    # Adds "--privileged" to the "docker run" command. In unknown circumstances we encounter on the
+    # RHEL build agent, the container must be run with --privileged in order to access the shared
+    # docker socket. See https://stackoverflow.com/a/36614457 for an untried potential alternative.
+    [switch]$RunPrivileged
 )
 
 Set-StrictMode -Version Latest
@@ -23,7 +28,13 @@ try {
         throw "Failed building ImageBuilder."
     }
 
+    $runPrivilegedArg = ""
+    if ($RunPrivileged) {
+        $runPrivilegedArg = "--privileged "
+    }
+
     $expression = "docker run --rm " +
+        $runPrivilegedArg +
         "-v /var/run/docker.sock:/var/run/docker.sock " +
         "imagebuilder " +
         "build --manifest manifest.json --path '$DockerfilePath' $ImageBuilderCustomArgs"

--- a/build.ps1
+++ b/build.ps1
@@ -2,12 +2,8 @@
 param(
     [string]$DockerfilePath = "*",
     [string]$ImageBuilderCustomArgs,
-    [switch]$CleanupDocker,
-
-    # Adds "--privileged" to the "docker run" command. In unknown circumstances we encounter on the
-    # RHEL build agent, the container must be run with --privileged in order to access the shared
-    # docker socket. See https://stackoverflow.com/a/36614457 for an untried potential alternative.
-    [switch]$RunPrivileged
+    [string]$RunCustomArgs,
+    [switch]$CleanupDocker
 )
 
 Set-StrictMode -Version Latest
@@ -28,15 +24,9 @@ try {
         throw "Failed building ImageBuilder."
     }
 
-    $runPrivilegedArg = ""
-    if ($RunPrivileged) {
-        $runPrivilegedArg = "--privileged "
-    }
-
     $expression = "docker run --rm " +
-        $runPrivilegedArg +
         "-v /var/run/docker.sock:/var/run/docker.sock " +
-        "imagebuilder " +
+        "$RunCustomArgs imagebuilder " +
         "build --manifest manifest.json --path '$DockerfilePath' $ImageBuilderCustomArgs"
 
     Invoke-Expression $expression

--- a/manifest.json
+++ b/manifest.json
@@ -375,6 +375,22 @@
           ]
         }
       ]
+    },
+    {
+      "name": "dotnet-buildtools-prereqs",
+      "images": [
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/rhel/7.5",
+              "os": "linux",
+              "tags": {
+                "rhel-7.5-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
+              }
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/rhel/7.5/Dockerfile
+++ b/src/rhel/7.5/Dockerfile
@@ -1,0 +1,58 @@
+FROM registry.access.redhat.com/rhel7.5
+
+# Disable repository with undesired packages.
+RUN yum-config-manager --disable rhel-7-server-rt-beta-rpms
+
+# Install the base toolchain we need to build anything (clang, cmake, make and the like)
+# this does not include libraries that we need to compile different projects, we'd like
+# them in a different layer.
+
+# --- Toolchain from RHEL-7 software collection ---
+RUN yum updateinfo \
+    && yum-config-manager --enable rhel-7-server-devtools-rpms \
+    && yum install -y rh-dotnet20-jsoncpp --enablerepo=rhel-7-server-dotnet-rpms \
+        cmake \
+        llvm-toolset-7-clang.x86_64 \
+        llvm-toolset-7-clang-libs.x86_64 \
+        llvm-toolset-7-lldb.x86_64 \
+        llvm-toolset-7-lldb-devel.x86_64 \
+        llvm-toolset-7-llvm.x86_64 \
+        llvm-toolset-7-llvm-libs.x86_64 \
+        wget \
+        which \
+        make \
+    && yum clean all
+
+# Needed by coreclr build to discover llvm-toolset-7 clang, and includes.
+ENV PATH "/opt/rh/llvm-toolset-7/root/usr/bin:${PATH}"
+ENV CMAKE_INCLUDE_PATH "/opt/rh/llvm-toolset-7/root/usr/include"
+
+# Install tools used by the VSO build automation.  We use NodeJS from nodesource.com.
+RUN yum install -y https://rpm.nodesource.com/pub_0.10/el/7/x86_64/nodesource-release-el7-1.noarch.rpm \
+    && yum updateinfo \
+    && yum install -y git \
+        zip \
+        tar \
+        nodejs \
+        patch \
+    && yum clean all \
+    && npm install -g azure-cli
+
+# Dependencies of CoreCLR and CoreFX.  Everything except lttng is present in RHEL, for lttng we
+# get the development packages from EfficiOS.
+RUN wget -P /etc/yum.repos.d/ https://packages.efficios.com/repo.files/EfficiOS-RHEL7-x86-64.repo \
+    && rpmkeys --import https://packages.efficios.com/rhel/repo.key \
+    && yum updateinfo \
+    && yum install --enablerepo=rhel-7-server-optional-rpms -y \
+        libicu-devel \
+        libuuid-devel \
+        libcurl-devel \
+        openssl-devel \
+        libunwind-devel \
+        lttng-ust-devel \
+    && yum clean all
+
+# Define the en_US.UTF-8 locale.  (Without this, processes MSBuild tries to launch complain about
+# being unable to use the en_US.UTF-8 locale which can cause downstream failures if you capture
+# the output of a run.)
+RUN localedef -c -i en_US -f UTF-8 en_US.UTF-8

--- a/src/rhel/7.5/Dockerfile
+++ b/src/rhel/7.5/Dockerfile
@@ -24,8 +24,8 @@ RUN yum updateinfo \
     && yum clean all
 
 # Needed by coreclr build to discover llvm-toolset-7 clang, and includes.
-ENV PATH "/opt/rh/llvm-toolset-7/root/usr/bin:${PATH}"
-ENV CMAKE_INCLUDE_PATH "/opt/rh/llvm-toolset-7/root/usr/include"
+ENV PATH="/opt/rh/llvm-toolset-7/root/usr/bin:${PATH}" \
+    CMAKE_INCLUDE_PATH="/opt/rh/llvm-toolset-7/root/usr/include"
 
 # Install tools used by the VSO build automation.  We use NodeJS from nodesource.com.
 RUN yum install -y https://rpm.nodesource.com/pub_0.10/el/7/x86_64/nodesource-release-el7-1.noarch.rpm \


### PR DESCRIPTION
Add @dleeapho's RHEL7.5 Dockerfile. To support builds, add `-RunPrivileged` build.ps1 arg and upgrade image-builder to get https://github.com/dotnet/docker-tools/pull/109.

Unlike `microsoft/dotnet-buildtools-prereqs`, the new `dotnet-buildtools-prereqs` repo in the manifest doesn't get pushed to public Dockerhub. There is now a second build definition [dotnet-buildtools-prereqs-docker-rhel](https://devdiv.visualstudio.com/DevDiv/_build/index?context=allDefinitions&path=\dotnet-docker&definitionId=9629&_a=completed) that uses a registered Red Hat machine to build and push to a private Azure Container Registry. (RHEL images can't be pushed to public repos.)

We plan to use this for CI in source-build: https://github.com/dotnet/source-build/issues/415.