### PR TITLE
Add missing debian 8.2 native dependencies for Core repos

### DIFF
--- a/src/debian/8.2/coredeps/Dockerfile
+++ b/src/debian/8.2/coredeps/Dockerfile
@@ -7,9 +7,9 @@ RUN apt-get update \
     && wget -O - https://deb.nodesource.com/setup_8.x | bash \
     && apt-get install -y \
         git \
-        zip \
-        tar \
         nodejs \
+        tar \
+        zip \
     && rm -rf /var/lib/apt/lists/* \
     # Set unsafe-perm to true to avoid EACCES.
     && npm install -g azure-cli@0.9.15 --unsafe-perm=true \

--- a/src/debian/8.2/coredeps/Dockerfile
+++ b/src/debian/8.2/coredeps/Dockerfile
@@ -23,8 +23,10 @@ RUN apt-get update \
             libcurl4-openssl-dev \
             libgdiplus \
             libicu-dev \
+            libkrb5-dev \
             liblttng-ust-dev \
             libssl-dev \
+            libunwind8 \
             libunwind8-dev \
             uuid-dev \
     && rm -rf /var/lib/apt/lists/*

--- a/src/debian/8.2/coredeps/Dockerfile
+++ b/src/debian/8.2/coredeps/Dockerfile
@@ -1,18 +1,19 @@
 FROM debian:8.2
 
-# Install tools used by the VSO build automation.  nodejs-legacy is a Debian specific
-# package that provides `node' on the path (which azure cli needs).
+# Install tools used by the VSO build automation. Set up a new apt-get source to
+# get a new version of node and npm: the built-in old cert is no longer valid.
 RUN apt-get update \
+    && apt-get install -y wget \
+    && wget -O - https://deb.nodesource.com/setup_8.x | bash \
     && apt-get install -y \
-            git \
-            nodejs \
-            nodejs-legacy \
-            npm \
-            tar \
-            zip \
+        git \
+        zip \
+        tar \
+        nodejs \
     && rm -rf /var/lib/apt/lists/* \
-    && npm install -g azure-cli@0.10.2 \
-    && npm cache clean
+    # Set unsafe-perm to true to avoid EACCES.
+    && npm install -g azure-cli@0.9.15 --unsafe-perm=true \
+    && npm cache clean -f
 
 # Dependencies for generic .NET Core builds
 RUN apt-get update \

--- a/src/ubuntu/14.04/coredeps/Dockerfile
+++ b/src/ubuntu/14.04/coredeps/Dockerfile
@@ -7,9 +7,9 @@ RUN apt-get update \
     && wget -O - https://deb.nodesource.com/setup_8.x | bash \
     && apt-get install -y \
         git \
-        zip \
-        tar \
         nodejs \
+        tar \
+        zip \
     && rm -rf /var/lib/apt/lists/* \
     # Set unsafe-perm to true to avoid EACCES.
     && npm install -g azure-cli@0.9.15 --unsafe-perm=true \


### PR DESCRIPTION
1. Got the debian 8.2 images building again by adding the nodejs fix from https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/46.
2. Added `libkrb5-dev` and `libunwind8`, which are included in other Dockerfiles but not this one.

These changes make the `debian-8.2` image able to build source-build `release/2.1`. (For https://github.com/dotnet/source-build/issues/815)