### PR TITLE
Add new docker image with node built from source in order to be able to use it in azure dev ops

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,10 @@
               "dockerfile": "src/alpine/3.6",
               "os": "linux",
               "tags": {
-                "alpine-3.6-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
+                "alpine-3.6-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {},
+                "alpine-3.6": {
+                  "isLocal": true
+                }
               }
             }
           ]
@@ -21,6 +24,17 @@
               "os": "linux",
               "tags": {
                 "alpine-3.6-ForHelix-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/alpine/3.6-WithNode",
+              "os": "linux",
+              "tags": {
+                "alpine-3.6-WithNode-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
               }
             }
           ]

--- a/src/alpine/3.6-WithNode/Dockerfile
+++ b/src/alpine/3.6-WithNode/Dockerfile
@@ -26,9 +26,9 @@ RUN apk add --no-cache \
             77984A986EBC2AA786BC0F66B01FBB92821C587A \
             8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
         ; do \
-            gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
-            gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
-            gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+            gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" \
+            || gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" \
+            || gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
         done \
             && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION.tar.xz" \
             && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
@@ -46,13 +46,16 @@ RUN apk add --no-cache \
 
 ENV YARN_VERSION 1.10.1
 
-RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
+RUN apk add --no-cache --virtual .build-deps-yarn \
+  curl \
+  gnupg \
+  tar \
   && for key in \
     6A010C5166006599AA17F08146C2130DFD2497F5 \
   ; do \
-    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
-    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
-    gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" \
+    || gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" \
+    || gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done \
   && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
   && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \

--- a/src/alpine/3.6-WithNode/Dockerfile
+++ b/src/alpine/3.6-WithNode/Dockerfile
@@ -1,0 +1,71 @@
+FROM microsoft/dotnet-buildtools-prereqs:alpine-3.6
+
+RUN apk update
+
+ENV NODE_VERSION 10.13.0
+
+### BUILD NODE
+RUN apk add --no-cache \
+        libstdc++ \
+    && apk add --no-cache --virtual .build-deps \
+        binutils-gold \
+        curl \
+        g++ \
+        gnupg \
+        libgcc \
+        make \
+        # gpg keys listed at https://github.com/nodejs/node#release-team
+        && for key in \
+            94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+            FD3A5288F042B6850C66B31F09FE44734EB7990E \
+            71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+            DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+            C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+            B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+            56730D5401028683275BD23C23EFEFE93C4CFFFE \
+            77984A986EBC2AA786BC0F66B01FBB92821C587A \
+            8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
+        ; do \
+            gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+            gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+            gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+        done \
+            && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION.tar.xz" \
+            && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+            && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+            && grep " node-v$NODE_VERSION.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+            && tar -xf "node-v$NODE_VERSION.tar.xz" \
+            && cd "node-v$NODE_VERSION" \
+            && ./configure \
+            && make -j$(getconf _NPROCESSORS_ONLN) \
+            && make install \
+            && apk del .build-deps \
+            && cd .. \
+            && rm -Rf "node-v$NODE_VERSION" \
+            && rm "node-v$NODE_VERSION.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt
+
+ENV YARN_VERSION 1.10.1
+
+RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
+  && for key in \
+    6A010C5166006599AA17F08146C2130DFD2497F5 \
+  ; do \
+    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+  done \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
+  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && mkdir -p /opt \
+  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && apk del .build-deps-yarn
+
+# Add label for bring your own node in azure devops
+LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/local/bin/node"
+
+# Start node
+CMD [ "node" ]

--- a/src/alpine/3.6-WithNode/Dockerfile
+++ b/src/alpine/3.6-WithNode/Dockerfile
@@ -47,25 +47,25 @@ RUN apk add --no-cache \
 ENV YARN_VERSION 1.10.1
 
 RUN apk add --no-cache --virtual .build-deps-yarn \
-  curl \
-  gnupg \
-  tar \
-  && for key in \
-    6A010C5166006599AA17F08146C2130DFD2497F5 \
-  ; do \
-    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" \
-    || gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" \
-    || gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
-  done \
-  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
-  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
-  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
-  && mkdir -p /opt \
-  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
-  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
-  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
-  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
-  && apk del .build-deps-yarn
+        curl \
+        gnupg \
+        tar \
+        && for key in \
+            6A010C5166006599AA17F08146C2130DFD2497F5 \
+        ; do \
+            gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" \
+            || gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" \
+            || gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+        done \
+            && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
+            && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
+            && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+            && mkdir -p /opt \
+            && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
+            && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
+            && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+            && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+            && apk del .build-deps-yarn
 
 # Add label for bring your own node in azure devops
 LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/local/bin/node"

--- a/src/alpine/3.6/Dockerfile
+++ b/src/alpine/3.6/Dockerfile
@@ -26,7 +26,10 @@ RUN apk add --no-cache \
         paxctl \
         python \
         util-linux-dev \
-        zlib-dev
+        zlib-dev \
+        sudo \
+        which \
+        shadow
 
 RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache \
         userspace-rcu-dev \

--- a/src/alpine/3.6/Dockerfile
+++ b/src/alpine/3.6/Dockerfile
@@ -25,11 +25,11 @@ RUN apk add --no-cache \
         openssl-dev \
         paxctl \
         python \
-        util-linux-dev \
-        zlib-dev \
+        shadow \
         sudo \
+        util-linux-dev \
         which \
-        shadow
+        zlib-dev
 
 RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache \
         userspace-rcu-dev \


### PR DESCRIPTION
In order to use non glibc docker images in azure devops we need to build node from source in this type of images since they rely on node to execute their pipelines.

cc: @danmosemsft @chcosta @markwilkie 