### PR TITLE
Add libffi-dev to Helix images

### DIFF
--- a/src/alpine/3.6-ForHelix/Dockerfile
+++ b/src/alpine/3.6-ForHelix/Dockerfile
@@ -23,6 +23,7 @@ RUN apk add --no-cache \
         libtool \
         libunwind-dev \
         libffi \
+        libffi-dev \
         linux-headers \
         llvm \
         make \

--- a/src/alpine/3.8-ForHelix/Dockerfile
+++ b/src/alpine/3.8-ForHelix/Dockerfile
@@ -22,6 +22,7 @@ RUN apk add --no-cache \
         libtool \
         libunwind-dev \
         libffi \
+        libffi-dev \
         linux-headers \
         llvm \
         make \


### PR DESCRIPTION
Needed by some PIP modules used in Helix