### PR TITLE
Add curl to alpine image in order to build corefx with new way to bootstrap dotnet cli

### DIFF
--- a/src/alpine/3.6-WithNode/Dockerfile
+++ b/src/alpine/3.6-WithNode/Dockerfile
@@ -9,7 +9,6 @@ RUN apk add --no-cache \
         libstdc++ \
     && apk add --no-cache --virtual .build-deps \
         binutils-gold \
-        curl \
         g++ \
         gnupg \
         libgcc \
@@ -47,7 +46,6 @@ RUN apk add --no-cache \
 ENV YARN_VERSION 1.10.1
 
 RUN apk add --no-cache --virtual .build-deps-yarn \
-        curl \
         gnupg \
         tar \
         && for key in \

--- a/src/alpine/3.6/Dockerfile
+++ b/src/alpine/3.6/Dockerfile
@@ -10,6 +10,7 @@ RUN apk add --no-cache \
         clang-dev \
         cmake \
         coreutils \
+        curl \
         curl-dev \
         gcc \
         gettext-dev \


### PR DESCRIPTION
To download and install dotnet cli we use curl when present if not fallback to wget. Wget is sometime rejected by the server due to ssl connection, this sometimes leads to build failures. Curl lets us use ssl.

cc: @MichaelSimons 