### PR TITLE
Install lldb in the alpine3.6 image

### DIFF
--- a/src/alpine/3.6/Dockerfile
+++ b/src/alpine/3.6/Dockerfile
@@ -20,7 +20,6 @@ RUN apk add --no-cache \
         libtool \
         libunwind-dev \
         linux-headers \
-        llvm \
         make \
         openssl \
         openssl-dev \
@@ -36,7 +35,10 @@ RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache \
         userspace-rcu-dev \
         lttng-ust-dev
 
-# Currently apk cannot find lldb for 3.8, and this is not required for execution so leaving it commented out.
+# On 3.6, a recent version of llvm from edge/main must be used to install lldb.
 # Details: https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/55 
-#RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/testing add --no-cache \
-#        lldb-dev
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache \
+        llvm
+
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/testing add --no-cache \
+        lldb-dev

--- a/src/alpine/3.6/Dockerfile
+++ b/src/alpine/3.6/Dockerfile
@@ -31,13 +31,11 @@ RUN apk add --no-cache \
         which \
         zlib-dev
 
-RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache \
-        userspace-rcu-dev \
-        lttng-ust-dev
-
 # On 3.6, a recent version of llvm from edge/main must be used to install lldb.
 # Details: https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/55 
 RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache \
+        userspace-rcu-dev \
+        lttng-ust-dev \
         llvm
 
 RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/testing add --no-cache \


### PR DESCRIPTION
Required to build coreclr linux-musl.
See https://github.com/dotnet/coreclr/pull/21568 for some discussion.

@echesakovMSFT