### PR TITLE
Add build infra to support build Linux arm images

### DIFF
--- a/.vsts-pipelines/dotnet-buildtools-prereqs.yml
+++ b/.vsts-pipelines/dotnet-buildtools-prereqs.yml
@@ -1,23 +1,32 @@
 trigger: none
 jobs:
-- job:
-  pool:
-    name: DotNet-Build
-    demands: agent.os -equals linux
-  workspace:
-    clean: all
-  variables:
-    imageBuilderCustomArgs: >
-      --push
-      --username $(dockerRegistry.userName)
-      --password $(BotAccount-dotnet-dockerhub-bot-password)
-      $(imageBuilder.queueBuildArgs)
-  steps:
-  - script: docker build -t runner --pull -f ./Dockerfile.linux.runner .
-    displayName: Build Runner Image
-  - script: >
-      docker run
-      --rm -v /var/run/docker.sock:/var/run/docker.sock
-      runner
-      pwsh -File ./build.ps1 -DockerfilePath $(imageBuilder.path) -ImageBuilderCustomArgs "$(imageBuilderCustomArgs)" -CleanupDocker
-    displayName: Build Images
+- template: jobs/build-images.yml
+  parameters:
+    name: Build_Linux_amd64
+    pool: # linuxAmd64Pool
+      name: DotNet-Build
+      demands:
+      - agent.os -equals linux
+    architecture: amd64
+- template: jobs/build-images.yml
+  parameters:
+    name: Build_Linux_arm64v8
+    pool: # linuxArm64v8Pool
+      name: DotNetCore-Infra
+      demands:
+      - agent.os -equals linux
+      - RemoteDockerServerOS -equals linux
+      - RemoteDockerServerArch -equals arm64v8
+    architecture: arm64
+    useRemoteDockerServer: true
+- template: jobs/build-images.yml
+  parameters:
+    name: Build_Linux_arm32v7
+    pool: # linuxArm32v7Pool
+      name: DotNetCore-Infra
+      demands:
+      - agent.os -equals linux
+      - RemoteDockerServerOS -equals linux
+      - RemoteDockerServerArch -equals arm32v7
+    architecture: arm
+    useRemoteDockerServer: true

--- a/.vsts-pipelines/jobs/build-images.yml
+++ b/.vsts-pipelines/jobs/build-images.yml
@@ -1,0 +1,43 @@
+parameters:
+  name: null
+  pool: {}
+  architecture: null
+  useRemoteDockerServer: false
+jobs:
+- job: ${{ parameters.name }}
+  pool: ${{ parameters.pool }}
+  variables:
+    ${{ if eq(parameters.useRemoteDockerServer, 'true') }}:
+      dockerArmRunArgs: 
+        -v $(DOCKER_CERT_PATH):/docker-certs
+        -e DOCKER_CERT_PATH=/docker-certs
+        -e DOCKER_TLS_VERIFY=1
+        -e DOCKER_HOST=tcp://$(DOCKER_HOST_IP):2376
+    ${{ if eq(parameters.useRemoteDockerServer, 'false') }}:
+      dockerArmRunArgs:
+    imageBuilderTag: image-builder
+    imageBuilderArgs:
+      build
+      --path $(imageBuilder.path)
+      --manifest manifest.json
+      --architecture ${{ parameters.architecture }}
+      --username $(dockerRegistry.userName)
+      --password $(BotAccount-dotnet-dockerhub-bot-password)
+      $(imageBuilder.queueBuildArgs)
+  steps:
+  - template: ../steps/cleanup-docker-linux.yml
+    parameters:
+      runOnlyBasicCleanup: ${{ parameters.useRemoteDockerServer }}
+  - script: docker build -t $(imageBuilderTag) --pull -f ./Dockerfile.linux.imagebuilder .
+    displayName: Build Runner Image
+  - script: >
+      docker run
+      --rm
+      -v /var/run/docker.sock:/var/run/docker.sock
+      $(dockerArmRunArgs)
+      $(imageBuilderTag)
+      $(imageBuilderArgs)
+    displayName: Build Images
+  - template: ../steps/cleanup-docker-linux.yml
+    parameters:
+      cleanupRemoteDockerServer: ${{ parameters.useRemoteDockerServer }}

--- a/.vsts-pipelines/steps/cleanup-docker-linux.yml
+++ b/.vsts-pipelines/steps/cleanup-docker-linux.yml
@@ -1,0 +1,41 @@
+parameters:
+  cleanupRemoteDockerServer: false
+  runOnlyBasicCleanup: false
+
+steps:
+################################################################################
+# Cleanup local Docker server (basic)
+################################################################################
+- script: docker system prune -f
+  displayName: Cleanup Docker (basic)
+  condition: always()
+  continueOnError: true
+
+- ${{ if eq(parameters.runOnlyBasicCleanup, 'false') }}:
+  ################################################################################
+  # Cleanup remote Docker server
+  ################################################################################
+  - ${{ if eq(parameters.cleanupRemoteDockerServer, 'true') }}:
+    - script: docker run --rm $(dockerArmRunArgs) --entrypoint docker $(imageBuilderTag) system prune -f --volumes
+      displayName: Cleanup Remote Docker Server (basic)
+      condition: always()
+      continueOnError: true
+    - script: >
+        docker run --rm $(dockerArmRunArgs) --entrypoint /bin/bash $(imageBuilderTag) -c
+        'docker rmi -f $(docker images --format "{{.Repository}}:{{.Tag}}" | grep -v -e ^arm32v7/ -e ^arm64v8/)'
+      displayName: Cleanup Remote Docker Server (images)
+      condition: always()
+      continueOnError: true
+
+  ################################################################################
+  # Cleanup local Docker server (advanced)
+  ################################################################################
+  - ${{ if eq(parameters.cleanupRemoteDockerServer, 'false') }}:
+    - script: docker stop $(docker ps -q) || true
+      displayName: Stop Running Containers
+      condition: always()
+      continueOnError: true
+    - script: docker system prune -a -f --volumes
+      displayName: Cleanup Docker (advanced)
+      condition: always()
+      continueOnError: true

--- a/Dockerfile.linux.imagebuilder
+++ b/Dockerfile.linux.imagebuilder
@@ -1,7 +1,7 @@
 # Use this Dockerfile to create an image containing this repo and ImageBuilder
 # Usage: docker run --rm -v /var/run/docker.sock:/var/run/docker.sock imagebuilder <imagebuilder_args> .
 
-FROM microsoft/dotnet-buildtools-prereqs:image-builder-debian-20180723194508
+FROM microsoft/dotnet-buildtools-prereqs:image-builder-debian-20190128213805
 
 WORKDIR /repo
 COPY . .


### PR DESCRIPTION
Fixes #71 

Update the build infra to support building arm32 and arm64 images.  The core build logic was migrated from https://github.com/dotnet/dotnet-docker.

**Note:** There is no CI support for ARM images.  There are currently no machines available in CI to support this scenario - there is an open issue for this.

@dotnet-bot -skip CI please.

