### PR TITLE
Add linux musl arm64 build image.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -319,6 +319,17 @@
         {
           "platforms": [
             {
+              "dockerfile": "src/ubuntu/16.04/cross/arm64-alpine",
+              "os": "linux",
+              "tags": {
+                "ubuntu-16.04-cross-arm64-alpine$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
               "dockerfile": "src/ubuntu/16.04/cross",
               "os": "linux",
               "tags": {

--- a/src/ubuntu/16.04/cross/arm64-alpine/Dockerfile
+++ b/src/ubuntu/16.04/cross/arm64-alpine/Dockerfile
@@ -10,13 +10,14 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Workaround to build a functioning ld.gold which can link for linux-musl arm64
-RUN cd /tmp && git clone https://github.com/richfelker/musl-cross-make.git
-
-RUN echo "TARGET = aarch64-alpine-linux-musl" >> /tmp/musl-cross-make/config.mak
-RUN echo "OUTPUT = /usr" >> /tmp/musl-cross-make/config.mak
-RUN echo "BINUTILS_CONFIG=--enable-gold=yes --program-prefix=aarch64-alpine-linux-musl-" >> /tmp/musl-cross-make/config.mak
-
-RUN cd /tmp/musl-cross-make && make
-RUN cd /tmp/musl-cross-make && make install
+RUN cd /tmp \
+    && wget https://ftp.gnu.org/gnu/binutils/binutils-2.27.tar.gz \
+    && tar -xf binutils-2.27.tar.gz \
+    && cd binutils-2.27 \
+    && ./configure --disable-werror --target=aarch64-alpine-linux-musl --prefix=/usr --libdir=/lib --disable-multilib --with-sysroot=aarch64-alpine-linux-musl --enable-gold=yes --program-prefix=aarch64-alpine-linux-musl- \
+    && make \
+    && make install \
+    && cd .. \
+    && rm -r *
 
 ADD rootfs.arm64.tar crossrootfs

--- a/src/ubuntu/16.04/cross/arm64-alpine/Dockerfile
+++ b/src/ubuntu/16.04/cross/arm64-alpine/Dockerfile
@@ -1,0 +1,22 @@
+FROM microsoft/dotnet-buildtools-prereqs:ubuntu-16.04-crossdeps
+
+# Install binutils-aarch64-linux-gnu
+#
+# Also install bison. This is required to build musl-cross-make
+RUN apt-get update \
+    && apt-get install -y \
+        binutils-aarch64-linux-gnu \
+        bison \
+    && rm -rf /var/lib/apt/lists/*
+
+# Workaround to build a functioning ld.gold which can link for linux-musl arm64
+RUN cd /tmp && git clone https://github.com/richfelker/musl-cross-make.git
+
+RUN echo "TARGET = aarch64-alpine-linux-musl" >> /tmp/musl-cross-make/config.mak
+RUN echo "OUTPUT = /usr" >> /tmp/musl-cross-make/config.mak
+RUN echo "BINUTILS_CONFIG=--enable-gold=yes --program-prefix=aarch64-alpine-linux-musl-" >> /tmp/musl-cross-make/config.mak
+
+RUN cd /tmp/musl-cross-make && make
+RUN cd /tmp/musl-cross-make && make install
+
+ADD rootfs.arm64.tar crossrootfs

--- a/src/ubuntu/16.04/cross/arm64-alpine/hooks/post-build
+++ b/src/ubuntu/16.04/cross/arm64-alpine/hooks/post-build
@@ -1,0 +1,1 @@
+../../../../build-scripts/build-rootfs-cleanup.sh

--- a/src/ubuntu/16.04/cross/arm64-alpine/hooks/pre-build
+++ b/src/ubuntu/16.04/cross/arm64-alpine/hooks/pre-build
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+$(dirname ${BASH_SOURCE[0]})/../../../../build-scripts/build-rootfs.sh ubuntu-16.04 alpine arm64 lldb3.9

--- a/src/ubuntu/16.04/crossdeps/Dockerfile
+++ b/src/ubuntu/16.04/crossdeps/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update \
         qemu \
         qemu-user-static \
         wget \
+        build-essential \
     && rm -rf /var/lib/apt/lists/*
 
 RUN apt-get update \


### PR DESCRIPTION
This adds an ubuntu x64 image that can cross build linux arm64 musl. Note that it has to build ld.gold which takes quite some time. This is required to link correctly when building arm64 with the crossrootfs.