### PR TITLE
Add missing NUMA development library

### DIFF
--- a/src/alpine/3.6/amd64/Dockerfile
+++ b/src/alpine/3.6/amd64/Dockerfile
@@ -36,4 +36,5 @@ RUN apk add --no-cache \
 RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache \
         userspace-rcu-dev \
         lttng-ust-dev \
-        llvm
+        llvm \
+        numactl-dev

--- a/src/alpine/3.6/arm64v8/Dockerfile
+++ b/src/alpine/3.6/arm64v8/Dockerfile
@@ -36,7 +36,8 @@ RUN apk add --no-cache \
 RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache \
         userspace-rcu-dev \
         lttng-ust-dev \
-        llvm
+        llvm \
+        numactl-dev
 
 RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/testing add --no-cache \
         lldb-dev

--- a/src/alpine/3.6/helix/amd64/Dockerfile
+++ b/src/alpine/3.6/helix/amd64/Dockerfile
@@ -38,7 +38,8 @@ RUN apk update && \
         zlib-dev && \
     apk -X http://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache \
         userspace-rcu-dev \
-        lttng-ust-dev 
+        lttng-ust-dev \
+        numactl-dev
 
 # Install Helix Dependencies
 

--- a/src/alpine/3.8/helix/amd64/Dockerfile
+++ b/src/alpine/3.8/helix/amd64/Dockerfile
@@ -37,7 +37,8 @@ RUN apk update && \
         zlib-dev && \
     apk -X http://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache \
         userspace-rcu-dev \
-        lttng-ust-dev 
+        lttng-ust-dev \
+        numactl-dev
 
 # Install Helix Dependencies
 

--- a/src/alpine/3.8/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.8/helix/arm64v8/Dockerfile
@@ -40,7 +40,8 @@ RUN apk update && \
         zlib-dev && \
     apk -X http://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache \
         lttng-ust-dev \
-        userspace-rcu-dev        
+        userspace-rcu-dev \
+        numactl-dev
 
 # Install Helix Dependencies
 

--- a/src/alpine/3.9/helix/amd64/Dockerfile
+++ b/src/alpine/3.9/helix/amd64/Dockerfile
@@ -37,7 +37,8 @@ RUN apk update && \
         zlib-dev && \
     apk -X http://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache \
         userspace-rcu-dev \
-        lttng-ust-dev 
+        lttng-ust-dev \
+        numactl-dev
 
 # Install Helix Dependencies
 

--- a/src/centos/6/Dockerfile
+++ b/src/centos/6/Dockerfile
@@ -32,6 +32,7 @@ RUN yum install -y \
         lttng-ust-devel \
         lzma \
         ncurses-devel \
+        numactl-devel \
         openssl-devel \
         perl-devel \
         python-argparse \

--- a/src/centos/7/Dockerfile
+++ b/src/centos/7/Dockerfile
@@ -31,6 +31,7 @@ RUN yum install -y \
         lzma \
         make \
         ncurses-devel \
+        numactl-devel \
         openssl-devel \
         python-argparse \
         python27 \

--- a/src/debian/9/arm32v7/Dockerfile
+++ b/src/debian/9/arm32v7/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
             libicu-dev \
             libkrb5-dev \
             liblttng-ust-dev \
+            libnuma-dev \
             libssl-dev \
             libunwind8 \
             libunwind8-dev \

--- a/src/debian/9/arm64v8/Dockerfile
+++ b/src/debian/9/arm64v8/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
             libicu-dev \
             libkrb5-dev \
             liblttng-ust-dev \
+            libnuma-dev \
             libssl-dev \
             libunwind8 \
             libunwind8-dev \

--- a/src/debian/9/helix/arm32v7/Dockerfile
+++ b/src/debian/9/helix/arm32v7/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && \
         libffi-dev \
         libgdiplus \
         libicu-dev \
+        libnuma-dev \
         libssl-dev \
         libunwind8 \
         locales \

--- a/src/debian/9/helix/arm64v8/Dockerfile
+++ b/src/debian/9/helix/arm64v8/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && \
         libffi-dev \
         libgdiplus \
         libicu-dev \
+        libnuma-dev \
         libssl-dev \
         libunwind8 \
         locales \

--- a/src/debian/jessie/coredeps/Dockerfile
+++ b/src/debian/jessie/coredeps/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update \
             libicu-dev \
             libkrb5-dev \
             liblttng-ust-dev \
+            libnuma-dev \
             libssl-dev \
             libunwind8 \
             libunwind8-dev \

--- a/src/debian/stretch/Dockerfile
+++ b/src/debian/stretch/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update \
             libkrb5-dev \
             liblldb-3.9-dev \
             liblttng-ust-dev \
+            libnuma-dev \
             libssl1.0-dev \
             libssl1.0.2 \
             libunwind8-dev \

--- a/src/fedora/28/Dockerfile
+++ b/src/fedora/28/Dockerfile
@@ -44,6 +44,7 @@ RUN dnf install -y \
         libunwind-devel \
         libuuid-devel \
         lttng-ust-devel \
+        numactl-devel \
         uuid-devel \
     && dnf clean all
 

--- a/src/fedora/29/Dockerfile
+++ b/src/fedora/29/Dockerfile
@@ -37,6 +37,7 @@ RUN dnf install -y \
         libunwind-devel \
         libuuid-devel \
         lttng-ust-devel \
+        numactl-devel \
         uuid-devel \
     && dnf clean all
 

--- a/src/opensuse/42.3/Dockerfile
+++ b/src/opensuse/42.3/Dockerfile
@@ -89,6 +89,7 @@ RUN zypper -n install --force-resolution \
         libcurl-devel \
         libgdiplus0 \
         libicu-devel \
+        libnuma-devel \
         libunwind-devel \
         libuuid-devel \
         lttng-ust-devel \

--- a/src/ubuntu/14.04/Dockerfile
+++ b/src/ubuntu/14.04/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get install -y gettext \
             libgdiplus \
             libicu-dev \
             liblttng-ust-dev \
+            libnuma-dev \
             libssl-dev \
             libunwind8-dev \
             libunwind8 \

--- a/src/ubuntu/14.04/coredeps/Dockerfile
+++ b/src/ubuntu/14.04/coredeps/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update \
         libcurl4-openssl-dev \
         libgdiplus \
         libicu-dev \
+        libnuma-dev \
         liblttng-ust-dev \
         libssl-dev \
         libunwind8 \

--- a/src/ubuntu/16.04/Dockerfile
+++ b/src/ubuntu/16.04/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get install -y gettext \
             libicu-dev \
             libkrb5-dev \
             liblttng-ust-dev \
+            libnuma-dev \
             libssl-dev \
             libunwind8-dev \
             libunwind8 \

--- a/src/ubuntu/16.04/arm32v7/Dockerfile
+++ b/src/ubuntu/16.04/arm32v7/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && \
         liblttng-ust-dev \
         libcurl4-openssl-dev \
         libicu-dev \
+        libnuma-dev \
         libssl-dev \
         libkrb5-dev \
     && rm -rf /var/lib/apt/lists/*

--- a/src/ubuntu/16.04/arm64v8/Dockerfile
+++ b/src/ubuntu/16.04/arm64v8/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && \
         liblttng-ust-dev \
         libcurl4-openssl-dev \
         libicu-dev \
+        libnuma-dev \
         libssl-dev \
         libkrb5-dev \
     && rm -rf /var/lib/apt/lists/*

--- a/src/ubuntu/16.04/coredeps/Dockerfile
+++ b/src/ubuntu/16.04/coredeps/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update \
         libicu-dev \
         libkrb5-dev \
         liblttng-ust-dev \
+        libnuma-dev \
         libssl-dev \
         libunwind8 \
         libunwind8-dev \

--- a/src/ubuntu/16.04/helix/arm32v7/Dockerfile
+++ b/src/ubuntu/16.04/helix/arm32v7/Dockerfile
@@ -9,7 +9,8 @@ RUN apt-get update && \
         libcurl3 \
         libffi-dev \
         libgdiplus \        
-        libicu-dev \        
+        libicu-dev \
+        libnuma-dev \
         libssl-dev \
         libunwind8 \        
         libunwind-dev \

--- a/src/ubuntu/16.04/helix/arm64v8/Dockerfile
+++ b/src/ubuntu/16.04/helix/arm64v8/Dockerfile
@@ -9,7 +9,8 @@ RUN apt-get update && \
         libcurl3 \
         libffi-dev \
         libgdiplus \        
-        libicu-dev \        
+        libicu-dev \
+        libnuma-dev \
         libssl-dev \
         libunwind8 \        
         libunwind-dev \

--- a/src/ubuntu/17.10/Dockerfile
+++ b/src/ubuntu/17.10/Dockerfile
@@ -43,6 +43,7 @@ RUN apt-get update \
         libicu-dev \
         libkrb5-dev \
         liblttng-ust-dev \
+        libnuma-dev \
         libssl-dev \
         libunwind8 \
         libunwind8-dev \

--- a/src/ubuntu/18.04/amd64/Dockerfile
+++ b/src/ubuntu/18.04/amd64/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get update \
         libicu-dev \
         libkrb5-dev \
         liblttng-ust-dev \
+        libnuma-dev \
         libssl1.0-dev \
         libunwind8 \
         libunwind8-dev \

--- a/src/ubuntu/18.04/arm32v7/Dockerfile
+++ b/src/ubuntu/18.04/arm32v7/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && \
         libunwind8 \
         libunwind8-dev \
         libicu-dev \
+        libnuma-dev \
         liblttng-ust-dev \
         libcurl4-openssl-dev \
         libicu-dev \

--- a/src/ubuntu/18.04/arm64v8/Dockerfile
+++ b/src/ubuntu/18.04/arm64v8/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && \
         libunwind8 \
         libunwind8-dev \
         libicu-dev \
+        libnuma-dev \
         liblttng-ust-dev \
         libcurl4-openssl-dev \
         libicu-dev \

--- a/src/ubuntu/18.04/helix/arm32v7/Dockerfile
+++ b/src/ubuntu/18.04/helix/arm32v7/Dockerfile
@@ -17,7 +17,8 @@ RUN apt-get update && \
         libcurl4 \
         libffi-dev \
         libgdiplus \
-        libicu-dev \        
+        libicu-dev \
+        libnuma-dev \
         libssl-dev \
         libunwind8 \        
         libunwind-dev \        

--- a/src/ubuntu/18.04/helix/arm64v8/Dockerfile
+++ b/src/ubuntu/18.04/helix/arm64v8/Dockerfile
@@ -17,7 +17,8 @@ RUN apt-get update && \
         libcurl4 \
         libffi-dev \
         libgdiplus \
-        libicu-dev \        
+        libicu-dev \
+        libnuma-dev \
         libssl-dev \
         libunwind8 \        
         libunwind-dev \        


### PR DESCRIPTION
This library is needed to enable the coreclr binaries to be NUMA aware.
We have found today that this was accidentally missing for all of our build docker images.