### PR TITLE
Add sudo, dotnet SDK build need this to reduce risk of sdk build failure

### DIFF
--- a/src/centos/6/Dockerfile
+++ b/src/centos/6/Dockerfile
@@ -37,6 +37,7 @@ RUN yum install -y \
         python-argparse \
         python27 \
         readline-devel \
+        sudo \
         swig \
         xz \
         zlib-devel \

--- a/src/centos/7/Dockerfile
+++ b/src/centos/7/Dockerfile
@@ -36,6 +36,7 @@ RUN yum install -y \
         python27 \
         python-devel \
         readline-devel \
+        sudo \
         swig \
         wget \
         which \

--- a/src/debian/jessie/Dockerfile
+++ b/src/debian/jessie/Dockerfile
@@ -19,4 +19,5 @@ RUN apt-get update \
                llvm-3.9 \
                make \
                python-lldb-5.0 \
+               sudo \
     && rm -rf /var/lib/apt/lists/*

--- a/src/debian/stretch/Dockerfile
+++ b/src/debian/stretch/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update \
             llvm \
             make \
             python-lldb-3.9 \
+            sudo \
             tar \
             uuid-dev \
             zip \

--- a/src/fedora/28/Dockerfile
+++ b/src/fedora/28/Dockerfile
@@ -17,6 +17,7 @@ RUN dnf install -y \
         make \
         python \
         python2-lldb \
+        sudo \
         which \
     && dnf clean all
 

--- a/src/fedora/29/Dockerfile
+++ b/src/fedora/29/Dockerfile
@@ -13,6 +13,7 @@ RUN dnf install -y \
         make \
         python \
         python2-lldb \
+        sudo \
         which \
     && dnf clean all
 

--- a/src/opensuse/42.3/Dockerfile
+++ b/src/opensuse/42.3/Dockerfile
@@ -13,6 +13,7 @@ RUN zypper -n install \
         llvm-devel \
         python \
         python-xml \
+        sudo \
         wget \
         which \
     && ln -s /usr/bin/clang++ /usr/bin/clang++-3.5 \

--- a/src/ubuntu/14.04/Dockerfile
+++ b/src/ubuntu/14.04/Dockerfile
@@ -17,7 +17,8 @@ RUN apt-get update && \
             lldb-3.9 \
             llvm-3.9 \
             make \
-            python-lldb-3.9 && \
+            python-lldb-3.9 \
+            sudo && \
     apt-get clean
 
 # Install tools used by the VSO build automation. Set up a new apt-get source to

--- a/src/ubuntu/16.04/Dockerfile
+++ b/src/ubuntu/16.04/Dockerfile
@@ -17,7 +17,8 @@ RUN apt-get update && \
             lldb-3.9 \
             llvm-3.9 \
             make \
-            python-lldb-3.9 && \
+            python-lldb-3.9 \
+            sudo && \
     apt-get clean
 
 # Install tools used by the VSO build automation.  nodejs-legacy is a Debian specific

--- a/src/ubuntu/17.10/Dockerfile
+++ b/src/ubuntu/17.10/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update \
         llvm-3.9 \
         make \
         python-lldb-3.9 \
+        sudo \
     && rm -rf /var/lib/apt/lists/*
 
 # Install tools used by the VSO build automation.  nodejs-legacy is a Debian specific

--- a/src/ubuntu/18.04/amd64/Dockerfile
+++ b/src/ubuntu/18.04/amd64/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update \
         llvm-3.9 \
         make \
         python-lldb-3.9 \
+        sudo \
         wget \
     && rm -rf /var/lib/apt/lists/* \
     && wget https://cmake.org/files/v3.10/cmake-3.10.2-Linux-x86_64.tar.gz \


### PR DESCRIPTION
We (SDK) hope to add sudo to build in docker image. So we do not need to download during CI build to reduce build failure like this.

https://dev.azure.com/dnceng/public/_build/results?buildId=90582

cc @nguerrera 