### PR TITLE
make sure /root/commands is accessible to other users

### DIFF
--- a/src/alpine/3.9/helix/amd64/Dockerfile
+++ b/src/alpine/3.9/helix/amd64/Dockerfile
@@ -57,6 +57,7 @@ RUN python -m pip install --upgrade pip==19.0.2 && \
 
 # Fixup helixbot user
 RUN /usr/sbin/adduser -D -G adm -s /bin/sh helixbot; \
+    chmod 755 /root ; \
     echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot
 
 USER helixbot


### PR DESCRIPTION
Needed to start helix client. 

Can you please rebuild and post another image @MichaelSimons ? Build is failing now as helixbot cannot execute common scripts. 