### PR TITLE
set LANG to en-US.UTF-8

### DIFF
--- a/src/alpine/3.9/helix/amd64/Dockerfile
+++ b/src/alpine/3.9/helix/amd64/Dockerfile
@@ -58,6 +58,7 @@ RUN python -m pip install --upgrade pip==19.0.2 && \
 # Fixup helixbot user
 RUN /usr/sbin/adduser -D -G adm -s /bin/sh helixbot; \
     chmod 755 /root ; \
+    echo LANG=en-US.UTF-8 > /home/helixbot/.bashrc ; \
     echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot
 
 USER helixbot


### PR DESCRIPTION
This fixes Generic collection tests and perhaps other.
Without this, it was failing on string comparison. 

It seems like Alpine 3.9 images sets LANG=C.UTF-8 and that breaks .Net tests for some reason. I did tests with LANG set to en_US-UTF-8 and unset and with both, test can pass. There are articles about locale on musl libc and their lack of completes. 



```
  Discovering: System.Collections.NonGeneric.Tests (method display = ClassAndMethod, method display options = None)
  Discovered:  System.Collections.NonGeneric.Tests (found 1524 test cases)
  Starting:    System.Collections.NonGeneric.Tests (parallel test collections = on, max threads = 8)
  Finished:    System.Collections.NonGeneric.Tests
=== TEST EXECUTION SUMMARY ===
   System.Collections.NonGeneric.Tests  Total: 3945, Errors: 0, Failed: 0, Skipped: 0, Time: 10.795s
```