### PR TITLE
make sure LANG is available in ash and docker exec commands

### DIFF
--- a/src/alpine/3.9/helix/amd64/Dockerfile
+++ b/src/alpine/3.9/helix/amd64/Dockerfile
@@ -55,10 +55,12 @@ RUN python -m pip install --upgrade pip==19.0.2 && \
                   six==1.12.0 \
                   virtualenv==16.2.0
 
-# Fixup helixbot user
+# Needed for corefx tests to pass
+ENV LANG=en-US.UTF-8
+
+# create helixbot user and give rights to sudo without password
 RUN /usr/sbin/adduser -D -G adm -s /bin/sh helixbot; \
     chmod 755 /root ; \
-    echo LANG=en-US.UTF-8 > /home/helixbot/.bashrc ; \
     echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot
 
 USER helixbot


### PR DESCRIPTION
This is follow-up on #90. Using .bashrc worked when tests were executed from shell but it did not work commands started via docker exec. 

```
  Discovering: System.Collections.NonGeneric.Tests (method display = ClassAndMethod, method display options = None)
  Discovered:  System.Collections.NonGeneric.Tests (found 1524 test cases)
  Starting:    System.Collections.NonGeneric.Tests (parallel test collections = on, max threads = 8)
    System.Collections.Tests.ComparerTests.Default_Compare(a: "hello", b: "HELLO", expected: -1) [FAIL]
      Assert.Equal() Failure
      Expected: -1
      Actual:   1
      Stack Trace:
        /__w/1/s/src/System.Collections.NonGeneric/tests/ComparerTests.cs(115,0): at System.Collections.Tests.ComparerTests.Default_Compare(Object a, Object b, Int32 expected)
```

We verified with @MattGal that setting this makes tests pass and I'm going to write up corefx issue. 

also:
```
furt@net-dale:/mnt/github/dotnet-helix-machines$ docker exec -i 3ca7174d4855 printenv
PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
HOSTNAME=3ca7174d4855
LANG=en-US.UTF-8
```

Alpine does not really have same locale option as glibc based distributions. So far I did not find issues after setting this globally.
