### PR TITLE
Refactoring the debian:8.2 images to be based on debian:jessie

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -112,11 +112,11 @@
         {
           "platforms": [
             {
-              "dockerfile": "src/debian/8.2/coredeps",
+              "dockerfile": "src/debian/jessie/coredeps",
               "os": "linux",
               "tags": {
-                "debian-8.2-coredeps-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {},
-                "debian-8.2-coredeps": {
+                "debian-jessie-coredeps-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {},
+                "debian-jessie-coredeps": {
                   "isLocal": true
                 }
               }
@@ -126,11 +126,11 @@
         {
           "platforms": [
             {
-              "dockerfile": "src/debian/8.2",
+              "dockerfile": "src/debian/jessie",
               "os": "linux",
               "tags": {
-                "debian-8.2-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {},
-                "debian-8.2": {
+                "debian-jessie-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {},
+                "debian-jessie": {
                   "isLocal": true
                 }
               }
@@ -140,10 +140,10 @@
         {
           "platforms": [
             {
-              "dockerfile": "src/debian/8.2/debpkg",
+              "dockerfile": "src/debian/jessie/debpkg",
               "os": "linux",
               "tags": {
-                "debian-8.2-debpkg-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
+                "debian-jessie-debpkg-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
               }
             }
           ]
@@ -151,10 +151,10 @@
         {
           "platforms": [
             {
-              "dockerfile": "src/debian/8.2/corert",
+              "dockerfile": "src/debian/jessie/corert",
               "os": "linux",
               "tags": {
-                "debian-8.2-corert-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
+                "debian-jessie-corert-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
               }
             }
           ]

--- a/src/debian/jessie/Dockerfile
+++ b/src/debian/jessie/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:debian-8.2-coredeps
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:debian-jessie-coredeps
 
 # Install the base toolchain we need to build anything (clang, cmake, make and the like)
 # this does not include libraries that we need to compile different projects, we'd like

--- a/src/debian/jessie/coredeps/Dockerfile
+++ b/src/debian/jessie/coredeps/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:8.2
+FROM debian:jessie
 
 # Install tools used by the VSO build automation. Set up a new apt-get source to
 # get a new version of node and npm: the built-in old cert is no longer valid.

--- a/src/debian/jessie/corert/Dockerfile
+++ b/src/debian/jessie/corert/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:debian-8.2-coredeps
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:debian-jessie-coredeps
 
 # Install tools needs to build CoreRT.
 RUN apt-get update \

--- a/src/debian/jessie/debpkg/Dockerfile
+++ b/src/debian/jessie/debpkg/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:debian-8.2
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:debian-jessie
 
 # Install the deb packaging toolchain we need to build debs
 RUN apt-get update \


### PR DESCRIPTION
The debian:8.2 images are currently broken for two reasons.  Debian 8.2 is EOL and package feed configuration it comes with was archived to a different location.  This means you can't use apt-get.  To resolve this, a decision was made to refactor the 8.2 images to be based on debian:jessie.

Fixes #107 