### PR TITLE
Fix Alpine ARM64 crossbuild by updating binutils

### DIFF
--- a/src/ubuntu/16.04/cross/arm64-alpine/Dockerfile
+++ b/src/ubuntu/16.04/cross/arm64-alpine/Dockerfile
@@ -11,10 +11,10 @@ RUN apt-get update \
 
 # Workaround to build a functioning ld.gold which can link for linux-musl arm64
 RUN cd /tmp \
-    && wget https://ftp.gnu.org/gnu/binutils/binutils-2.27.tar.gz \
-    && tar -xf binutils-2.27.tar.gz \
-    && cd binutils-2.27 \
-    && ./configure --disable-werror --target=aarch64-alpine-linux-musl --prefix=/usr --libdir=/lib --disable-multilib --with-sysroot=aarch64-alpine-linux-musl --enable-gold=yes --program-prefix=aarch64-alpine-linux-musl- \
+    && wget https://ftp.gnu.org/gnu/binutils/binutils-2.31.1.tar.gz \
+    && tar -xf binutils-2.31.1.tar.gz \
+    && cd binutils-2.31.1 \
+    && ./configure --disable-werror --target=aarch64-alpine-linux-musl --prefix=/usr --libdir=/lib --disable-multilib --with-sysroot=aarch64-alpine-linux-musl --enable-gold=yes --enable-plugins=yes --program-prefix=aarch64-alpine-linux-musl- \
     && make \
     && make install \
     && cd .. \


### PR DESCRIPTION
The linker from binutils 2.27 that we were using before was producing
binaries with missing symbols and so it was not possible to load
libcoreclr.so.

We were also not building the binutils with plugins enabled, which
caused LTO to be disabled.

This change updates binutils to 2.31.1 and adds missing option to the
configure command line so that the plugins support is built in.