### PR TITLE
Define a single uber PR build pipeline

### DIFF
--- a/.vsts-pipelines/dotnet-buildtools-prereqs-alpine.yml
+++ b/.vsts-pipelines/dotnet-buildtools-prereqs-alpine.yml
@@ -19,4 +19,8 @@ variables:
 jobs:
   - template: jobs/build-image-legs.yml
     parameters:
-      imageBuilderPath: src/alpine/*
+      matrix: {
+        "alpine": {
+          "imageBuilderPath": "src/alpine/*"
+        }
+      }

--- a/.vsts-pipelines/dotnet-buildtools-prereqs-centos6.yml
+++ b/.vsts-pipelines/dotnet-buildtools-prereqs-centos6.yml
@@ -19,4 +19,8 @@ variables:
 jobs:
   - template: jobs/build-image-legs.yml
     parameters:
-      imageBuilderPath: src/centos/6/*
+      matrix: {
+        "centos6": {
+          "imageBuilderPath": "src/centos/6*"
+        }
+      }

--- a/.vsts-pipelines/dotnet-buildtools-prereqs-centos7.yml
+++ b/.vsts-pipelines/dotnet-buildtools-prereqs-centos7.yml
@@ -19,4 +19,8 @@ variables:
 jobs:
   - template: jobs/build-image-legs.yml
     parameters:
-      imageBuilderPath: src/centos/7/*
+      matrix: {
+        "centos7": {
+          "imageBuilderPath": "src/centos/7*"
+        }
+      }

--- a/.vsts-pipelines/dotnet-buildtools-prereqs-debian.yml
+++ b/.vsts-pipelines/dotnet-buildtools-prereqs-debian.yml
@@ -19,4 +19,8 @@ variables:
 jobs:
   - template: jobs/build-image-legs.yml
     parameters:
-      imageBuilderPath: src/debian/*
+      matrix: {
+        "debian": {
+          "imageBuilderPath": "src/debian/*"
+        }
+      }

--- a/.vsts-pipelines/dotnet-buildtools-prereqs-fedora.yml
+++ b/.vsts-pipelines/dotnet-buildtools-prereqs-fedora.yml
@@ -19,4 +19,8 @@ variables:
 jobs:
   - template: jobs/build-image-legs.yml
     parameters:
-      imageBuilderPath: src/fedora/*
+      matrix: {
+        "fedora": {
+          "imageBuilderPath": "src/fedora/*"
+        }
+      }

--- a/.vsts-pipelines/dotnet-buildtools-prereqs-opensuse.yml
+++ b/.vsts-pipelines/dotnet-buildtools-prereqs-opensuse.yml
@@ -19,4 +19,8 @@ variables:
 jobs:
   - template: jobs/build-image-legs.yml
     parameters:
-      imageBuilderPath: src/opensuse/*
+      matrix: {
+        "opensuse": {
+          "imageBuilderPath": "src/opensuse/*"
+        }
+      }

--- a/.vsts-pipelines/dotnet-buildtools-prereqs-pr.yml
+++ b/.vsts-pipelines/dotnet-buildtools-prereqs-pr.yml
@@ -1,0 +1,44 @@
+trigger: none
+pr:
+  branches:
+    include:
+    - master
+
+variables:
+- template: variables/common.yml
+
+jobs:
+  - template: jobs/build-image-legs.yml
+    parameters:
+      matrix: {
+        "alpine": {
+          "imageBuilderPath": "src/alpine/*"
+        },
+        "centos6": {
+          "imageBuilderPath": "src/centos/6*"
+        },
+        "centos7": {
+          "imageBuilderPath": "src/centos/7*"
+        },
+        "debian": {
+          "imageBuilderPath": "src/debian/*"
+        },
+        "fedora": {
+          "imageBuilderPath": "src/fedora/*"
+        },
+        "opensuse": {
+          "imageBuilderPath": "src/opensuse/*"
+        },
+        "ubuntu14": {
+          "imageBuilderPath": "src/ubuntu/14*"
+        },
+        "ubuntu16": {
+          "imageBuilderPath": "src/ubuntu/16*"
+        },
+        "ubuntu17": {
+          "imageBuilderPath": "src/ubuntu/17*"
+        },
+        "ubuntu18": {
+          "imageBuilderPath": "src/ubuntu/18*"
+        }
+      }

--- a/.vsts-pipelines/dotnet-buildtools-prereqs-ubuntu14.yml
+++ b/.vsts-pipelines/dotnet-buildtools-prereqs-ubuntu14.yml
@@ -19,4 +19,8 @@ variables:
 jobs:
   - template: jobs/build-image-legs.yml
     parameters:
-      imageBuilderPath: src/ubuntu/14*
+      matrix: {
+        "ubuntu14": {
+          "imageBuilderPath": "src/ubuntu/14*"
+        }
+      }

--- a/.vsts-pipelines/dotnet-buildtools-prereqs-ubuntu16.yml
+++ b/.vsts-pipelines/dotnet-buildtools-prereqs-ubuntu16.yml
@@ -19,4 +19,8 @@ variables:
 jobs:
   - template: jobs/build-image-legs.yml
     parameters:
-      imageBuilderPath: src/ubuntu/16*
+      matrix: {
+        "ubuntu16": {
+          "imageBuilderPath": "src/ubuntu/16*"
+        }
+      }

--- a/.vsts-pipelines/dotnet-buildtools-prereqs-ubuntu17.yml
+++ b/.vsts-pipelines/dotnet-buildtools-prereqs-ubuntu17.yml
@@ -19,4 +19,8 @@ variables:
 jobs:
   - template: jobs/build-image-legs.yml
     parameters:
-      imageBuilderPath: src/ubuntu/17*
+      matrix: {
+        "ubuntu17": {
+          "imageBuilderPath": "src/ubuntu/17*"
+        }
+      }

--- a/.vsts-pipelines/dotnet-buildtools-prereqs-ubuntu18.yml
+++ b/.vsts-pipelines/dotnet-buildtools-prereqs-ubuntu18.yml
@@ -19,4 +19,8 @@ variables:
 jobs:
   - template: jobs/build-image-legs.yml
     parameters:
-      imageBuilderPath: src/ubuntu/18*
+      matrix: {
+        "ubuntu18": {
+          "imageBuilderPath": "src/ubuntu/18*"
+        }
+      }

--- a/.vsts-pipelines/jobs/build-image-legs.yml
+++ b/.vsts-pipelines/jobs/build-image-legs.yml
@@ -1,5 +1,5 @@
 parameters:
-  imageBuilderPath: null
+  matrix: {}
 
 jobs:
 - template: build-images.yml
@@ -8,7 +8,7 @@ jobs:
     pool: # linuxAmd64Pool
       name: Hosted Ubuntu 1604
     architecture: amd64
-    imageBuilderPath: ${{ parameters.imageBuilderPath }}
+    matrix: ${{ parameters.matrix }}
 - ${{ if ne(variables['System.TeamProject'], 'public') }}:
   - template: build-images.yml
     parameters:
@@ -20,7 +20,7 @@ jobs:
         - RemoteDockerServerOS -equals linux
         - RemoteDockerServerArch -equals aarch64
       architecture: arm64
-      imageBuilderPath: ${{ parameters.imageBuilderPath }}
+      matrix: ${{ parameters.matrix }}
       useRemoteDockerServer: true
   - template: build-images.yml
     parameters:
@@ -32,5 +32,5 @@ jobs:
         - RemoteDockerServerOS -equals linux
         - RemoteDockerServerArch -equals aarch64
       architecture: arm
-      imageBuilderPath: ${{ parameters.imageBuilderPath }}
+      matrix: ${{ parameters.matrix }}
       useRemoteDockerServer: true

--- a/.vsts-pipelines/jobs/build-images.yml
+++ b/.vsts-pipelines/jobs/build-images.yml
@@ -3,11 +3,13 @@ parameters:
   pool: {}
   architecture: null
   useRemoteDockerServer: false
-  imageBuilderPath: null
+  matrix: {}
 
 jobs:
 - job: ${{ parameters.name }}
   pool: ${{ parameters.pool }}
+  strategy: 
+    matrix: ${{ parameters.matrix }}
   timeoutInMinutes: 180
   variables:
     ${{ if eq(parameters.useRemoteDockerServer, 'true') }}:
@@ -32,7 +34,7 @@ jobs:
     imageBuilderTag: image-builder
     imageBuilderArgs:
       build
-      --path "${{ parameters.imageBuilderPath }}"
+      --path "$(imageBuilderPath)"
       --manifest manifest.json
       --architecture ${{ parameters.architecture }}
       $(imageBuilderBuildArgs)


### PR DESCRIPTION
It was determined that we can't make use of the path filter capability of AzDO pipelines when targeting GitHub repos.  This means for PR verification we can't make use of the OS-specific pipeline files that made use of the path filter.  Instead, we'll need to have a single pipeline that covers all the OS types.

These changes define a new PR yml pipeline and makes use of a matrix that defines the src paths to all the OS types.  This is basically a poor man's version of the functionality that Image Builder provides with it's matrix generation.  This was just a quick implementation to get things up and running before migrating to use the matrix generation.