### PR TITLE
Add Nano 1803 and 1809 Helix images

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -644,6 +644,30 @@
               "variant": "v8"
             }
           ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/nanoserver/1803/helix/amd64",
+              "os": "windows",
+              "osVersion": "nanoserver-1803",
+              "tags": {
+                "nanoserver-1803-helix-amd64-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/nanoserver/1809/helix/amd64",
+              "os": "windows",
+              "osVersion": "nanoserver-1809",
+              "tags": {
+                "nanoserver-1809-helix-amd64-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
+              }
+            }
+          ]
         }
       ]
     }

--- a/src/nanoserver/1803/helix/amd64/Dockerfile
+++ b/src/nanoserver/1803/helix/amd64/Dockerfile
@@ -1,0 +1,29 @@
+FROM mcr.microsoft.com/powershell:6.2.0-nanoserver-1803
+
+USER ContainerAdministrator
+ENTRYPOINT C:\Windows\System32\cmd.exe
+
+RUN curl -SL --output %TEMP%\python.zip https://www.nuget.org/api/v2/package/python/3.7.3 \
+    && md C:\Python C:\PythonTemp \
+    && tar -zxf %TEMP%\python.zip -C C:\PythonTemp \
+    && xcopy /s c:\PythonTemp\tools C:\Python \
+    && rd /s /q c:\PythonTemp \
+    && del /q %TEMP%\python.zip
+
+RUN setx /M PATH "%PATH%;C:\Python;C:\python\scripts" \
+    && setx /M PYTHONPATH "C:\Python\Lib;C:\Python\DLLs;"
+
+RUN python -m pip install --upgrade pip \
+    && python -m pip install applicationinsights==0.11.8 \
+                             certifi==2019.3.9 \
+                             docker==3.7.2 \
+                             ndg-httpsclient==0.5.1 \
+                             psutil==5.6.1 \
+                             pyasn1==0.4.5 \
+                             pyopenssl==19.0.0 \
+                             requests==2.21.0 \
+                             six==1.12.0 \
+                             virtualenv==16.5.0
+
+WORKDIR C:\\Work
+

--- a/src/nanoserver/1803/helix/amd64/Dockerfile
+++ b/src/nanoserver/1803/helix/amd64/Dockerfile
@@ -1,5 +1,6 @@
 FROM mcr.microsoft.com/powershell:6.2.0-nanoserver-1803
 
+SHELL ["cmd", "/S", "/C"]
 USER ContainerAdministrator
 ENTRYPOINT C:\Windows\System32\cmd.exe
 
@@ -10,7 +11,7 @@ RUN curl -SL --output %TEMP%\python.zip https://www.nuget.org/api/v2/package/pyt
     && rd /s /q c:\PythonTemp \
     && del /q %TEMP%\python.zip
 
-RUN setx /M PATH "%PATH%;C:\Python;C:\python\scripts" \
+RUN setx /M PATH "%PATH%;C:\Program Files\PowerShell\;C:\Python;C:\python\scripts" \
     && setx /M PYTHONPATH "C:\Python\Lib;C:\Python\DLLs;"
 
 RUN python -m pip install --upgrade pip \

--- a/src/nanoserver/1809/helix/amd64/Dockerfile
+++ b/src/nanoserver/1809/helix/amd64/Dockerfile
@@ -1,0 +1,30 @@
+FROM mcr.microsoft.com/powershell:6.2.0-nanoserver-1809
+
+SHELL ["cmd", "/S", "/C"]
+USER ContainerAdministrator
+ENTRYPOINT C:\Windows\System32\cmd.exe
+
+RUN curl -SL --output %TEMP%\python.zip https://www.nuget.org/api/v2/package/python/3.7.3 \
+    && md C:\Python C:\PythonTemp \
+    && tar -zxf %TEMP%\python.zip -C C:\PythonTemp \
+    && xcopy /s c:\PythonTemp\tools C:\Python \
+    && rd /s /q c:\PythonTemp \
+    && del /q %TEMP%\python.zip
+
+RUN setx /M PATH "%PATH%;C:\Program Files\PowerShell\;C:\Python;C:\python\scripts" \
+    && setx /M PYTHONPATH "C:\Python\Lib;C:\Python\DLLs;"
+
+RUN python -m pip install --upgrade pip \
+    && python -m pip install applicationinsights==0.11.8 \
+                             certifi==2019.3.9 \
+                             docker==3.7.2 \
+                             ndg-httpsclient==0.5.1 \
+                             psutil==5.6.1 \
+                             pyasn1==0.4.5 \
+                             pyopenssl==19.0.0 \
+                             requests==2.21.0 \
+                             six==1.12.0 \
+                             virtualenv==16.5.0
+
+WORKDIR C:\\Work
+


### PR DESCRIPTION
In the near future we'll want to be running our Windows Server Nano testing using the Helix client docker feature;  this builds usable Nano images with Python 3.7 installed for 1803 and 1809.

@MichaelSimons FYI.