### PR TITLE
Fix ubuntu trigger paths to not use wildcard for version folder name

### DIFF
--- a/.vsts-pipelines/dotnet-buildtools-prereqs-ubuntu14.yml
+++ b/.vsts-pipelines/dotnet-buildtools-prereqs-ubuntu14.yml
@@ -4,14 +4,14 @@ trigger:
     - master
   paths:
     include:
-    - src/ubuntu/14*
+    - src/ubuntu/14.04/*
 pr:
   branches:
     include:
     - master
   paths:
     include:
-    - src/ubuntu/14*
+    - src/ubuntu/14.04/*
 
 variables:
 - template: variables/common.yml
@@ -21,6 +21,6 @@ jobs:
     parameters:
       matrix: {
         "ubuntu14": {
-          "imageBuilderPath": "src/ubuntu/14*"
+          "imageBuilderPath": "src/ubuntu/14.04/*"
         }
       }

--- a/.vsts-pipelines/dotnet-buildtools-prereqs-ubuntu16.yml
+++ b/.vsts-pipelines/dotnet-buildtools-prereqs-ubuntu16.yml
@@ -4,14 +4,14 @@ trigger:
     - master
   paths:
     include:
-    - src/ubuntu/16*
+    - src/ubuntu/16.04/*
 pr:
   branches:
     include:
     - master
   paths:
     include:
-    - src/ubuntu/16*
+    - src/ubuntu/16.04/*
 
 variables:
 - template: variables/common.yml
@@ -21,6 +21,6 @@ jobs:
     parameters:
       matrix: {
         "ubuntu16": {
-          "imageBuilderPath": "src/ubuntu/16*"
+          "imageBuilderPath": "src/ubuntu/16.04/*"
         }
       }

--- a/.vsts-pipelines/dotnet-buildtools-prereqs-ubuntu17.yml
+++ b/.vsts-pipelines/dotnet-buildtools-prereqs-ubuntu17.yml
@@ -4,14 +4,14 @@ trigger:
     - master
   paths:
     include:
-    - src/ubuntu/17*
+    - src/ubuntu/17.10/*
 pr:
   branches:
     include:
     - master
   paths:
     include:
-    - src/ubuntu/17*
+    - src/ubuntu/17.10/*
 
 variables:
 - template: variables/common.yml
@@ -21,6 +21,6 @@ jobs:
     parameters:
       matrix: {
         "ubuntu17": {
-          "imageBuilderPath": "src/ubuntu/17*"
+          "imageBuilderPath": "src/ubuntu/17.10/*"
         }
       }

--- a/.vsts-pipelines/dotnet-buildtools-prereqs-ubuntu18.yml
+++ b/.vsts-pipelines/dotnet-buildtools-prereqs-ubuntu18.yml
@@ -4,14 +4,14 @@ trigger:
     - master
   paths:
     include:
-    - src/ubuntu/18*
+    - src/ubuntu/18.04/*
 pr:
   branches:
     include:
     - master
   paths:
     include:
-    - src/ubuntu/18*
+    - src/ubuntu/18.04/*
 
 variables:
 - template: variables/common.yml
@@ -21,6 +21,6 @@ jobs:
     parameters:
       matrix: {
         "ubuntu18": {
-          "imageBuilderPath": "src/ubuntu/18*"
+          "imageBuilderPath": "src/ubuntu/18.04/*"
         }
       }


### PR DESCRIPTION
The build triggers aren't working for Ubuntu, apparently because a wildcard is used in the folder name.  Changing it to be explicit for the version name instead.  This is technically the right thing to do anyway in case we were to ever add support for additional versions with the same major version, in which case we'd want separate pipelines for each.