### PR TITLE
Revert changes to add libnuma-dev to select arm32 images

### DIFF
--- a/src/debian/9/arm32v7/Dockerfile
+++ b/src/debian/9/arm32v7/Dockerfile
@@ -10,7 +10,6 @@ RUN apt-get update \
             libicu-dev \
             libkrb5-dev \
             liblttng-ust-dev \
-            libnuma-dev \
             libssl-dev \
             libunwind8 \
             libunwind8-dev \

--- a/src/debian/9/helix/arm32v7/Dockerfile
+++ b/src/debian/9/helix/arm32v7/Dockerfile
@@ -14,7 +14,6 @@ RUN apt-get update && \
         libffi-dev \
         libgdiplus \
         libicu-dev \
-        libnuma-dev \
         libssl-dev \
         libunwind8 \
         locales \

--- a/src/ubuntu/16.04/arm32v7/Dockerfile
+++ b/src/ubuntu/16.04/arm32v7/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update && \
         liblttng-ust-dev \
         libcurl4-openssl-dev \
         libicu-dev \
-        libnuma-dev \
         libssl-dev \
         libkrb5-dev \
     && rm -rf /var/lib/apt/lists/*

--- a/src/ubuntu/16.04/helix/arm32v7/Dockerfile
+++ b/src/ubuntu/16.04/helix/arm32v7/Dockerfile
@@ -10,7 +10,6 @@ RUN apt-get update && \
         libffi-dev \
         libgdiplus \        
         libicu-dev \
-        libnuma-dev \
         libssl-dev \
         libunwind8 \        
         libunwind-dev \


### PR DESCRIPTION
These changes were recently introduced in #74.  libnuma-dev is not available in the [ubuntu 16.04](https://packages.ubuntu.com/xenial/libnuma-dev) and [debian 9](https://packages.debian.org/stretch/libnuma-dev) arm32 default package feeds.  I would like to revert these changes to unblock the builds.