### PR TITLE
Fix Alpine 3.6 arm64 docker image

### DIFF
--- a/src/alpine/3.6/arm64v8/Dockerfile
+++ b/src/alpine/3.6/arm64v8/Dockerfile
@@ -36,7 +36,7 @@ RUN apk add --no-cache \
 RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache \
         userspace-rcu-dev \
         lttng-ust-dev \
-        llvm \
+        llvm5 \
         numactl-dev
 
 RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/testing add --no-cache \


### PR DESCRIPTION
Alpine now installs llvm7 when llvm package is requested. However,
lldb-dev depends on llvm5, which used to be installed for llvm before.
So building the Alpine 3.6 arm64 image doesn't work anymore.

The fix is to install llvm5 explicitly.

Close #132