### PR TITLE
Fix Ubuntu build legs to use correct image builder path args

### DIFF
--- a/.vsts-pipelines/dotnet-buildtools-prereqs-ubuntu14.yml
+++ b/.vsts-pipelines/dotnet-buildtools-prereqs-ubuntu14.yml
@@ -21,6 +21,6 @@ jobs:
     parameters:
       matrix: {
         "ubuntu14": {
-          "imageBuilderPath": "src/ubuntu/14.04/*"
+          "imageBuilderPath": "src/ubuntu/14.04*"
         }
       }

--- a/.vsts-pipelines/dotnet-buildtools-prereqs-ubuntu16.yml
+++ b/.vsts-pipelines/dotnet-buildtools-prereqs-ubuntu16.yml
@@ -21,6 +21,6 @@ jobs:
     parameters:
       matrix: {
         "ubuntu16": {
-          "imageBuilderPath": "src/ubuntu/16.04/*"
+          "imageBuilderPath": "src/ubuntu/16.04*"
         }
       }

--- a/.vsts-pipelines/dotnet-buildtools-prereqs-ubuntu17.yml
+++ b/.vsts-pipelines/dotnet-buildtools-prereqs-ubuntu17.yml
@@ -21,6 +21,6 @@ jobs:
     parameters:
       matrix: {
         "ubuntu17": {
-          "imageBuilderPath": "src/ubuntu/17.10/*"
+          "imageBuilderPath": "src/ubuntu/17.10*"
         }
       }

--- a/.vsts-pipelines/dotnet-buildtools-prereqs-ubuntu18.yml
+++ b/.vsts-pipelines/dotnet-buildtools-prereqs-ubuntu18.yml
@@ -21,6 +21,6 @@ jobs:
     parameters:
       matrix: {
         "ubuntu18": {
-          "imageBuilderPath": "src/ubuntu/18.04/*"
+          "imageBuilderPath": "src/ubuntu/18.04*"
         }
       }

--- a/.vsts-pipelines/dotnet-buildtools-prereqs-ubuntu19.yml
+++ b/.vsts-pipelines/dotnet-buildtools-prereqs-ubuntu19.yml
@@ -4,7 +4,7 @@ trigger:
     - master
   paths:
     include:
-    - src/ubuntu/19*
+    - src/ubuntu/19.04/*
 pr:
   branches:
     include:
@@ -21,6 +21,6 @@ jobs:
     parameters:
       matrix: {
         "ubuntu19": {
-          "imageBuilderPath": "src/ubuntu/19*"
+          "imageBuilderPath": "src/ubuntu/19.04*"
         }
       }


### PR DESCRIPTION
The Ubuntu build legs were specifying the wrong image builder path args and as a result were not building all images.  This is because of https://github.com/dotnet/docker-tools/issues/170