### PR TITLE
Update Ubuntu 14.04 crossfs build to install lldb3.9 instead of 3.6

### DIFF
--- a/src/ubuntu/14.04/cross/hooks/pre-build
+++ b/src/ubuntu/14.04/cross/hooks/pre-build
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-$(dirname ${BASH_SOURCE[0]})/../../../build-scripts/build-rootfs.sh ubuntu-14.04 trusty
+$(dirname ${BASH_SOURCE[0]})/../../../build-scripts/build-rootfs.sh ubuntu-14.04 trusty "" lldb3.9


### PR DESCRIPTION
This ensures that we build a lldb plugin that works on LLDB 3.9 and newer
instead of just LLDB 3.6 that is unusable on arm anyways.