### PR TITLE
Remove llvm5 and lldb-dev packages from Alpine 3.9

### DIFF
--- a/src/alpine/3.9/amd64/Dockerfile
+++ b/src/alpine/3.9/amd64/Dockerfile
@@ -21,7 +21,6 @@ RUN apk add --no-cache \
         libunwind-dev \
         linux-headers \
         llvm \
-        llvm5 \
         make \
         openssl \
         openssl-dev \
@@ -37,6 +36,3 @@ RUN apk -X http://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache \
         userspace-rcu-dev \
         lttng-ust-dev \
         numactl-dev
-
-RUN apk -X http://dl-cdn.alpinelinux.org/alpine/edge/testing add --no-cache \
-        lldb-dev

--- a/src/alpine/3.9/arm32v7/Dockerfile
+++ b/src/alpine/3.9/arm32v7/Dockerfile
@@ -21,7 +21,6 @@ RUN apk add --no-cache \
         libunwind-dev \
         linux-headers \
         llvm \
-        llvm5 \
         make \
         openssl \
         openssl-dev \
@@ -36,6 +35,3 @@ RUN apk add --no-cache \
 RUN apk -X http://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache \
         userspace-rcu-dev \
         lttng-ust-dev
-
-RUN apk -X http://dl-cdn.alpinelinux.org/alpine/edge/testing add --no-cache \
-        lldb-dev

--- a/src/alpine/3.9/arm64v8/Dockerfile
+++ b/src/alpine/3.9/arm64v8/Dockerfile
@@ -21,7 +21,6 @@ RUN apk add --no-cache \
         libunwind-dev \
         linux-headers \
         llvm \
-        llvm5 \
         make \
         openssl \
         openssl-dev \
@@ -37,6 +36,3 @@ RUN apk -X http://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache \
         userspace-rcu-dev \
         lttng-ust-dev \
         numactl-dev
-
-RUN apk -X http://dl-cdn.alpinelinux.org/alpine/edge/testing add --no-cache \
-        lldb-dev


### PR DESCRIPTION
Fixes #154 