### PR TITLE
Add Helix NanoServer 1809 image

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -763,6 +763,18 @@
               }
             }
           ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/nanoserver/1809/helix/amd64",
+              "os": "windows",
+              "osVersion": "nanoserver-1809",
+              "tags": {
+                "nanoserver-1809-helix-amd64-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
+              }
+            }
+          ]
         }
       ]
     }

--- a/src/nanoserver/1809/helix/amd64/Dockerfile
+++ b/src/nanoserver/1809/helix/amd64/Dockerfile
@@ -1,32 +1,32 @@
+# escape=`
 FROM mcr.microsoft.com/powershell:6.2.0-nanoserver-1809
-# escape=` (backtick)
 
 SHELL ["cmd", "/S", "/C"]
 USER ContainerAdministrator
 ENTRYPOINT C:\Windows\System32\cmd.exe
 
-RUN curl -SL --output %TEMP%\python.zip https://www.nuget.org/api/v2/package/python/3.7.3 \
-    && md C:\Python C:\PythonTemp \
-    && tar -zxf %TEMP%\python.zip -C C:\PythonTemp \
-    && xcopy /s c:\PythonTemp\tools C:\Python \
-    && rd /s /q c:\PythonTemp \
-    && del /q %TEMP%\python.zip \
+RUN curl -SL --output %TEMP%\python.zip https://www.nuget.org/api/v2/package/python/3.7.3 `
+    && md C:\Python C:\PythonTemp `
+    && tar -zxf %TEMP%\python.zip -C C:\PythonTemp `
+    && xcopy /s c:\PythonTemp\tools C:\Python `
+    && rd /s /q c:\PythonTemp `
+    && del /q %TEMP%\python.zip `
     && setx /M PYTHONPATH "C:\Python\Lib;C:\Python\DLLs;"
 
 ENV PATH="$PATH;C:\Program Files\PowerShell\;C:\Python;C:\python\scripts"
 
-RUN python -m pip install --upgrade pip \
-    && python -m pip install applicationinsights==0.11.8 \
-                             certifi==2019.3.9 \
-                             docker==3.7.2 \
-                             ndg-httpsclient==0.5.1 \
-                             psutil==5.6.1 \
-                             pyasn1==0.4.5 \
-                             pyopenssl==19.0.0 \
-                             requests==2.21.0 \
-                             six==1.12.0 \
-                             virtualenv==16.5.0\
-                             vsts==0.1.20\
+RUN python -m pip install --upgrade pip `
+    && python -m pip install applicationinsights==0.11.8 `
+                             certifi==2019.3.9 `
+                             docker==3.7.2 `
+                             ndg-httpsclient==0.5.1 `
+                             psutil==5.6.1 `
+                             pyasn1==0.4.5 `
+                             pyopenssl==19.0.0 `
+                             requests==2.21.0 `
+                             six==1.12.0 `
+                             virtualenv==16.5.0 `
+                             vsts==0.1.20 `
                              future==0.17.1
 
 WORKDIR C:\\Work

--- a/src/nanoserver/1809/helix/amd64/Dockerfile
+++ b/src/nanoserver/1809/helix/amd64/Dockerfile
@@ -1,4 +1,5 @@
 FROM mcr.microsoft.com/powershell:6.2.0-nanoserver-1809
+# escape=` (backtick)
 
 SHELL ["cmd", "/S", "/C"]
 USER ContainerAdministrator
@@ -12,7 +13,7 @@ RUN curl -SL --output %TEMP%\python.zip https://www.nuget.org/api/v2/package/pyt
     && del /q %TEMP%\python.zip \
     && setx /M PYTHONPATH "C:\Python\Lib;C:\Python\DLLs;"
 
-ENV PATH="$WindowsPATH;C:\Program Files\PowerShell\;C:\Python;C:\python\scripts"
+ENV PATH="$PATH;C:\Program Files\PowerShell\;C:\Python;C:\python\scripts"
 
 RUN python -m pip install --upgrade pip \
     && python -m pip install applicationinsights==0.11.8 \

--- a/src/nanoserver/1809/helix/amd64/Dockerfile
+++ b/src/nanoserver/1809/helix/amd64/Dockerfile
@@ -1,0 +1,32 @@
+FROM mcr.microsoft.com/powershell:6.2.0-nanoserver-1809
+
+SHELL ["cmd", "/S", "/C"]
+USER ContainerAdministrator
+ENTRYPOINT C:\Windows\System32\cmd.exe
+
+RUN curl -SL --output %TEMP%\python.zip https://www.nuget.org/api/v2/package/python/3.7.3 \
+    && md C:\Python C:\PythonTemp \
+    && tar -zxf %TEMP%\python.zip -C C:\PythonTemp \
+    && xcopy /s c:\PythonTemp\tools C:\Python \
+    && rd /s /q c:\PythonTemp \
+    && del /q %TEMP%\python.zip \
+    && setx /M PYTHONPATH "C:\Python\Lib;C:\Python\DLLs;"
+
+ENV PATH="$WindowsPATH;C:\Program Files\PowerShell\;C:\Python;C:\python\scripts"
+
+RUN python -m pip install --upgrade pip \
+    && python -m pip install applicationinsights==0.11.8 \
+                             certifi==2019.3.9 \
+                             docker==3.7.2 \
+                             ndg-httpsclient==0.5.1 \
+                             psutil==5.6.1 \
+                             pyasn1==0.4.5 \
+                             pyopenssl==19.0.0 \
+                             requests==2.21.0 \
+                             six==1.12.0 \
+                             virtualenv==16.5.0\
+                             vsts==0.1.20\
+                             future==0.17.1
+
+WORKDIR C:\\Work
+


### PR DESCRIPTION
I finally read up on the changes from 1803->1809 and this should make a viable image for running .NET Core tests on for .NET Helix. 