### PR TITLE
Fix PR build by adding a stub test script

### DIFF
--- a/eng/common/templates/steps/test-images-linux-client.yml
+++ b/eng/common/templates/steps/test-images-linux-client.yml
@@ -39,9 +39,9 @@ steps:
 - script: >
     docker exec $(testRunner.container) pwsh
     -File ./tests/run-tests.ps1
-    -VersionFilter $(dotnetVersion)
-    -OSFilter $(osVariant)*
-    -ArchitectureFilter $(architecture)
+    -VersionFilter '$(dotnetVersion)'
+    -OSFilter '$(osVariant)*'
+    -ArchitectureFilter '$(architecture)'
     $(optionalTestArgs)
   displayName: Test Images
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:

--- a/eng/common/templates/steps/test-images-windows-client.yml
+++ b/eng/common/templates/steps/test-images-windows-client.yml
@@ -17,8 +17,8 @@ steps:
   displayName: Cleanup Old Test Results
 - powershell: >
     ./tests/run-tests.ps1
-    -VersionFilter $(dotnetVersion)
-    -OSFilter $(osVariant)
+    -VersionFilter '$(dotnetVersion)'
+    -OSFilter '$(osVariant)'
     $(optionalTestArgs)
   displayName: Test Images
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:

--- a/eng/pipelines/variables/common.yml
+++ b/eng/pipelines/variables/common.yml
@@ -6,3 +6,7 @@ variables:
   value: build
 - name: stagingRepoPrefix
   value: $(publishRepoPrefix)
+- name: dotnetVersion
+  value: '*'
+- name: osVariant
+  value: ''

--- a/tests/run-tests.ps1
+++ b/tests/run-tests.ps1
@@ -1,0 +1,21 @@
+#!/usr/bin/env pwsh
+#
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+[cmdletbinding()]
+param(
+    [string]$VersionFilter,
+    [string]$ArchitectureFilter,
+    [string]$OSFilter,
+    [string]$Registry,
+    [string]$RepoPrefix,
+    [switch]$DisableHttpVerification,
+    [switch]$IsLocalRun
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# No-op -- No tests to run


### PR DESCRIPTION
The PR build was broken because it was attempting to execute tests during the build stage.  This was a regression due to #156 which integrated common pipeline logic including running tests in the build stage.  This repo has no tests, plus the common logic was attempting to reference variables from the build matrix that had never been set.

To fix this, the missing variables have been defined default values in the common.yml file for the repo and a stub run-tests.ps1 file has been added which doesn't run any tests.