### PR TITLE
Set timeout for PR build

### DIFF
--- a/eng/pipelines/dotnet-buildtools-prereqs-pr.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-pr.yml
@@ -11,3 +11,5 @@ variables:
 
 stages:
   - template: ../common/templates/stages/build-test-publish-repo.yml
+    parameters:
+      linuxAmdBuildJobTimeout: 120


### PR DESCRIPTION
The CentOS and openSUSE build jobs have been failing for the PR build due to timeouts.  Increasing the timeout.