### PR TITLE
Update pipeline to make use of all stages

### DIFF
--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -15,6 +15,10 @@ jobs:
       publicSourceBranch: master
   steps:
   - template: ../steps/init-docker-linux.yml
+  - template: ../steps/download-build-artifact.yml
+    parameters:
+      targetPath: $(Build.ArtifactStagingDirectory)
+      artifactName: image-info
   - script: >
       $(runImageBuilderCmd) copyAcrImages
       $(stagingRepoPrefix)
@@ -26,6 +30,7 @@ jobs:
       --os-type '*'
       --architecture '*'
       --repo-prefix $(publishRepoPrefix)
+      --image-info $(artifactsPath)/image-info.json
       $(imageBuilder.pathArgs)
       $(imageBuilder.commonCmdArgs)
     displayName: Copy Images
@@ -47,11 +52,7 @@ jobs:
       $(publicGitRepoUri)/blob/$(publicSourceBranch)
       $(imageBuilder.commonCmdArgs)
     displayName: Publish Readme
-  - template: ../steps/download-build-artifact.yml
-    parameters:
-      targetPath: $(Build.ArtifactStagingDirectory)
-      artifactName: image-info
-      requiresPublicRepoPrefix: true
+    condition: and(succeeded(), eq(variables['publishReadme'], 'true'))
   - script: >
       $(runImageBuilderCmd) publishImageInfo
       $(dotnetBot-userName)

--- a/eng/common/templates/variables/common.yml
+++ b/eng/common/templates/variables/common.yml
@@ -3,6 +3,8 @@ variables:
 - template: common-paths.yml
 - name: stagingRepoPrefix
   value: build-staging/$(sourceBuildId)/
+- name: publishReadme
+  value: true
 - name: skipComponentGovernanceDetection
   value: true
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,6 +1,6 @@
 variables:
-  imageNames.imageBuilder.linux: mcr.microsoft.com/dotnet-buildtools/image-builder:debian-20190709191713
-  imageNames.imageBuilder.windows: mcr.microsoft.com/dotnet-buildtools/image-builder:nanoserver-20190709191713
+  imageNames.imageBuilder.linux: mcr.microsoft.com/dotnet-buildtools/image-builder:debian-20190731154912
+  imageNames.imageBuilder.windows: mcr.microsoft.com/dotnet-buildtools/image-builder:nanoserver-20190731154912
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-stretch-docker-testrunner-63f2145-20184325094343
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)

--- a/eng/pipelines/variables/common.yml
+++ b/eng/pipelines/variables/common.yml
@@ -2,11 +2,9 @@ variables:
 - template: ../../common/templates/variables/common.yml
 - name: manifest
   value: manifest.json
-- name: singlePhase
-  value: build
-- name: stagingRepoPrefix
-  value: $(publishRepoPrefix)
 - name: dotnetVersion
   value: '*'
 - name: osVariant
   value: ''
+- name: publishReadme
+  value: false

--- a/tests/run-tests.ps1
+++ b/tests/run-tests.ps1
@@ -12,7 +12,8 @@ param(
     [string]$Registry,
     [string]$RepoPrefix,
     [switch]$DisableHttpVerification,
-    [switch]$IsLocalRun
+    [switch]$IsLocalRun,
+    [string]$ImageInfoPath
 )
 
 Set-StrictMode -Version Latest


### PR DESCRIPTION
The build pipeline for this repo had been configured to only run the build stage.  When it built the images, it would push them directly to the public location rather than staging.  Since there were no tests to execute, the test stage was skipped.  And the publish stage was skipped because it had already pushed the images directly to the public location.

But skipping the publish stage meant that we weren't publishing the image info data for these images.  And we need that data as part of the work for #69.  These changes update the pipeline so that all 3 stages get executed.  Tests are just a no-op since there are no tests for these images.

One key part of these changes is that it makes use of the `image-info` parameter of the copyAcrImages command.  This parameter was added in https://github.com/dotnet/docker-tools/pull/239 and is necessary because the image tags contain dynamic values.