### PR TITLE
User fixups for helixbot's folders

### DIFF
--- a/src/alpine/3.8/helix/amd64/Dockerfile
+++ b/src/alpine/3.8/helix/amd64/Dockerfile
@@ -45,7 +45,7 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     python -m pip install \ 
                   applicationinsights==0.11.7 \
                   certifi==2018.11.29 \
-                  cryptography==2.5 \                  
+                  cryptography==2.5 \
                   docker==3.6.0 \
                   ndg-httpsclient==0.5.1  \
                   psutil==5.4.8 \
@@ -53,7 +53,9 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
                   pyopenssl==18.0.0 \
                   requests==2.21.0 \
                   six==1.12.0 \
-                  virtualenv==16.2.0
+                  virtualenv==16.2.0 \
+                  azure-devops==5.0.0b9 \
+                  future==0.17.1
 
 # Needed for corefx tests to pass
 ENV LANG=en-US.UTF-8
@@ -65,3 +67,5 @@ RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
     echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot
 
 USER helixbot
+
+RUN python -m virtualenv --no-site-packages /home/helixbot/.vsts-env

--- a/src/alpine/3.8/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.8/helix/arm64v8/Dockerfile
@@ -21,22 +21,22 @@ RUN apk update && \
         libffi \
         libffi-dev \
         libtool \
-        libunwind-dev \        
+        libunwind-dev \
         linux-headers \
         llvm \
         make \
         openssl \
         openssl-dev \
-        paxctl \        
+        paxctl \
         python3 \
         python3-dev \
         py-cffi \
-        py-pip \        
+        py-pip \
         sudo \
         tzdata \
         util-linux-dev \
         wget \
-        which \        
+        which \
         zlib-dev && \
     apk -X http://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache \
         lttng-ust-dev \
@@ -47,10 +47,10 @@ RUN apk update && \
 
 RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     python -m pip install --upgrade pip==19.0.2 && \
-    python -m pip install \ 
+    python -m pip install \
         applicationinsights==0.11.7 \
         certifi==2018.11.29 \
-        cryptography==2.5 \                  
+        cryptography==2.5 \
         docker==3.6.0 \
         ndg-httpsclient==0.5.1  \
         psutil==5.4.8 \
@@ -58,14 +58,18 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
         pyopenssl==18.0.0 \
         requests==2.21.0 \
         six==1.12.0 \
-        virtualenv==16.2.0
+        virtualenv==16.2.0 \
+        azure-devops==5.0.0b9 \
+        future==0.17.1
 
 # create helixbot user and give rights to sudo without password
 # Alpine does not support long options
 RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1001 helixbot && \
     chmod 755 /root && \
-    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot && \
-    python -m virtualenv --no-site-packages /home/helixbot/.vsts-env        && \
-    /home/helixbot/.vsts-env/bin/python -m pip install vsts==0.1.20 future==0.17.1
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot
 
 USER helixbot
+
+RUN python -m virtualenv --no-site-packages /home/helixbot/.vsts-env
+
+

--- a/src/alpine/3.9/helix/amd64/Dockerfile
+++ b/src/alpine/3.9/helix/amd64/Dockerfile
@@ -45,7 +45,7 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     python -m pip install \ 
                   applicationinsights==0.11.7 \
                   certifi==2018.11.29 \
-                  cryptography==2.5 \                  
+                  cryptography==2.5 \
                   docker==3.6.0 \
                   ndg-httpsclient==0.5.1  \
                   psutil==5.4.8 \
@@ -53,7 +53,9 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
                   pyopenssl==18.0.0 \
                   requests==2.21.0 \
                   six==1.12.0 \
-                  virtualenv==16.2.0
+                  virtualenv==16.2.0 \
+                  azure-devops==5.0.0b9 \
+                  future==0.17.1
 
 # Needed for corefx tests to pass
 ENV LANG=en-US.UTF-8
@@ -65,3 +67,5 @@ RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
     echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot
 
 USER helixbot
+
+RUN python -m virtualenv --no-site-packages /home/helixbot/.vsts-env

--- a/src/debian/10/helix/amd64/Dockerfile
+++ b/src/debian/10/helix/amd64/Dockerfile
@@ -24,7 +24,6 @@ RUN apt-get update && \
         tzdata \
         unzip \
     && rm -rf /var/lib/apt/lists/* \
-    \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
 ENV LANG en_US.utf8
@@ -50,9 +49,7 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
 # additionally, preinstall the virtualenv packages used for VSTS reporting to save time
 RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm helixbot && \
     chmod 755 /root && \
-    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers && \
-    python -m virtualenv --no-site-packages /home/helixbot/.vsts-env && \
-    /home/helixbot/.vsts-env/bin/python -m pip install vsts==0.1.20 future==0.17.1
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
 
 USER helixbot
 

--- a/src/debian/10/helix/amd64/Dockerfile
+++ b/src/debian/10/helix/amd64/Dockerfile
@@ -19,9 +19,9 @@ RUN apt-get update && \
         locales \
         locales-all \
         python3-dev \
-        python3-pip \ 
-        sudo \   
-        tzdata \        
+        python3-pip \
+        sudo \
+        tzdata \
         unzip \
     && rm -rf /var/lib/apt/lists/* \
     \
@@ -42,7 +42,9 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
                   pyopenssl==18.0.0 \
                   requests==2.21.0 \
                   six==1.12.0 \
-                  virtualenv==16.2.0
+                  virtualenv==16.2.0 \
+                  azure-devops==5.0.0b9 \
+                  future==0.17.1
 
 # Create helixbot user and give rights to sudo without password
 # additionally, preinstall the virtualenv packages used for VSTS reporting to save time
@@ -53,3 +55,5 @@ RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bas
     /home/helixbot/.vsts-env/bin/python -m pip install vsts==0.1.20 future==0.17.1
 
 USER helixbot
+
+RUN python -m virtualenv --no-site-packages /home/helixbot/.vsts-env

--- a/src/debian/10/helix/arm32v7/Dockerfile
+++ b/src/debian/10/helix/arm32v7/Dockerfile
@@ -19,9 +19,9 @@ RUN apt-get update && \
         locales \
         locales-all \
         python3-dev \
-        python3-pip \ 
-        sudo \   
-        tzdata \        
+        python3-pip \
+        sudo \
+        tzdata \
         unzip \
     && rm -rf /var/lib/apt/lists/* \
     \
@@ -42,7 +42,9 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
                   pyopenssl==18.0.0 \
                   requests==2.21.0 \
                   six==1.12.0 \
-                  virtualenv==16.2.0
+                  virtualenv==16.2.0 \
+                  azure-devops==5.0.0b9 \
+                  future==0.17.1
 
 # Create helixbot user and give rights to sudo without password
 # additionally, preinstall the virtualenv packages used for VSTS reporting to save time
@@ -53,3 +55,5 @@ RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1001 --shell /bin/bas
     /home/helixbot/.vsts-env/bin/python -m pip install vsts==0.1.20 future==0.17.1
 
 USER helixbot
+
+RUN python -m virtualenv --no-site-packages /home/helixbot/.vsts-env

--- a/src/debian/10/helix/arm32v7/Dockerfile
+++ b/src/debian/10/helix/arm32v7/Dockerfile
@@ -50,9 +50,7 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
 # additionally, preinstall the virtualenv packages used for VSTS reporting to save time
 RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1001 --shell /bin/bash --ingroup adm helixbot && \
     chmod 755 /root && \
-    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers && \
-    python -m virtualenv --no-site-packages /home/helixbot/.vsts-env && \
-    /home/helixbot/.vsts-env/bin/python -m pip install vsts==0.1.20 future==0.17.1
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
 
 USER helixbot
 

--- a/src/debian/10/helix/arm64v8/Dockerfile
+++ b/src/debian/10/helix/arm64v8/Dockerfile
@@ -19,9 +19,9 @@ RUN apt-get update && \
         locales \
         locales-all \
         python3-dev \
-        python3-pip \ 
-        sudo \   
-        tzdata \        
+        python3-pip \
+        sudo \
+        tzdata \
         unzip \
     && rm -rf /var/lib/apt/lists/* \
     \
@@ -42,7 +42,9 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
                   pyopenssl==18.0.0 \
                   requests==2.21.0 \
                   six==1.12.0 \
-                  virtualenv==16.2.0
+                  virtualenv==16.2.0 \
+                  azure-devops==5.0.0b9 \
+                  future==0.17.1
 
 # Create helixbot user and give rights to sudo without password
 # additionally, preinstall the virtualenv packages used for VSTS reporting to save time
@@ -53,3 +55,5 @@ RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1001 --shell /bin/bas
     /home/helixbot/.vsts-env/bin/python -m pip install vsts==0.1.20 future==0.17.1
 
 USER helixbot
+
+RUN python -m virtualenv --no-site-packages /home/helixbot/.vsts-env

--- a/src/debian/10/helix/arm64v8/Dockerfile
+++ b/src/debian/10/helix/arm64v8/Dockerfile
@@ -50,9 +50,7 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
 # additionally, preinstall the virtualenv packages used for VSTS reporting to save time
 RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1001 --shell /bin/bash --ingroup adm helixbot && \
     chmod 755 /root && \
-    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers && \
-    python -m virtualenv --no-site-packages /home/helixbot/.vsts-env && \
-    /home/helixbot/.vsts-env/bin/python -m pip install vsts==0.1.20 future==0.17.1
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers 
 
 USER helixbot
 

--- a/src/debian/9/helix/arm32v7/Dockerfile
+++ b/src/debian/9/helix/arm32v7/Dockerfile
@@ -47,9 +47,7 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
 
 RUN adduser --disabled-password --gecos '' --uid 1001 --shell /bin/bash --ingroup adm helixbot && \
     chmod -R +x /root && \
-    echo 'helixbot ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
-    python -m virtualenv --no-site-packages /home/helixbot/.vsts-env && \
-    /home/helixbot/.vsts-env/bin/python -m pip install vsts==0.1.20 future==0.17.1
+    echo 'helixbot ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 USER helixbot
 

--- a/src/debian/9/helix/arm32v7/Dockerfile
+++ b/src/debian/9/helix/arm32v7/Dockerfile
@@ -20,18 +20,17 @@ RUN apt-get update && \
         locales-all \
         python3-dev \
         python3-pip \
-        sudo \    
-        tzdata \        
+        sudo \
+        tzdata \
         unzip \
     && rm -rf /var/lib/apt/lists/* \
-    \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
 ENV LANG en_US.utf8
 
 RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     python -m pip install --upgrade pip==19.1.1 && \
-    python -m pip install \ 
+    python -m pip install \
                   applicationinsights==0.11.7 \
                   certifi==2018.11.29 \
                   cryptography==2.5 \
@@ -42,7 +41,9 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
                   pyopenssl==18.0.0 \
                   requests==2.21.0 \
                   six==1.12.0 \
-                  virtualenv==16.2.0
+                  virtualenv==16.2.0 \
+                  azure-devops==5.0.0b9 \
+                  future==0.17.1
 
 RUN adduser --disabled-password --gecos '' --uid 1001 --shell /bin/bash --ingroup adm helixbot && \
     chmod -R +x /root && \
@@ -51,3 +52,5 @@ RUN adduser --disabled-password --gecos '' --uid 1001 --shell /bin/bash --ingrou
     /home/helixbot/.vsts-env/bin/python -m pip install vsts==0.1.20 future==0.17.1
 
 USER helixbot
+
+RUN python -m virtualenv --no-site-packages /home/helixbot/.vsts-env

--- a/src/debian/9/helix/arm64v8/Dockerfile
+++ b/src/debian/9/helix/arm64v8/Dockerfile
@@ -20,9 +20,9 @@ RUN apt-get update && \
         locales \
         locales-all \
         python3-dev \
-        python3-pip \ 
-        sudo \   
-        tzdata \        
+        python3-pip \
+        sudo \
+        tzdata \
         unzip \
     && rm -rf /var/lib/apt/lists/* \
     \
@@ -32,7 +32,7 @@ ENV LANG en_US.utf8
 
 RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     python -m pip install --upgrade pip==19.1.1 && \
-    python -m pip install \ 
+    python -m pip install \
                   applicationinsights==0.11.7 \
                   certifi==2018.11.29 \
                   cryptography==2.5 \
@@ -43,12 +43,16 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
                   pyopenssl==18.0.0 \
                   requests==2.21.0 \
                   six==1.12.0 \
-                  virtualenv==16.2.0
+                  virtualenv==16.2.0 \
+                  azure-devops==5.0.0b9 \
+                  future==0.17.1
 
 RUN adduser --disabled-password --gecos '' --uid 1001 --shell /bin/bash --ingroup adm helixbot && \
     chmod -R +x /root && \
-    echo 'helixbot ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
-    python -m virtualenv --no-site-packages /home/helixbot/.vsts-env && \
-    /home/helixbot/.vsts-env/bin/python -m pip install vsts==0.1.20 future==0.17.1
+    echo 'helixbot ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 USER helixbot
+
+RUN python -m virtualenv --no-site-packages /home/helixbot/.vsts-env
+
+

--- a/src/debian/9/helix/arm64v8/Dockerfile
+++ b/src/debian/9/helix/arm64v8/Dockerfile
@@ -54,5 +54,3 @@ RUN adduser --disabled-password --gecos '' --uid 1001 --shell /bin/bash --ingrou
 USER helixbot
 
 RUN python -m virtualenv --no-site-packages /home/helixbot/.vsts-env
-
-

--- a/src/fedora/29/helix/amd64/Dockerfile
+++ b/src/fedora/29/helix/amd64/Dockerfile
@@ -24,7 +24,7 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
                   six==1.12.0 \
                   virtualenv==16.2.0 \
                   azure-devops==5.0.0b9 \
-                  future==0.17.1 \
+                  future==0.17.1
 
 # Needed for .NET corefx tests to pass
 ENV LANG=en-US.UTF-8

--- a/src/fedora/29/helix/amd64/Dockerfile
+++ b/src/fedora/29/helix/amd64/Dockerfile
@@ -5,7 +5,7 @@ FROM mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-29
 RUN dnf install -y \
         python3 \
         python3-devel \
-        redhat-rpm-config \        
+        redhat-rpm-config \
         sudo \
     && dnf clean all
 
@@ -14,7 +14,7 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     python -m pip install \ 
                   applicationinsights==0.11.7 \
                   certifi==2018.11.29 \
-                  cryptography==2.5 \                  
+                  cryptography==2.5 \
                   docker==3.6.0 \
                   ndg-httpsclient==0.5.1  \
                   psutil==5.4.8 \
@@ -22,7 +22,9 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
                   pyopenssl==18.0.0 \
                   requests==2.21.0 \
                   six==1.12.0 \
-                  virtualenv==16.2.0
+                  virtualenv==16.2.0 \
+                  azure-devops==5.0.0b9 \
+                  future==0.17.1 \
 
 # Needed for .NET corefx tests to pass
 ENV LANG=en-US.UTF-8
@@ -34,3 +36,5 @@ RUN /usr/sbin/adduser --uid 1000 --shell /bin/bash --group adm helixbot && \
     echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
 
 USER helixbot
+
+RUN python -m virtualenv --no-site-packages /home/helixbot/.vsts-env

--- a/src/fedora/30/helix/amd64/Dockerfile
+++ b/src/fedora/30/helix/amd64/Dockerfile
@@ -5,7 +5,7 @@ FROM mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-30
 RUN dnf install -y \
         python3 \
         python3-devel \
-        redhat-rpm-config \        
+        redhat-rpm-config \
         sudo \
     && dnf clean all
 
@@ -14,15 +14,17 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     python -m pip install \ 
                   applicationinsights==0.11.7 \
                   certifi==2018.11.29 \
-                  cryptography==2.5 \                  
+                  cryptography==2.5 \
                   docker==3.6.0 \
-                  ndg-httpsclient==0.5.1  \
+                  ndg-httpsclient==0.5.1 \
                   psutil==5.4.8 \
                   pyasn1==0.4.5 \
                   pyopenssl==18.0.0 \
                   requests==2.21.0 \
                   six==1.12.0 \
-                  virtualenv==16.2.0
+                  virtualenv==16.2.0 \
+                  azure-devops==5.0.0b9 \
+                  future==0.17.1
 
 # Needed for .NET corefx tests to pass
 ENV LANG=en-US.UTF-8
@@ -34,3 +36,5 @@ RUN /usr/sbin/adduser --uid 1000 --shell /bin/bash --group adm helixbot && \
     echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
 
 USER helixbot
+
+RUN python -m virtualenv --no-site-packages /home/helixbot/.vsts-env

--- a/src/ubuntu/16.04/helix/arm32v7/Dockerfile
+++ b/src/ubuntu/16.04/helix/arm32v7/Dockerfile
@@ -3,36 +3,35 @@ FROM arm32v7/ubuntu:16.04
 # Install Helix Dependencies 
 
 RUN apt-get update && \
-    apt-get install -y \        
+    apt-get install -y \
         gss-ntlmssp \
         iputils-ping \
         libcurl3 \
         libffi-dev \
-        libgdiplus \        
+        libgdiplus \
         libicu-dev \
         libssl-dev \
-        libunwind8 \        
+        libunwind8 \
         libunwind-dev \
-        lldb-3.9 \        
+        lldb-3.9 \
         locales \
         locales-all \
         python3-dev \ 
         python3-pip \
         sudo \
         tzdata \
-        unzip \              
+        unzip \
     && rm -rf /var/lib/apt/lists/* \
-    \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
 ENV LANG en_US.utf8
 
 RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     python -m pip install --upgrade pip==19.0.2 && \
-    python -m pip install \ 
+    python -m pip install \
                   applicationinsights==0.11.7 \
                   certifi==2018.11.29 \
-                  cryptography==2.5 \                  
+                  cryptography==2.5 \
                   docker==3.6.0 \
                   ndg-httpsclient==0.5.1  \
                   psutil==5.4.8 \
@@ -40,12 +39,16 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
                   pyopenssl==18.0.0 \
                   requests==2.21.0 \
                   six==1.12.0 \
-                  virtualenv==16.2.0
+                  virtualenv==16.2.0 \
+                  azure-devops==5.0.0b9 \
+                  future==0.17.1
 
 RUN adduser --disabled-password --gecos '' --uid 1001 --shell /bin/bash --ingroup adm helixbot && \
     chmod -R +x /root && \
-    echo 'helixbot ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
-    python -m virtualenv --no-site-packages /home/helixbot/.vsts-env && \
-    /home/helixbot/.vsts-env/bin/python -m pip install vsts==0.1.20 future==0.17.1
+    echo 'helixbot ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 USER helixbot
+
+RUN python -m virtualenv --no-site-packages /home/helixbot/.vsts-env
+
+

--- a/src/ubuntu/16.04/helix/arm64v8/Dockerfile
+++ b/src/ubuntu/16.04/helix/arm64v8/Dockerfile
@@ -3,27 +3,26 @@ FROM arm64v8/ubuntu:16.04
 # Install Helix Dependencies
 
 RUN apt-get update && \
-    apt-get install -y \        
+    apt-get install -y \
         gss-ntlmssp \
         iputils-ping \
         libcurl3 \
         libffi-dev \
-        libgdiplus \        
+        libgdiplus \
         libicu-dev \
         libnuma-dev \
         libssl-dev \
-        libunwind8 \        
+        libunwind8 \
         libunwind-dev \
-        lldb-3.9 \        
+        lldb-3.9 \
         locales \
         locales-all \
-        python3-dev \ 
+        python3-dev \
         python3-pip \
         sudo \
         tzdata \
-        unzip \              
+        unzip \
     && rm -rf /var/lib/apt/lists/* \
-    \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
 ENV LANG en_US.utf8
@@ -33,20 +32,24 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     python -m pip install \ 
                   applicationinsights==0.11.7 \
                   certifi==2018.11.29 \
-                  cryptography==2.5 \                  
+                  cryptography==2.5 \
                   docker==3.6.0 \
-                  ndg-httpsclient==0.5.1  \
+                  ndg-httpsclient==0.5.1 \
                   psutil==5.4.8 \
                   pyasn1==0.4.5 \
                   pyopenssl==18.0.0 \
                   requests==2.21.0 \
                   six==1.12.0 \
-                  virtualenv==16.2.0
+                  virtualenv==16.2.0 \
+                  azure-devops==5.0.0b9 \
+                  future==0.17.1
 
 RUN adduser --disabled-password --gecos '' --uid 1001 --shell /bin/bash --ingroup adm helixbot && \
     chmod -R +x /root && \
-    echo 'helixbot ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
-    python -m virtualenv --no-site-packages /home/helixbot/.vsts-env && \
-    /home/helixbot/.vsts-env/bin/python -m pip install vsts==0.1.20 future==0.17.1
+    echo 'helixbot ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers 
 
 USER helixbot
+
+RUN python -m virtualenv --no-site-packages /home/helixbot/.vsts-env
+
+

--- a/src/ubuntu/18.04/helix/arm32v7/Dockerfile
+++ b/src/ubuntu/18.04/helix/arm32v7/Dockerfile
@@ -5,13 +5,13 @@ FROM arm32v7/ubuntu:18.04
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && \
-    apt-get install -qq -y \                        
+    apt-get install -qq -y \
         build-essential \
         clang \
-        cmake \        
+        cmake \
         gcc \
         gdb \
-        git \        
+        git \
         gss-ntlmssp \
         iputils-ping \
         libcurl4 \
@@ -20,14 +20,14 @@ RUN apt-get update && \
         libicu-dev \
         libnuma-dev \
         libssl-dev \
-        libunwind8 \        
-        libunwind-dev \        
+        libunwind8 \
+        libunwind-dev \
         lldb-3.9 \
         locales \
         locales-all \
         python3-dev \
         python3-pip \
-        sudo \        
+        sudo \
         tzdata \
         unzip \
     && rm -rf /var/lib/apt/lists/* \
@@ -41,7 +41,7 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     python -m pip install \ 
                   applicationinsights==0.11.7 \
                   certifi==2018.11.29 \
-                  cryptography==2.5 \                  
+                  cryptography==2.5 \
                   docker==3.6.0 \
                   ndg-httpsclient==0.5.1  \
                   psutil==5.4.8 \
@@ -49,12 +49,16 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
                   pyopenssl==18.0.0 \
                   requests==2.21.0 \
                   six==1.12.0 \
-                  virtualenv==16.2.0
+                  virtualenv==16.2.0 \
+                  azure-devops==5.0.0b9 \
+                  future==0.17.1
 
 RUN adduser --disabled-password --gecos '' --uid 1001 --shell /bin/bash --ingroup adm helixbot && \
     chmod -R +x /root && \
-    echo 'helixbot ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
-    python -m virtualenv --no-site-packages /home/helixbot/.vsts-env && \
-    /home/helixbot/.vsts-env/bin/python -m pip install vsts==0.1.20 future==0.17.1
+    echo 'helixbot ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 USER helixbot
+
+RUN python -m virtualenv --no-site-packages /home/helixbot/.vsts-env 
+
+

--- a/src/ubuntu/18.04/helix/arm64v8/Dockerfile
+++ b/src/ubuntu/18.04/helix/arm64v8/Dockerfile
@@ -5,13 +5,13 @@ FROM arm64v8/ubuntu:18.04
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && \
-    apt-get install -qq -y \                        
+    apt-get install -qq -y \
         build-essential \
         cmake \
         clang \
         gcc \
         gdb \
-        git \        
+        git \
         gss-ntlmssp \
         iputils-ping \
         libcurl4 \
@@ -20,14 +20,14 @@ RUN apt-get update && \
         libicu-dev \
         libnuma-dev \
         libssl-dev \
-        libunwind8 \        
-        libunwind-dev \        
+        libunwind8 \
+        libunwind-dev \
         lldb-3.9 \
         locales \
         locales-all \
         python3-dev \
         python3-pip \
-        sudo \        
+        sudo \
         tzdata \
         unzip \
         curl \
@@ -42,7 +42,7 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     python -m pip install \ 
                   applicationinsights==0.11.7 \
                   certifi==2018.11.29 \
-                  cryptography==2.5 \                  
+                  cryptography==2.5 \
                   docker==3.6.0 \
                   ndg-httpsclient==0.5.1  \
                   psutil==5.4.8 \
@@ -50,12 +50,16 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
                   pyopenssl==18.0.0 \
                   requests==2.21.0 \
                   six==1.12.0 \
-                  virtualenv==16.2.0
+                  virtualenv==16.2.0 \
+                  azure-devops==5.0.0b9 \
+                  future==0.17.1
 
 RUN adduser --disabled-password --gecos '' --uid 1001 --shell /bin/bash --ingroup adm helixbot && \
     chmod -R +x /root && \
-    echo 'helixbot ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
-    python -m virtualenv --no-site-packages /home/helixbot/.vsts-env && \
-    /home/helixbot/.vsts-env/bin/python -m pip install vsts==0.1.20 future==0.17.1
+    echo 'helixbot ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 USER helixbot
+
+RUN python -m virtualenv --no-site-packages /home/helixbot/.vsts-env
+
+

--- a/src/ubuntu/19.04/helix/amd64/Dockerfile
+++ b/src/ubuntu/19.04/helix/amd64/Dockerfile
@@ -4,28 +4,28 @@ FROM ubuntu:19.04
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && \
-    apt-get install -qq -y \                        
+    apt-get install -qq -y \
         build-essential \
         cmake \
         clang \
         gcc \
         gdb \
-        git \        
+        git \
         gss-ntlmssp \
         iputils-ping \
         libcurl4 \
         libffi-dev \
         libgdiplus \
-        libicu-dev \        
+        libicu-dev \
         libssl-dev \
-        libunwind8 \        
-        libunwind-dev \        
+        libunwind8 \
+        libunwind-dev \
         lldb-3.9 \
         locales \
         locales-all \
         python3-dev \
         python3-pip \
-        sudo \        
+        sudo \
         tzdata \
         unzip \
     && rm -rf /var/lib/apt/lists/* \
@@ -39,7 +39,7 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     python -m pip install \ 
                   applicationinsights==0.11.7 \
                   certifi==2018.11.29 \
-                  cryptography==2.5 \                  
+                  cryptography==2.5 \
                   docker==3.6.0 \
                   ndg-httpsclient==0.5.1  \
                   psutil==5.4.8 \
@@ -47,7 +47,9 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
                   pyopenssl==18.0.0 \
                   requests==2.21.0 \
                   six==1.12.0 \
-                  virtualenv==16.2.0
+                  virtualenv==16.2.0 \
+                  azure-devops==5.0.0b9 \
+                  future==0.17.1
 
 # create helixbot user and give rights to sudo without password
 RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm helixbot && \
@@ -55,3 +57,5 @@ RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bas
     echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
 
 USER helixbot
+
+RUN python -m virtualenv --no-site-packages /home/helixbot/.vsts-env


### PR DESCRIPTION
Some small fixes: 

- Fix up helixbot's .vsts-env folder so that it owns it (change user from root to helixbot before creating it) 
- Preinstalling azure-devops package
- Incidental whitespace cleanup.