### PR TITLE
Set DOCKER_REPO variable

### DIFF
--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -20,7 +20,7 @@ jobs:
       imageBuilderBuildArgs: --registry-override $(acr.server) --repo-prefix $(stagingRepoPrefix) --push --username $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(imageBuilder.queueArgs)
     ${{ if eq(variables['System.TeamProject'], 'public') }}:
       imageBuilderBuildArgs: $(imageBuilder.queueArgs)
-    imageBuilderDockerRunOptions: $(build.imageBuilderDockerRunOptions)
+    imageBuilderDockerRunExtraOptions: $(build.imageBuilderDockerRunExtraOptions)
   steps:
   # This script is necessary to workaround there not being a matching architecture when pulling images
   # on an aarch64 machine. By using the multi-arch tag for the images referenced in the sample

--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -20,6 +20,7 @@ jobs:
       imageBuilderBuildArgs: --registry-override $(acr.server) --repo-prefix $(stagingRepoPrefix) --push --username $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(imageBuilder.queueArgs)
     ${{ if eq(variables['System.TeamProject'], 'public') }}:
       imageBuilderBuildArgs: $(imageBuilder.queueArgs)
+    imageBuilderDockerRunOptions: $(build.imageBuilderDockerRunOptions)
   steps:
   # This script is necessary to workaround there not being a matching architecture when pulling images
   # on an aarch64 machine. By using the multi-arch tag for the images referenced in the sample

--- a/eng/common/templates/steps/cleanup-docker-linux.yml
+++ b/eng/common/templates/steps/cleanup-docker-linux.yml
@@ -11,12 +11,12 @@ steps:
   # owned by this build.
   ################################################################################
 - ${{ if and(eq(parameters.cleanupRemoteDockerServer, 'true'), eq(parameters.initCleanup, 'false')) }}:
-  - script: docker run --rm $(dockerArmRunArgs) --entrypoint docker $(dockerClientImage) system prune -f --volumes
+  - script: docker run --rm $(dockerArmRunOptions) --entrypoint docker $(dockerClientImage) system prune -f --volumes
     displayName: Cleanup Remote Docker Server (basic)
     condition: always()
     continueOnError: true
   - script: >
-      docker run --rm $(dockerArmRunArgs) --entrypoint /bin/bash $(dockerClientImage) -c
+      docker run --rm $(dockerArmRunOptions) --entrypoint /bin/bash $(dockerClientImage) -c
       'docker rmi -f $(docker images --format "{{.Repository}}:{{.Tag}}" | grep -v -e ^arm32v7/ -e ^arm64v8/ -e ^mcr\\.microsoft\\.com/windows)'
     displayName: Cleanup Remote Docker Server (images)
     condition: always()

--- a/eng/common/templates/steps/init-docker-linux.yml
+++ b/eng/common/templates/steps/init-docker-linux.yml
@@ -55,6 +55,7 @@ steps:
       -v $(Build.ArtifactStagingDirectory):$(artifactsPath)
       -w /repo
       $(dockerArmRunArgs)
+      $(imageBuilderDockerRunOptions)
       $(imageNames.imageBuilder.withrepo)"
     displayName: Define runImageBuilderCmd Variable
   - ${{ if eq(parameters.setupRemoteDockerServer, 'true') }}:

--- a/eng/common/templates/steps/init-docker-linux.yml
+++ b/eng/common/templates/steps/init-docker-linux.yml
@@ -29,12 +29,12 @@ steps:
   ################################################################################
 - ${{ if eq(parameters.setupRemoteDockerServer, 'true') }}:
   - script: >
-      echo "##vso[task.setvariable variable=dockerArmRunArgs]
+      echo "##vso[task.setvariable variable=dockerArmRunOptions]
       -v $(DOCKER_CERT_PATH):/docker-certs
       -e DOCKER_CERT_PATH=/docker-certs
       -e DOCKER_TLS_VERIFY=1
       -e DOCKER_HOST=tcp://$(DOCKER_HOST_IP):2376"
-    displayName: Define dockerArmRunArgs Variable
+    displayName: Define dockerArmRunOptions Variable
 
   ################################################################################
   # Setup Image Builder (Optional)
@@ -54,8 +54,8 @@ steps:
       -v /var/run/docker.sock:/var/run/docker.sock
       -v $(Build.ArtifactStagingDirectory):$(artifactsPath)
       -w /repo
-      $(dockerArmRunArgs)
-      $(imageBuilderDockerRunOptions)
+      $(dockerArmRunOptions)
+      $(imageBuilderDockerRunExtraOptions)
       $(imageNames.imageBuilder.withrepo)"
     displayName: Define runImageBuilderCmd Variable
   - ${{ if eq(parameters.setupRemoteDockerServer, 'true') }}:

--- a/eng/common/templates/steps/test-images-linux-client.yml
+++ b/eng/common/templates/steps/test-images-linux-client.yml
@@ -26,7 +26,7 @@ steps:
     docker run -t -d
     -v /var/run/docker.sock:/var/run/docker.sock
     -v $(Build.ArtifactStagingDirectory):$(artifactsPath)
-    -w /repo $(dockerArmRunArgs)
+    -w /repo $(dockerArmRunOptions)
     -e RUNNING_TESTS_IN_CONTAINER=true 
     --name $(testRunner.container)
     $(imageNames.testRunner.withrepo)

--- a/eng/common/templates/variables/common.yml
+++ b/eng/common/templates/variables/common.yml
@@ -7,6 +7,10 @@ variables:
   value: true
 - name: skipComponentGovernanceDetection
   value: true
+- name: build.imageBuilderDockerRunOptions
+  value: ""
+- name: imageBuilderDockerRunOptions
+  value: ""
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNet-Docker-Common
   - group: DotNet-Docker-Secrets

--- a/eng/common/templates/variables/common.yml
+++ b/eng/common/templates/variables/common.yml
@@ -7,9 +7,9 @@ variables:
   value: true
 - name: skipComponentGovernanceDetection
   value: true
-- name: build.imageBuilderDockerRunOptions
+- name: build.imageBuilderDockerRunExtraOptions
   value: ""
-- name: imageBuilderDockerRunOptions
+- name: imageBuilderDockerRunExtraOptions
   value: ""
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNet-Docker-Common

--- a/eng/pipelines/variables/common.yml
+++ b/eng/pipelines/variables/common.yml
@@ -9,5 +9,5 @@ variables:
 - name: publishReadme
   value: false
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-    - name: build.imageBuilderDockerRunOptions
+    - name: build.imageBuilderDockerRunExtraOptions
       value: -e DOCKER_REPO=$(acr.server)/$(stagingRepoPrefix)dotnet-buildtools/prereqs

--- a/eng/pipelines/variables/common.yml
+++ b/eng/pipelines/variables/common.yml
@@ -8,3 +8,6 @@ variables:
   value: ''
 - name: publishReadme
   value: false
+- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+    - name: build.imageBuilderDockerRunOptions
+      value: -e DOCKER_REPO=$(acr.server)/$(stagingRepoPrefix)dotnet-buildtools/prereqs


### PR DESCRIPTION
The DOCKER_REPO environment variable is not being set when calling the Build command of ImageBuilder.  This variable must be set in order for to build an Ubuntu crossdeps image because the variable is referenced in the build-rootfs.sh script.  Without the variable being set, it attempts to reference the base image in MCR rather than the staging location.

This is fixed by introducing a `build.imageBuilderDockerRunOptions` variable that a pipeline can optionally set.  The options defined in that string will be passed to the `docker run` call when running the Build command of Image Builder.  Since the `docker run` call is embedded in the init-docker-linux.yml file which is used for _all_ commands, not just the Build command, the value of `build.imageBuilderDockerRunOptions` is first set to `imageBuilderDockerRunOptions` in the build-images.yml and it's the `imageBuilderDockerRunOptions` value that is actually used for the call to `docker run`.  This ensures that the value is only used in the scope of calling the Build command.