### PR TITLE
Change docker-testrunner base image from stretch to stretch-slim

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -151,11 +151,11 @@
         {
           "platforms": [
             {
-              "dockerfile": "src/debian/stretch/docker-testrunner",
+              "dockerfile": "src/debian/stretch-slim/docker-testrunner",
               "os": "linux",
               "osVersion": "stretch",
               "tags": {
-                "debian-stretch-docker-testrunner-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
+                "debian-stretch-slim-docker-testrunner-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
               }
             }
           ]

--- a/src/debian/stretch-slim/docker-testrunner/Dockerfile
+++ b/src/debian/stretch-slim/docker-testrunner/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile used to create a testrunner image that can perform Docker operations.
 # Usage:  docker run --rm -v /var/run/docker.sock:/var/run/docker.sock testrunner pwsh -File xyz.ps1
 
-FROM debian:stretch
+FROM debian:stretch-slim
 
 # Install Docker
 RUN apt-get update \


### PR DESCRIPTION
This reduces the size of the image by ~70 mb on disk which is ~13%.  For as many times as the image is pulled this seems worth doing.