### PR TITLE
Fix build script reference

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+**/bin
+**/obj
+**/out
+**/.vscode
+**/.vs
+.dotnet
+.Microsoft.DotNet.ImageBuilder

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# Build output
+[Bb]in/
+[Oo]bj/
+[Oo]ut/
+
+# cache for misc downloads
+artifacts/
+
+# dotnet install directory
+.dotnet/
+
+ # Visual Studio 2015 cache/options directory
+.vs/
+
+# Visual Studio Code cache/options directory
+.vscode/
+
+# Visual Studio debug profile
+**/launchSettings.json
+
+# Test files
+*.trx
+
+# User-specific files
+*.suo
+*.user
+
+# ImageBuilder directory
+.Microsoft.DotNet.ImageBuilder

--- a/build.ps1
+++ b/build.ps1
@@ -8,7 +8,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 pushd $PSScriptRoot
 try {
-    ./scripts/Invoke-ImageBuilder.ps1 "build --path '$DockerfilePath' $ImageBuilderCustomArgs"
+    ./eng/common/Invoke-ImageBuilder.ps1 "build --path '$DockerfilePath' $ImageBuilderCustomArgs"
 }
 finally {
     popd


### PR DESCRIPTION
Fixes the build script by referencing the `Invoke-ImageBuilder.ps1` script with the correct path.

Also added `.gitignore` and `.dockerignore` files.

Fixes #175 