### PR TITLE
Install modern CMake on build docker images

### DIFF
--- a/src/alpine/3.9/amd64/Dockerfile
+++ b/src/alpine/3.9/amd64/Dockerfile
@@ -8,7 +8,6 @@ RUN apk add --no-cache \
         build-base \
         clang \
         clang-dev \
-        cmake \
         coreutils \
         curl \
         curl-dev \
@@ -33,6 +32,7 @@ RUN apk add --no-cache \
         zlib-dev
 
 RUN apk -X http://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache \
+        cmake \
         userspace-rcu-dev \
         lttng-ust-dev \
         numactl-dev

--- a/src/centos/6/Dockerfile
+++ b/src/centos/6/Dockerfile
@@ -43,7 +43,7 @@ RUN yum install -y \
     && \
     yum clean all
 
-# Build and install CMake 3.14
+# Build and install CMake 3.15.3
 
 RUN wget -O cmake-install.sh https://github.com/Kitware/CMake/releases/download/v3.15.3/cmake-3.15.3-Linux-x86_64.sh && \
     bash ./cmake-install.sh --skip-license --exclude-subdir --prefix=/usr/local && \

--- a/src/centos/6/Dockerfile
+++ b/src/centos/6/Dockerfile
@@ -12,8 +12,6 @@ RUN yum install -y \
     yum install -y \
         "perl(Time::HiRes)" \
         autoconf \
-        cmake \
-        cmake3 \
         devtoolset-2-toolchain \
         doxygen \
         expat-devel \
@@ -45,6 +43,12 @@ RUN yum install -y \
     && \
     yum clean all
 
+# Build and install CMake 3.14
+
+RUN wget -O cmake-install.sh https://github.com/Kitware/CMake/releases/download/v3.15.3/cmake-3.15.3-Linux-x86_64.sh && \
+    bash ./cmake-install.sh --skip-license --exclude-subdir --prefix=/usr/local && \
+    rm ./cmake-install.sh
+
 # Build and install clang and lldb 3.9.1
 
 RUN wget ftp://sourceware.org/pub/binutils/snapshots/binutils-2.29.1.tar.xz && \
@@ -71,7 +75,7 @@ RUN wget ftp://sourceware.org/pub/binutils/snapshots/binutils-2.29.1.tar.xz && \
     cd llvmbuild && \
     scl enable python27 devtoolset-2 \
     ' \
-        cmake3 \
+        cmake \
             -DCMAKE_CXX_COMPILER=/opt/rh/devtoolset-2/root/usr/bin/g++ \
             -DCMAKE_C_COMPILER=/opt/rh/devtoolset-2/root/usr/bin/gcc \
             -DCMAKE_LINKER=/opt/rh/devtoolset-2/root/usr/bin/ld \

--- a/src/centos/7/Dockerfile
+++ b/src/centos/7/Dockerfile
@@ -8,8 +8,6 @@ RUN yum install -y \
     && \
     yum install -y \
         "perl(Time::HiRes)" \
-        cmake \
-        cmake3 \
         doxygen \
         gcc \
         gcc-c++ \
@@ -46,6 +44,12 @@ RUN yum install -y \
     && \
     yum clean all
 
+# Build and install CMake 3.14
+
+RUN wget -O cmake-install.sh https://github.com/Kitware/CMake/releases/download/v3.15.3/cmake-3.15.3-Linux-x86_64.sh && \
+    bash ./cmake-install.sh --skip-license --exclude-subdir --prefix=/usr/local && \
+    rm ./cmake-install.sh
+
 # Build and install clang and lldb 3.9.1
 
 RUN wget ftp://sourceware.org/pub/binutils/snapshots/binutils-2.29.1.tar.xz && \
@@ -70,7 +74,7 @@ RUN wget ftp://sourceware.org/pub/binutils/snapshots/binutils-2.29.1.tar.xz && \
     \
     mkdir llvmbuild && \
     cd llvmbuild && \
-    cmake3 \
+    cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DLLVM_LIBDIR_SUFFIX=64\
         -DLLVM_ENABLE_EH=1 \

--- a/src/centos/7/Dockerfile
+++ b/src/centos/7/Dockerfile
@@ -44,7 +44,7 @@ RUN yum install -y \
     && \
     yum clean all
 
-# Build and install CMake 3.14
+# Build and install CMake 3.15.3
 
 RUN wget -O cmake-install.sh https://github.com/Kitware/CMake/releases/download/v3.15.3/cmake-3.15.3-Linux-x86_64.sh && \
     bash ./cmake-install.sh --skip-license --exclude-subdir --prefix=/usr/local && \

--- a/src/centos/7/mlnet/Dockerfile
+++ b/src/centos/7/mlnet/Dockerfile
@@ -11,7 +11,7 @@ RUN wget http://releases.llvm.org/3.9.1/openmp-3.9.1.src.tar.xz && \
     \
     mkdir llvmbuild && \
     cd llvmbuild && \
-    cmake3 \
+    cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DLLVM_LIBDIR_SUFFIX=64\
         -DLLVM_ENABLE_EH=1 \

--- a/src/ubuntu/16.04/Dockerfile
+++ b/src/ubuntu/16.04/Dockerfile
@@ -4,10 +4,12 @@ FROM ubuntu:16.04
 # this does not include libraries that we need to compile different projects, we'd like
 # them in a different layer.
 RUN apt-get update && \
-    apt-get install -y wget && \
+    apt-get install -y apt-transport-https ca-certificates gnupg software-properties-common wget && \
     echo "deb http://llvm.org/apt/xenial/ llvm-toolchain-xenial main" | tee /etc/apt/sources.list.d/llvm.list && \
     echo "deb http://llvm.org/apt/xenial/ llvm-toolchain-xenial-3.9 main" | tee -a /etc/apt/sources.list.d/llvm.list && \
     wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | apt-key add - && \
+    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc | apt-key add - && \
+    apt-add-repository 'deb https://apt.kitware.com/ubuntu/ xenial main' && \
     apt-get update && \
     apt-get install -y \
             cmake \


### PR DESCRIPTION
Install CMake 3.15.3 on CentOS docker images.

Install CMake on Ubuntu via Kitware's official feed to get the most recent official release (currently 3.15.3) instead of the OS bundled release.

Install CMake 3.15.3 on Alpine 3.9 via the "edge" package repository.

This will enable CoreCLR (along with other repos) to upgrade their build scripts to use modern CMake features and (in some CoreCLR's case) clean up our build scripts with new features available in more recent CMake versions.

I've locally verified that the correct CMake version is installed and that it runs on all of the images.

cc: @jashook @janvorli 

@MichaelSimons PTAL