### PR TITLE
Install modern CMake on Ubuntu 16.04 cross-build images.

### DIFF
--- a/src/ubuntu/16.04/crossdeps/Dockerfile
+++ b/src/ubuntu/16.04/crossdeps/Dockerfile
@@ -2,7 +2,12 @@ FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-coredeps
 
 # Install the base toolchain we need to build anything (clang, cmake, make and the like).
 RUN apt-get update \
-    && apt-get install -y apt-transport-https ca-certificates gnupg software-properties-common wget \
+    && apt-get install -y \
+        apt-transport-https \
+        ca-certificates \
+        gnupg \
+        software-properties-common \
+        wget \
     && wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc | apt-key add - \
     && apt-add-repository 'deb https://apt.kitware.com/ubuntu/ xenial main' \
     && apt-get update \
@@ -15,7 +20,6 @@ RUN apt-get update \
         make \
         qemu \
         qemu-user-static \
-        wget \
         build-essential \
     && rm -rf /var/lib/apt/lists/*
 

--- a/src/ubuntu/16.04/crossdeps/Dockerfile
+++ b/src/ubuntu/16.04/crossdeps/Dockerfile
@@ -2,6 +2,9 @@ FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-coredeps
 
 # Install the base toolchain we need to build anything (clang, cmake, make and the like).
 RUN apt-get update \
+    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc | apt-key add - && \
+    apt-add-repository 'deb https://apt.kitware.com/ubuntu/ xenial main' && \
+    && apt-get update \
     && apt-get install -y \
         binfmt-support \
         binutils-arm-linux-gnueabihf \

--- a/src/ubuntu/16.04/crossdeps/Dockerfile
+++ b/src/ubuntu/16.04/crossdeps/Dockerfile
@@ -2,8 +2,9 @@ FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-coredeps
 
 # Install the base toolchain we need to build anything (clang, cmake, make and the like).
 RUN apt-get update \
-    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc | apt-key add - && \
-    apt-add-repository 'deb https://apt.kitware.com/ubuntu/ xenial main' && \
+    && apt-get install -y apt-transport-https ca-certificates gnupg software-properties-common wget \
+    && wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc | apt-key add - \
+    && apt-add-repository 'deb https://apt.kitware.com/ubuntu/ xenial main' \
     && apt-get update \
     && apt-get install -y \
         binfmt-support \


### PR DESCRIPTION
I missed that the cross images aren't based on the regular Ubuntu 16.04 image.

This PR combined with the fix for #187 will enable CoreCLR to move up to CMake 3.14.

cc: @MichaelSimons 