### PR TITLE
Update CentOS images to install CMake 3.15.5.

### DIFF
--- a/src/centos/6/Dockerfile
+++ b/src/centos/6/Dockerfile
@@ -45,9 +45,9 @@ RUN yum install -y \
     && \
     yum clean all
 
-# Build and install CMake 3.15.3
+# Install CMake 3.15.5
 
-RUN wget -O cmake-install.sh https://github.com/Kitware/CMake/releases/download/v3.15.3/cmake-3.15.3-Linux-x86_64.sh && \
+RUN wget -O cmake-install.sh https://github.com/Kitware/CMake/releases/download/v3.15.5/cmake-3.15.5-Linux-x86_64.sh && \
     bash ./cmake-install.sh --skip-license --exclude-subdir --prefix=/usr/local && \
     rm ./cmake-install.sh
 

--- a/src/centos/7/Dockerfile
+++ b/src/centos/7/Dockerfile
@@ -44,9 +44,9 @@ RUN yum install -y \
     && \
     yum clean all
 
-# Build and install CMake 3.15.3
+# Install CMake 3.15.5
 
-RUN wget -O cmake-install.sh https://github.com/Kitware/CMake/releases/download/v3.15.3/cmake-3.15.3-Linux-x86_64.sh && \
+RUN wget -O cmake-install.sh https://github.com/Kitware/CMake/releases/download/v3.15.5/cmake-3.15.5-Linux-x86_64.sh && \
     bash ./cmake-install.sh --skip-license --exclude-subdir --prefix=/usr/local && \
     rm ./cmake-install.sh
 


### PR DESCRIPTION
The minimum CMake version for the consolidated repository is going to be CMake 3.15.5 to account for some fixes in CMake for their VS generators.

@MichaelSimons can you also rebuild the Ubuntu 16.04 image, the Ubuntu 16.04 crossdeps image, and the various images that depend on those images? They need to pull an updated CMake version from the package feed.