### PR TITLE
Update dockerfile for glibc-langpack-en

### DIFF
--- a/src/fedora/30/amd64/Dockerfile
+++ b/src/fedora/30/amd64/Dockerfile
@@ -8,6 +8,7 @@ RUN dnf install -y \
         cmake \
         findutils \
         gdb \
+        glibc-langpack-en \
         lldb-devel \
         llvm-devel \
         make \
@@ -15,7 +16,6 @@ RUN dnf install -y \
         python2-lldb \
         sudo \
         which \
-        glibc-langpack-en \
     && dnf clean all
 
 # Install tools used by build automation.

--- a/src/fedora/30/amd64/Dockerfile
+++ b/src/fedora/30/amd64/Dockerfile
@@ -39,3 +39,8 @@ RUN dnf install -y \
         lttng-ust-devel \
         uuid-devel \
     && dnf clean all
+
+# Dependencies of source-build.
+RUN dnf install -y \
+        glibc-langpack-en
+    && dnf clean all

--- a/src/fedora/30/amd64/Dockerfile
+++ b/src/fedora/30/amd64/Dockerfile
@@ -15,6 +15,7 @@ RUN dnf install -y \
         python2-lldb \
         sudo \
         which \
+        glibc-langpack-en \
     && dnf clean all
 
 # Install tools used by build automation.
@@ -39,8 +40,4 @@ RUN dnf install -y \
         lttng-ust-devel \
         uuid-devel \
     && dnf clean all
-
-# Dependencies of source-build.
-RUN dnf install -y \
-        glibc-langpack-en \
-    && dnf clean all
+    

--- a/src/fedora/30/amd64/Dockerfile
+++ b/src/fedora/30/amd64/Dockerfile
@@ -40,4 +40,3 @@ RUN dnf install -y \
         lttng-ust-devel \
         uuid-devel \
     && dnf clean all
-    

--- a/src/fedora/30/amd64/Dockerfile
+++ b/src/fedora/30/amd64/Dockerfile
@@ -42,5 +42,5 @@ RUN dnf install -y \
 
 # Dependencies of source-build.
 RUN dnf install -y \
-        glibc-langpack-en
+        glibc-langpack-en \
     && dnf clean all


### PR DESCRIPTION
For source-build [fixup](https://github.com/dotnet/source-build/issues/1324#issuecomment-548885319), glibc-langpack-en needs to be a part of base image.