### PR TITLE
Revert change that removed publishReadme condition from task

### DIFF
--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -61,6 +61,7 @@ jobs:
       $(dryRunArg)
       $(imageBuilder.commonCmdArgs)
     displayName: Publish Readme
+    condition: and(succeeded(), eq(variables['publishReadme'], 'true'))
   - script: >
       $(runImageBuilderCmd) publishImageInfo
       $(dotnetBot-userName)

--- a/eng/common/templates/variables/common.yml
+++ b/eng/common/templates/variables/common.yml
@@ -3,6 +3,8 @@ variables:
 - template: common-paths.yml
 - name: stagingRepoPrefix
   value: build-staging/$(sourceBuildId)/
+- name: publishReadme
+  value: true
 - name: skipComponentGovernanceDetection
   value: true
 - name: build.imageBuilderDockerRunExtraOptions


### PR DESCRIPTION
The changes in https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/230 caused a regression in the build for this repo when running the publish stage.  It attempts to publish a readme but this repo has no associated readme so the task fails.  Adding back the logic to conditionally execute the task to publish a readme.