### PR TITLE
Fix using CMake on alpine 3.9 docker images

### DIFF
--- a/src/alpine/3.9/amd64/Dockerfile
+++ b/src/alpine/3.9/amd64/Dockerfile
@@ -32,7 +32,7 @@ RUN apk add --no-cache \
         which \
         zlib-dev
 
-RUN apk -X http://dl-cdn.alpinelinux.org/alpine/v3.11/main add --no-cache \
+RUN apk -X http://dl-cdn.alpinelinux.org/alpine/v3.10/main add --no-cache \
         cmake && \
     apk -X http://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache \
         userspace-rcu-dev \

--- a/src/alpine/3.9/amd64/Dockerfile
+++ b/src/alpine/3.9/amd64/Dockerfile
@@ -32,8 +32,9 @@ RUN apk add --no-cache \
         which \
         zlib-dev
 
-RUN apk -X http://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache \
-        cmake \
+RUN apk -X http://dl-cdn.alpinelinux.org/alpine/v3.11/main add --no-cache \
+        cmake && \
+    apk -X http://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache \
         userspace-rcu-dev \
         lttng-ust-dev \
         numactl-dev


### PR DESCRIPTION
The version of CMake in the edge and 3.11 Alpine repositories are built against a new version of libstdc++ that exposes new symbols. As a result, CMake from 3.11+ Alpine won't run on <=3.10 Alpine. Change the cmake install to install from the 3.10 Alpine repository as a result.

This change is to support https://github.com/dotnet/runtime/issues/2030.

cc: @mthalman @janvorli 