### PR TITLE
Add path filtering to PR triggers

### DIFF
--- a/eng/pipelines/dotnet-buildtools-prereqs-alpine.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-alpine.yml
@@ -5,7 +5,13 @@ trigger:
   paths:
     include:
     - src/alpine/*
-pr: none
+pr:
+  branches:
+    include:
+    - master
+  paths:
+    include:
+    - src/alpine/*
 
 variables:
 - template: variables/common.yml

--- a/eng/pipelines/dotnet-buildtools-prereqs-centos6.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-centos6.yml
@@ -5,7 +5,13 @@ trigger:
   paths:
     include:
     - src/centos/6/*
-pr: none
+pr:
+  branches:
+    include:
+    - master
+  paths:
+    include:
+    - src/centos/6/*
 
 variables:
 - template: variables/common.yml

--- a/eng/pipelines/dotnet-buildtools-prereqs-centos7.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-centos7.yml
@@ -5,7 +5,13 @@ trigger:
   paths:
     include:
     - src/centos/7/*
-pr: none
+pr:
+  branches:
+    include:
+    - master
+  paths:
+    include:
+    - src/centos/7/*
 
 variables:
 - template: variables/common.yml

--- a/eng/pipelines/dotnet-buildtools-prereqs-debian.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-debian.yml
@@ -5,7 +5,13 @@ trigger:
   paths:
     include:
     - src/debian/*
-pr: none
+pr:
+  branches:
+    include:
+    - master
+  paths:
+    include:
+    - src/debian/*
 
 variables:
 - template: variables/common.yml

--- a/eng/pipelines/dotnet-buildtools-prereqs-eng.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-eng.yml
@@ -3,6 +3,10 @@ pr:
   branches:
     include:
     - master
+  paths:
+    exclude:
+    - src/*
+    - README.md
 
 variables:
 - template: variables/common.yml

--- a/eng/pipelines/dotnet-buildtools-prereqs-nanoserver-1809.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-nanoserver-1809.yml
@@ -5,7 +5,13 @@ trigger:
   paths:
     include:
     - src/nanoserver/1809/*
-pr: none
+pr:
+  branches:
+    include:
+    - master
+  paths:
+    include:
+    - src/nanoserver/1809/*
 
 variables:
 - template: variables/common.yml

--- a/eng/pipelines/dotnet-buildtools-prereqs-ubuntu16.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-ubuntu16.yml
@@ -5,7 +5,13 @@ trigger:
   paths:
     include:
     - src/ubuntu/16.04/*
-pr: none
+pr:
+  branches:
+    include:
+    - master
+  paths:
+    include:
+    - src/ubuntu/16.04/*
 
 variables:
 - template: variables/common.yml

--- a/eng/pipelines/dotnet-buildtools-prereqs-ubuntu18.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-ubuntu18.yml
@@ -5,7 +5,13 @@ trigger:
   paths:
     include:
     - src/ubuntu/18.04/*
-pr: none
+pr:
+  branches:
+    include:
+    - master
+  paths:
+    include:
+    - src/ubuntu/18.04/*
 
 variables:
 - template: variables/common.yml

--- a/eng/pipelines/dotnet-buildtools-prereqs-ubuntu19.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-ubuntu19.yml
@@ -5,7 +5,13 @@ trigger:
   paths:
     include:
     - src/ubuntu/19*
-pr: none
+pr:
+  branches:
+    include:
+    - master
+  paths:
+    include:
+    - src/ubuntu/19*
 
 variables:
 - template: variables/common.yml


### PR DESCRIPTION
Updates distro-specific build pipelines so that they are triggered for PRs whenever their respective Dockerfiles change.

Update and rename the `dotnet-buildtools-prereqs-pr.yml` file to `dotnet-buildtools-prereqs-eng.yml` so that it runs for any other repo changes.  Those other changes could affect the build of any distro so it should build all of them.

Fixes #235 