### PR TITLE
Switch to newer Python 3 on CentOS

### DIFF
--- a/src/centos/6/Dockerfile
+++ b/src/centos/6/Dockerfile
@@ -40,7 +40,7 @@ RUN yum install -y \
         python-argparse \
         python27 \
         readline-devel \
-        rh-python35 \
+        python34 \
         sudo \
         xz \
         zlib-devel \

--- a/src/centos/7/Dockerfile
+++ b/src/centos/7/Dockerfile
@@ -38,7 +38,7 @@ RUN yum install -y \
         python27 \
         python-devel \
         readline-devel \
-        rh-python35 \
+        python3 \
         sudo \
         swig \
         wget \


### PR DESCRIPTION
It seems there is actually a package outside of the scl on cent, so it's better to use that. Apologies for the churn, I don't normally deal with infra :(