### PR TITLE
Add g++-7 symlink

### DIFF
--- a/src/centos/7/Dockerfile
+++ b/src/centos/7/Dockerfile
@@ -94,4 +94,5 @@ RUN wget ftp://sourceware.org/pub/binutils/snapshots/binutils-2.29.1.tar.xz && \
     rm -r binutils-2.29.1
 
 # Create gcc-7 symlink available in PATH
-RUN ln -s /opt/rh/devtoolset-7/root/usr/bin/gcc /usr/local/bin/gcc-7
+RUN ln -s /opt/rh/devtoolset-7/root/usr/bin/gcc /usr/local/bin/gcc-7 && \
+    ln -s /opt/rh/devtoolset-7/root/usr/bin/g++ /usr/local/bin/g++-7


### PR DESCRIPTION
I tested master branches of `dotnet/dotnet-buildtools-prereqs-docker` and `dotnet/runime` and found an inconsistency in gcc builds:

```sh
./src/coreclr/build-runtime.sh -gcc
...
Commencing build of "CoreCLR component" for Linux.x64.Debug in /runtime/artifacts/obj/coreclr/Linux.x64.Debug
...
  -- The C compiler identification is GNU 7.3.1
  -- The CXX compiler identification is Clang 9.0.0
```
PR adds a g++ symlink, so now it looks like:

```
-- The C compiler identification is GNU 7.3.1
-- The CXX compiler identification is GNU 7.3.1
```

note: some distros do not have explicit g++, clang++, so `gcc file.cpp` would internally invoke the C++ compilation. This is distro specific for CentOS.