### PR TITLE
Add Fedora 31 build image.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -178,6 +178,19 @@
           }]
         },
         {
+          "platforms": [{
+            "dockerfile": "src/fedora/31/amd64",
+            "os": "linux",
+            "osVersion": "fedora31",
+            "tags": {
+              "fedora-31-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {},
+              "fedora-31": {
+                "isLocal": true
+              }
+            }
+          }]
+        },
+        {
           "platforms": [
             {
               "dockerfile": "src/ubuntu/16.04",

--- a/src/fedora/31/amd64/Dockerfile
+++ b/src/fedora/31/amd64/Dockerfile
@@ -1,0 +1,43 @@
+FROM fedora:31
+
+# Install the base toolchain we need to build anything (clang, cmake, make and the like)
+# this does not include libraries that we need to compile different projects, we'd like
+# them in a different layer.
+RUN dnf install -y \
+        clang \
+        cmake \
+        findutils \
+        gdb \
+        glibc-langpack-en \
+        lldb-devel \
+        llvm-devel \
+        make \
+        python \
+        which \
+    && dnf clean all
+
+# Install tools used by build automation.
+RUN dnf install -y \
+        git \
+        tar \
+        procps \
+        zip \
+    && dnf clean all
+
+# Dependencies of CoreCLR, Mono and CoreFX.
+RUN dnf install -y \
+        autoconf \
+        automake \
+        compat-openssl10-devel \
+        glibc-locale-source \
+        iputils \
+        krb5-devel \
+        libcurl-devel \
+        libgdiplus \
+        libicu-devel \
+        libtool \
+        libunwind-devel \
+        libuuid-devel \
+        lttng-ust-devel \
+        uuid-devel \
+    && dnf clean all


### PR DESCRIPTION
This is mostly a copy of the Fedora 30 image with some packages that are no longer available removed.  I was able to build source-build on this image so the missing packages do not seem to be required for any core product builds.