### PR TITLE
Add dockerfiles for CentOS 8

### DIFF
--- a/eng/pipelines/dotnet-buildtools-prereqs-centos8.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-centos8.yml
@@ -1,0 +1,24 @@
+trigger:
+  branches:
+    include:
+    - master
+  paths:
+    include:
+    - src/centos/8/*
+pr:
+  branches:
+    include:
+    - master
+  paths:
+    include:
+    - src/centos/8/*
+
+variables:
+- template: variables/common.yml
+- name: imageBuilder.pathArgs
+  value: --path 'src/centos/8*'
+
+stages:
+  - template: ../common/templates/stages/build-test-publish-repo.yml
+    parameters:
+      linuxAmdBuildJobTimeout: 210

--- a/manifest.json
+++ b/manifest.json
@@ -82,6 +82,33 @@
         {
           "platforms": [
             {
+              "dockerfile": "src/centos/8",
+              "os": "linux",
+              "osVersion": "centos8",
+              "tags": {
+                "centos-8-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {},
+                "centos-8": {
+                  "isLocal": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/centos/8/rpmpkg",
+              "os": "linux",
+              "osVersion": "centos8",
+              "tags": {
+                "centos-8-rpmpkg-$(System:DockerfileGitCommitSha)-$(System:TimeStamp)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
               "dockerfile": "src/centos/7",
               "os": "linux",
               "osVersion": "centos7",

--- a/src/centos/8/Dockerfile
+++ b/src/centos/8/Dockerfile
@@ -1,0 +1,53 @@
+FROM centos:8
+
+# Install dependencies
+
+RUN dnf install --setopt tsflags=nodocs --refresh -y \
+        dnf-plugins-core \
+        epel-release \
+    && \
+    dnf config-manager --set-enabled PowerTools \
+    && \
+    dnf install --setopt tsflags=nodocs -y \
+        "perl(Time::HiRes)" \
+        autoconf \
+        automake \
+        clang \
+        cmake \
+        curl-devel \
+        doxygen \
+        findutils \
+        gcc \
+        gdb \
+        git \
+        glibc-langpack-en \
+        hostname \
+        krb5-devel \
+        libcurl-devel \
+        libedit-devel \
+        libicu-devel \
+        libidn-devel \
+        libnghttp2-devel \
+        libtool \
+        libuuid-devel \
+        libxml2-devel \
+        lldb-devel \
+        llvm \
+        lttng-ust-devel \
+        lzma \
+        make \
+        ncurses-devel \
+        numactl-devel \
+        openssl-devel \
+        python3 \
+        python3-devel \
+        readline-devel \
+        sudo \
+        swig \
+        tar \
+        wget \
+        which \
+        xz \
+        zlib-devel \
+    && \
+    dnf clean all

--- a/src/centos/8/rpmpkg/Dockerfile
+++ b/src/centos/8/rpmpkg/Dockerfile
@@ -1,0 +1,14 @@
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:centos-8
+
+# Install the rpm packaging toolchain required to build rpms
+RUN dnf clean all \
+    && \
+    dnf install -y \
+        gcc \
+        rpm-build \
+        ruby-devel \
+        rubygems \
+    && \
+    gem install --no-document fpm \
+    && \
+    dnf clean all


### PR DESCRIPTION
The package list is mainly based off of packages in CentOS 7, with some packages that are not available on CentOS 8 (such as gdiplus) removed.

cc @adaggarwal @crummel @dagood  