### PR TITLE
Fix broken rootfs cleanup logic

### DIFF
--- a/eng/pipelines/dotnet-buildtools-prereqs-ubuntu18.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-ubuntu18.yml
@@ -21,6 +21,6 @@ variables:
 stages:
   - template: ../common/templates/stages/build-test-publish-repo.yml
     parameters:
-      linuxAmdBuildJobTimeout: 90
+      linuxAmdBuildJobTimeout: 150
       customBuildInitSteps:
       - template: /eng/pipelines/steps/install-cross-build-prereqs.yml

--- a/src/ubuntu/18.04/cross/arm/16.04/hooks/post-build
+++ b/src/ubuntu/18.04/cross/arm/16.04/hooks/post-build
@@ -1,3 +1,1 @@
-#!/usr/bin/env bash
-
-rm -rf $PWD/rootfs
+../../../../../build-scripts/build-rootfs-cleanup.sh

--- a/src/ubuntu/18.04/cross/arm64-alpine/hooks/post-build
+++ b/src/ubuntu/18.04/cross/arm64-alpine/hooks/post-build
@@ -1,3 +1,1 @@
-#!/usr/bin/env bash
-
-rm -rf $PWD/rootfs
+../../../../build-scripts/build-rootfs-cleanup.sh

--- a/src/ubuntu/18.04/cross/arm64/16.04/hooks/post-build
+++ b/src/ubuntu/18.04/cross/arm64/16.04/hooks/post-build
@@ -1,3 +1,1 @@
-#!/usr/bin/env bash
-
-rm -rf $PWD/rootfs
+../../../../../build-scripts/build-rootfs-cleanup.sh

--- a/src/ubuntu/18.04/cross/arm64/hooks/post-build
+++ b/src/ubuntu/18.04/cross/arm64/hooks/post-build
@@ -1,3 +1,1 @@
-#!/usr/bin/env bash
-
-rm -rf $PWD/rootfs
+../../../../build-scripts/build-rootfs-cleanup.sh

--- a/src/ubuntu/18.04/cross/hooks/post-build
+++ b/src/ubuntu/18.04/cross/hooks/post-build
@@ -1,3 +1,1 @@
-#!/usr/bin/env bash
-
-rm -rf $PWD/rootfs
+../../../build-scripts/build-rootfs-cleanup.sh

--- a/src/ubuntu/build-scripts/build-rootfs-cleanup.sh
+++ b/src/ubuntu/build-scripts/build-rootfs-cleanup.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-rm -rf $PWD/rootfs
+rm -rf $PWD/rootfs*.tar

--- a/src/ubuntu/build-scripts/build-rootfs.sh
+++ b/src/ubuntu/build-scripts/build-rootfs.sh
@@ -12,12 +12,12 @@ lldb=${4:-}
 
 dockerCrossDepsTag="${DOCKER_REPO:-mcr.microsoft.com/dotnet-buildtools/prereqs}:${os}-crossdeps"
 
-rm -rf $PWD/rootfs.tar
-
 # If argument three was set, use that as the only arch, otherwise use default list of arches : 'arm'
 crossArchArray=(${archArg:-'arm'})
 for arch in $crossArchArray
 do
+    rm -rf $PWD/rootfs.$arch.tar
+
     echo "Using $dockerCrossDepsTag to set up cross-toolset for $arch for $crossToolset"
     buildRootFSContainer="rootfs-$arch-$crossToolset-$(date +%s)"
 


### PR DESCRIPTION
I discovered the logic that cleans up the rootfs tarballs was no longer working because of various refactoring over time.  For the ubuntu 18.04 leg this equates to 4.68 GB on tarballs.

I also increased the ubuntu leg timeout.

Related to #272 