### PR TITLE
add images to build runtime on FreeBSD

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -403,6 +403,30 @@
         {
           "platforms": [
             {
+              "dockerfile": "src/ubuntu/18.04/cross/freebsd/11",
+              "os": "linux",
+              "osVersion": "freebsd.11",
+              "tags": {
+                "ubuntu-18.04-cross-freebsd-11-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/18.04/cross/freebsd/12",
+              "os": "linux",
+              "osVersion": "freebsd.12",
+              "tags": {
+                "ubuntu-18.04-cross-freebsd-12-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
               "architecture": "arm64",
               "dockerfile": "src/alpine/3.8/helix/arm64v8",
               "os": "linux",

--- a/src/ubuntu/18.04/cross/freebsd/11/Dockerfile
+++ b/src/ubuntu/18.04/cross/freebsd/11/Dockerfile
@@ -1,0 +1,5 @@
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-coredeps
+
+RUN apt -y autoremove
+
+ADD rootfs.x64.tar crossrootfs

--- a/src/ubuntu/18.04/cross/freebsd/11/hooks/post-build
+++ b/src/ubuntu/18.04/cross/freebsd/11/hooks/post-build
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+rm -rf $PWD/rootfs*.tar

--- a/src/ubuntu/18.04/cross/freebsd/11/hooks/pre-build
+++ b/src/ubuntu/18.04/cross/freebsd/11/hooks/pre-build
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+$(dirname ${BASH_SOURCE[0]})/../../../../../build-scripts/build-rootfs.sh ubuntu-18.04 freebsd11 x64

--- a/src/ubuntu/18.04/cross/freebsd/12/Dockerfile
+++ b/src/ubuntu/18.04/cross/freebsd/12/Dockerfile
@@ -1,0 +1,5 @@
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-coredeps
+
+RUN apt -y autoremove
+
+ADD rootfs.x64.tar crossrootfs

--- a/src/ubuntu/18.04/cross/freebsd/12/hooks/post-build
+++ b/src/ubuntu/18.04/cross/freebsd/12/hooks/post-build
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+rm -rf $PWD/rootfs*.tar

--- a/src/ubuntu/18.04/cross/freebsd/12/hooks/pre-build
+++ b/src/ubuntu/18.04/cross/freebsd/12/hooks/pre-build
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+$(dirname ${BASH_SOURCE[0]})/../../../../../build-scripts/build-rootfs.sh ubuntu-18.04 freebsd12 x64

--- a/src/ubuntu/18.04/crossdeps/Dockerfile
+++ b/src/ubuntu/18.04/crossdeps/Dockerfile
@@ -21,6 +21,11 @@ RUN apt-get update \
         make \
         qemu \
         qemu-user-static \
+        libbz2-dev \
+        libz-dev \
+        liblzma-dev \
+        libarchive-dev \
+        libbsd-dev \
     && rm -rf /var/lib/apt/lists/*
 
 RUN apt-get update \
@@ -31,4 +36,4 @@ RUN apt-get update \
         llvm-9 \
         python-lldb-6.0 \
     && rm -rf /var/lib/apt/lists/*
-    
+

--- a/src/ubuntu/build-scripts/build-rootfs.sh
+++ b/src/ubuntu/build-scripts/build-rootfs.sh
@@ -32,7 +32,7 @@ do
 
     echo "Using $dockerCrossDepsTag to clone arcade to fetch scripts used to build cross-toolset"
     docker exec $buildRootFSContainer \
-        git clone https://github.com/dotnet/arcade /scripts
+        git clone --depth 1 https://github.com/dotnet/arcade /scripts
 
     if [ $? -ne 0 ]; then
         echo "Rootfs build failed: `git clone https://github.com/dotnet/arcade /scripts` returned error"


### PR DESCRIPTION
This wraps https://github.com/dotnet/arcade/pull/5100
build-rootfs.sh needs few more package to construct roots for FreeBSD. 
They all seems pretty small so I added them to crossdeps to avoid need to create new base image for pre-build hook. 


I'm not sure with naming but it seems os and base directory should reflect base container OS and not target. 

I also noticed arcade checkout taking some time on my home machine. Since do not seems to need history, I changed clone to shallow copy.
