### PR TITLE
Use custom agent pool for Ubuntu 18.04 builds

### DIFF
--- a/eng/pipelines/dotnet-buildtools-prereqs-eng.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-eng.yml
@@ -17,5 +17,11 @@ stages:
   - template: ../common/templates/stages/build-test-publish-repo.yml
     parameters:
       linuxAmdBuildJobTimeout: 210
+      ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        linuxAmdBuildPool: "NetCorePublic-Pool"
+        linuxAmdBuildQueue: "BuildPool.Ubuntu.1604.Amd64.Open"
+      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        linuxAmdBuildPool: "NetCoreInternal-Pool"
+        linuxAmdBuildQueue: "BuildPool.Ubuntu.1604.Amd64"
       customBuildInitSteps:
       - template: /eng/pipelines/steps/install-cross-build-prereqs.yml

--- a/eng/pipelines/dotnet-buildtools-prereqs-ubuntu18.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-ubuntu18.yml
@@ -22,5 +22,11 @@ stages:
   - template: ../common/templates/stages/build-test-publish-repo.yml
     parameters:
       linuxAmdBuildJobTimeout: 150
+      ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        linuxAmdBuildPool: "NetCorePublic-Pool"
+        linuxAmdBuildQueue: "BuildPool.Ubuntu.1604.Amd64.Open"
+      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        linuxAmdBuildPool: "NetCoreInternal-Pool"
+        linuxAmdBuildQueue: "BuildPool.Ubuntu.1604.Amd64"
       customBuildInitSteps:
       - template: /eng/pipelines/steps/install-cross-build-prereqs.yml


### PR DESCRIPTION
Resolves an issue exposed by https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/277 that resulted in their not being enough disk space on the Hosted Ubuntu 16.04 agent pool that is used by default for the Linux AMD64 build legs.  This customizes the pipeline to use a self-hosted agent pool that has larger disk space.