### PR TITLE
Add locales to ubuntu 16.0.4

### DIFF
--- a/src/ubuntu/16.04/Dockerfile
+++ b/src/ubuntu/16.04/Dockerfile
@@ -19,6 +19,8 @@ RUN apt-get update && \
             llvm-9 \
             make \
             python-lldb-6.0 \
+            locales \
+            locales-all \
             sudo && \
     apt-get clean
 

--- a/src/ubuntu/16.04/Dockerfile
+++ b/src/ubuntu/16.04/Dockerfile
@@ -17,9 +17,9 @@ RUN apt-get update && \
             liblldb-6.0-dev \
             lldb-6.0 \
             llvm-9 \
+            locales \
             make \
             python-lldb-6.0 \
-            locales \
             sudo && \
     apt-get clean
 

--- a/src/ubuntu/16.04/Dockerfile
+++ b/src/ubuntu/16.04/Dockerfile
@@ -20,7 +20,6 @@ RUN apt-get update && \
             make \
             python-lldb-6.0 \
             locales \
-            locales-all \
             sudo && \
     apt-get clean
 
@@ -33,6 +32,9 @@ RUN apt-get install -y git \
     apt-get clean && \
     npm install -g azure-cli@0.9.20 && \
     npm cache clean
+
+# .NET SDK MSBuild requires US.UTF-8 locale to execute tasks
+RUN locale-gen en_US.UTF-8 
 
 # Dependencies for CoreCLR, Mono and CoreFX
 RUN apt-get install -y \


### PR DESCRIPTION
The MSBuild `Exec` task will use `export LC_ALL=en_US.UTF-8` as a
part of the `bash` invocation. When ubuntu lacks the `locales`
package this will cause a warning to be emitted from the `Exec`
usage and the outer MSBuild invocation. Adding the `locales`
package here to get our builds warning free as this makes it
significantly easier to manage our build reliability

https://github.com/microsoft/msbuild/issues/4194
https://github.com/dotnet/runtime/issues/34280