### PR TITLE
fix freebsd images

### DIFF
--- a/src/ubuntu/18.04/cross/freebsd/11/Dockerfile
+++ b/src/ubuntu/18.04/cross/freebsd/11/Dockerfile
@@ -1,5 +1,3 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-coredeps
-
-RUN apt -y autoremove
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-crossdeps
 
 ADD rootfs.x64.tar crossrootfs

--- a/src/ubuntu/18.04/cross/freebsd/12/Dockerfile
+++ b/src/ubuntu/18.04/cross/freebsd/12/Dockerfile
@@ -1,5 +1,3 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-coredeps
-
-RUN apt -y autoremove
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-crossdeps
 
 ADD rootfs.x64.tar crossrootfs


### PR DESCRIPTION
It seems like my last minute changes to save space broke the build without me noticing. 
I only found that when I debugged CI logs ;(

Further more, it did not do what I intended. Instead of saving space, the auto remove added another layer.


```
$ docker history  mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-freebsd-11-20200403161435-3d73ec8
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
7e10aa535750        9 hours ago         /bin/sh -c #(nop) ADD file:f1092df180407aafb…   1.54GB
<missing>           9 hours ago         /bin/sh -c apt -y autoremove                    1.19MB
<missing>           11 hours ago        /bin/sh -c apt-get update     && apt-get ins…   166MB
<missing>           11 hours ago        /bin/sh -c apt-get update     && apt-get ins…   462MB
<missing>           8 months ago        /bin/sh -c #(nop)  CMD ["pwsh"]                 0B
<missing>           8 months ago        /bin/sh -c #(nop)  LABEL maintainer=PowerShe…   0B
<missing>           8 months ago        /bin/sh -c #(nop)  ARG IMAGE_NAME=mcr.micros…   0B
<missing>           8 months ago        /bin/sh -c #(nop)  ARG VCS_REF=none             0B
```

so instead I use standard image without any modification even it has extra stuff we do not need. The saving comes from fixes to build-roofs.sh in arcade.

```
furt@ubu18:~/github/dotnet-buildtools-prereqs-docker$ docker history  mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-freebsd-11-20200404025356-3d73ec8
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
cefe97f2c223        5 minutes ago       /bin/sh -c #(nop) ADD file:94f98d114aa142a10…   459MB
951c1fe466c1        About an hour ago   /bin/sh -c apt-get update     && apt-get ins…   895MB
78256b173099        About an hour ago   /bin/sh -c apt-get update     && apt-get ins…   592MB
761cad83d258        2 hours ago         /bin/sh -c apt-get update     && apt-get ins…   166MB
d5dbcf8a4a31        2 hours ago         /bin/sh -c apt-get update     && apt-get ins…   463MB
1a1778bdcf68        8 months ago        /bin/sh -c #(nop)  CMD ["pwsh"]                 0B
<missing>           8 months ago        /bin/sh -c #(nop)  LABEL maintainer=PowerShe…   0B
<missing>           8 months ago        /bin/sh -c #(nop)  ARG IMAGE_NAME=mcr.micros…   0B
<missing>           8 months ago        /bin/sh -c #(nop)  ARG VCS_REF=none             0B
```

can this please be merged when it passed CI?