### PR TITLE
Add Fedora rawhide build image

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -244,6 +244,16 @@
           }]
         },
         {
+          "platforms": [{
+            "dockerfile": "src/fedora/rawhide/amd64",
+            "os": "linux",
+            "osVersion": "fedora-rawhide",
+            "tags": {
+              "fedora-rawhide-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
+            }
+          }]
+        },
+        {
           "platforms": [
             {
               "dockerfile": "src/ubuntu/16.04",

--- a/src/fedora/rawhide/amd64/Dockerfile
+++ b/src/fedora/rawhide/amd64/Dockerfile
@@ -1,0 +1,44 @@
+FROM fedora:rawhide
+
+# Install the base toolchain we need to build anything (clang, cmake, make and the like)
+# this does not include libraries that we need to compile different projects, we'd like
+# them in a different layer.
+RUN dnf install -y \
+        clang \
+        cmake \
+        findutils \
+        gdb \
+        glibc-langpack-en \
+        lldb-devel \
+        llvm-devel \
+        make \
+        python \
+        which \
+    && dnf clean all
+
+# Install tools used by build automation.
+RUN dnf install -y \
+        git \
+        tar \
+        procps \
+        zip \
+    && dnf clean all
+
+# Dependencies of CoreCLR, Mono and CoreFX.
+RUN dnf install -y \
+        autoconf \
+        automake \
+        glibc-locale-source \
+        iputils \
+        krb5-devel \
+        libcurl-devel \
+        libgdiplus \
+        libicu-devel \
+        libtool \
+        libunwind-devel \
+        libuuid-devel \
+        lttng-ust-devel \
+        openssl-devel \
+        uuid-devel \
+        zlib-devel \
+    && dnf clean all


### PR DESCRIPTION
The dockerfile is based on the existing Fedora 31 dockerfile.

Fedora `rawhide` is a rolling distro. It's not really generally usable for end-users. However, it generally includes the latest in-development versions of various projects like `clang`. That should help us catch various compatiblity issues earlier before it hits other distributions.

cc @crummel 