### PR TITLE
Fix permissions on emscripten folder

### DIFF
--- a/src/ubuntu/18.04/webassembly/Dockerfile
+++ b/src/ubuntu/18.04/webassembly/Dockerfile
@@ -20,4 +20,5 @@ ENV EMSCRIPTEN_VERSION=1.39.9
 RUN git clone https://github.com/emscripten-core/emsdk.git /usr/local/emscripten \
     && cd /usr/local/emscripten \
     && ./emsdk install ${EMSCRIPTEN_VERSION}-upstream \
-    && ./emsdk activate --embedded ${EMSCRIPTEN_VERSION}-upstream
+    && ./emsdk activate --embedded ${EMSCRIPTEN_VERSION}-upstream \
+    && chmod -R 777 /usr/local/emscripten


### PR DESCRIPTION
The user used during build is different and emscripten tries to write various cache files into the directory.
Make it writable by everyone.

Unblocks https://github.com/dotnet/runtime/pull/33551