### PR TITLE
use openssl as backend for curl

### DIFF
--- a/src/ubuntu/16.04/crossdeps/Dockerfile
+++ b/src/ubuntu/16.04/crossdeps/Dockerfile
@@ -34,3 +34,16 @@ RUN apt-get update \
         llvm-9 \
         python-lldb-6.0 \
     && rm -rf /var/lib/apt/lists/*
+
+RUN echo "deb-src http://archive.ubuntu.com/ubuntu/ xenial main restricted" >> /etc/apt/sources.list && \
+    echo "deb-src http://archive.ubuntu.com/ubuntu/ xenial-updates multiverse" >>  /etc/apt/sources.list && \
+    echo "deb-src http://security.ubuntu.com/ubuntu/ xenial-security universe" >> /etc/apt/sources.list && \
+    apt-get update && \
+    mkdir /tmp/curl && cd  /tmp/curl && \
+    apt-get source -y curl && apt-get build-dep -y curl &&  apt install -y devscripts && \
+    sed -i.ORI -e 's/dh_install\ -pcurl /dh_install /' -e 's/dh_install -plibcurl3/dh_install -pcurl -plibcurl3/'  curl*/debian/rules && \
+    (cd curl* && DEB_BUILD_OPTIONS=nocheck debuild -b -uc -us) && \
+    dpkg --force-all -i curl_*.deb && \
+    curl --version | grep OpenSSL && \
+    rm -rf /var/lib/apt/lists/* /tmp/curl
+

--- a/src/ubuntu/16.04/crossdeps/Dockerfile
+++ b/src/ubuntu/16.04/crossdeps/Dockerfile
@@ -35,15 +35,17 @@ RUN apt-get update \
         python-lldb-6.0 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN echo "deb-src http://archive.ubuntu.com/ubuntu/ xenial main restricted" >> /etc/apt/sources.list && \
-    echo "deb-src http://archive.ubuntu.com/ubuntu/ xenial-updates multiverse" >>  /etc/apt/sources.list && \
-    echo "deb-src http://security.ubuntu.com/ubuntu/ xenial-security universe" >> /etc/apt/sources.list && \
-    apt-get update && \
-    mkdir /tmp/curl && cd  /tmp/curl && \
-    apt-get source -y curl && apt-get build-dep -y curl &&  apt install -y devscripts && \
-    sed -i.ORI -e 's/dh_install\ -pcurl /dh_install /' -e 's/dh_install -plibcurl3/dh_install -pcurl -plibcurl3/'  curl*/debian/rules && \
-    (cd curl* && DEB_BUILD_OPTIONS=nocheck debuild -b -uc -us) && \
-    dpkg --force-all -i curl_*.deb && \
-    curl --version | grep OpenSSL && \
-    rm -rf /var/lib/apt/lists/* /tmp/curl
+# rebuild curl with OpenSSL backend to avoid build issues with GnuTLS.
+RUN echo "deb-src http://archive.ubuntu.com/ubuntu/ xenial main restricted" >> /etc/apt/sources.list \
+    && echo "deb-src http://archive.ubuntu.com/ubuntu/ xenial-updates multiverse" >>  /etc/apt/sources.list \
+    && echo "deb-src http://security.ubuntu.com/ubuntu/ xenial-security universe" >> /etc/apt/sources.list \
+    && echo "deb-src http://us.archive.ubuntu.com/ubuntu/ xenial-updates main restricted" >>  /etc/apt/sources.list \
+    && apt-get update \
+    && mkdir /tmp/curl && cd  /tmp/curl \
+    && apt-get source -y curl && apt-get build-dep -y curl &&  apt install -y devscripts \
+    && sed -i.ORI -e 's/dh_install\ -pcurl /dh_install /' -e 's/dh_install -plibcurl3/dh_install -pcurl -plibcurl3/'  curl*/debian/rules \
+    && (cd curl* && DEB_BUILD_OPTIONS=nocheck debuild -b -uc -us) \
+    && dpkg --force-all -i curl_*.deb \
+    && curl --version | grep OpenSSL \
+    && rm -rf /var/lib/apt/lists/* /tmp/curl
 


### PR DESCRIPTION
rebuild curl with OpenSSL backend. Contributes to https://github.com/dotnet/runtime/issues/34015

With this ubuntu-16.04-crossdeps image have updated curl (coredeps do not)
```
root@21f1a5af6fb7:/# curl --version
curl 7.47.0 (x86_64-pc-linux-gnu) libcurl/7.47.0 OpenSSL/1.0.2g zlib/1.2.8 libidn/1.32 librtmp/2.3
Protocols: dict file ftp ftps gopher http https imap imaps ldap ldaps pop3 pop3s rtmp rtsp smb smbs smtp smtps telnet tftp
Features: AsynchDNS IDN IPv6 Largefile GSS-API Kerberos SPNEGO NTLM NTLM_WB SSL libz TLS-SRP UnixSockets
```

instead of builing drop from curl's repo, I rebuild original package to pick up any modifications and security fixes. They already build agains OpenSSL, GnuTLS and NSS and produce  according libraries. This change simply picks curl linked agains the one we want.  