### PR TITLE
Refactor build-rootfs apt cleanup logic to work correctly

### DIFF
--- a/src/ubuntu/build-scripts/build-rootfs.sh
+++ b/src/ubuntu/build-scripts/build-rootfs.sh
@@ -62,7 +62,7 @@ do
 
     echo "Cleaning apt files"
     docker exec $buildRootFSContainer \
-        rm -rf /rootfs/*/var/cache/apt/archives/* /rootfs/*/var/lib/apt/lists/*
+        bash -c 'rm -rf /rootfs/*/{var/cache/apt/archives/*,var/lib/apt/lists/*,usr/share/doc,usr/share/man}'
 
     echo "Tarring rootfs"
     docker exec $buildRootFSContainer \


### PR DESCRIPTION
Fixes #33 

With the `ubuntu-16.04-cross` image, these changes have the following effect on the `crossrootfs` contents/size.

**Before**
```
206M    /crossrootfs/arm/var/cache/apt
209M    /crossrootfs/arm/var/cache
13M     /crossrootfs/arm/var/lib/dpkg
148M    /crossrootfs/arm/var/lib/apt
161M    /crossrootfs/arm/var/lib
370M    /crossrootfs/arm/var
14M     /crossrootfs/arm/usr/share/doc
13M     /crossrootfs/arm/usr/share/i18n
20M     /crossrootfs/arm/usr/share/perl
17M     /crossrootfs/arm/usr/share/man
89M     /crossrootfs/arm/usr/share
30M     /crossrootfs/arm/usr/bin
12M     /crossrootfs/arm/usr/lib/python2.7
109M    /crossrootfs/arm/usr/lib/llvm-3.9
184M    /crossrootfs/arm/usr/lib/arm-linux-gnueabihf
24M     /crossrootfs/arm/usr/lib/python3.5
44M     /crossrootfs/arm/usr/lib/gcc
375M    /crossrootfs/arm/usr/lib
14M     /crossrootfs/arm/usr/include/llvm-3.9
40M     /crossrootfs/arm/usr/include
535M    /crossrootfs/arm/usr
13M     /crossrootfs/arm/lib/udev
11M     /crossrootfs/arm/lib/arm-linux-gnueabihf
31M     /crossrootfs/arm/lib
947M    /crossrootfs/arm
947M    /crossrootfs/
```

**After**
```
58M    /crossrootfs/arm/var/cache/apt
61M    /crossrootfs/arm/var/cache
13M    /crossrootfs/arm/var/lib/dpkg
13M    /crossrootfs/arm/var/lib
74M    /crossrootfs/arm/var
14M    /crossrootfs/arm/usr/include/llvm-3.9
40M    /crossrootfs/arm/usr/include
109M   /crossrootfs/arm/usr/lib/llvm-3.9
44M    /crossrootfs/arm/usr/lib/gcc
12M    /crossrootfs/arm/usr/lib/python2.7
24M    /crossrootfs/arm/usr/lib/python3.5
184M   /crossrootfs/arm/usr/lib/arm-linux-gnueabihf
375M   /crossrootfs/arm/usr/lib
13M    /crossrootfs/arm/usr/share/i18n
20M    /crossrootfs/arm/usr/share/perl
60M    /crossrootfs/arm/usr/share
30M    /crossrootfs/arm/usr/bin
506M   /crossrootfs/arm/usr
13M    /crossrootfs/arm/lib/udev
11M    /crossrootfs/arm/lib/arm-linux-gnueabihf
31M    /crossrootfs/arm/lib
621M   /crossrootfs/arm
621M   /crossrootfs/
```

Because the resulting images are smaller, they will be faster to pull in CI scenarios and have will have less COGS.