### PR TITLE
Revert use of custom build pool with larger storage space

### DIFF
--- a/eng/pipelines/dotnet-buildtools-prereqs-eng.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-eng.yml
@@ -17,11 +17,5 @@ stages:
   - template: ../common/templates/stages/build-test-publish-repo.yml
     parameters:
       linuxAmdBuildJobTimeout: 210
-      ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        linuxAmdBuildPool: "NetCorePublic-Pool"
-        linuxAmdBuildQueue: "BuildPool.Ubuntu.1604.Amd64.Open"
-      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        linuxAmdBuildPool: "NetCoreInternal-Pool"
-        linuxAmdBuildQueue: "BuildPool.Ubuntu.1604.Amd64"
       customBuildInitSteps:
       - template: /eng/pipelines/steps/install-cross-build-prereqs.yml

--- a/eng/pipelines/dotnet-buildtools-prereqs-ubuntu18.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-ubuntu18.yml
@@ -22,11 +22,5 @@ stages:
   - template: ../common/templates/stages/build-test-publish-repo.yml
     parameters:
       linuxAmdBuildJobTimeout: 150
-      ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        linuxAmdBuildPool: "NetCorePublic-Pool"
-        linuxAmdBuildQueue: "BuildPool.Ubuntu.1604.Amd64.Open"
-      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        linuxAmdBuildPool: "NetCoreInternal-Pool"
-        linuxAmdBuildQueue: "BuildPool.Ubuntu.1604.Amd64"
       customBuildInitSteps:
       - template: /eng/pipelines/steps/install-cross-build-prereqs.yml


### PR DESCRIPTION
This is a test to see if the larger build agents (changes made in https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/283) are necessary with the changes made in https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/33 to cleanup some unnecessary artifacts during the cross builds.