### PR TITLE
Update Ubuntu Dockerfile to configure system-wide locale

### DIFF
--- a/src/ubuntu/16.04/mlnet/Dockerfile
+++ b/src/ubuntu/16.04/mlnet/Dockerfile
@@ -3,3 +3,6 @@ FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04
 # Install openmp support with Clang
 RUN apt-get update \
     && apt-get install -y libomp-9-dev
+
+# Configure system locale
+RUN update-locale LANG=en_US.UTF-8


### PR DESCRIPTION
Related to [ML .NET Issue #5093](https://github.com/dotnet/machinelearning/issues/5093)

The ML .NET Ubuntu Docker instance needs a system-wide locale set. We are re-enabling our ONNX Runtime tests to run on Linux, and this requires installing the language-pack-en package,as noted [here](https://github.com/microsoft/onnxruntime/blob/master/README.md#system-language).