### PR TITLE
Use libomp-dev instead of libomp-9-dev

### DIFF
--- a/src/ubuntu/16.04/mlnet/Dockerfile
+++ b/src/ubuntu/16.04/mlnet/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04
 
 # Install openmp support with Clang
 RUN apt-get update \
-    && apt-get install -y libomp-9-dev
+    && apt-get install -y libomp-dev
 
 # Configure system locale
 RUN update-locale LANG=en_US.UTF-8

--- a/src/ubuntu/16.04/mlnet/Dockerfile
+++ b/src/ubuntu/16.04/mlnet/Dockerfile
@@ -2,7 +2,10 @@ FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04
 
 # Install openmp support with Clang
 RUN apt-get update \
-    && apt-get install -y clang-3.9 libomp5 libomp-dev
+    && apt-get install -y \
+        clang-3.9 \
+        libomp5 \
+        libomp-dev
 
 # Configure system locale
 RUN update-locale LANG=en_US.UTF-8

--- a/src/ubuntu/16.04/mlnet/Dockerfile
+++ b/src/ubuntu/16.04/mlnet/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04
 
 # Install openmp support with Clang
 RUN apt-get update \
-    && apt-get install -y libomp-dev
+    && apt-get install -y clang-3.9 libomp5 libomp-dev
 
 # Configure system locale
 RUN update-locale LANG=en_US.UTF-8


### PR DESCRIPTION
In the ML .NET Ubuntu builds, the `libomp-9-dev` package cannot be installed as shown in the error [here](https://dev.azure.com/dnceng/public/_build/results?buildId=637137&view=logs&j=28859320-f5de-51e0-1fd2-7bea8c11cf7a&t=ed8fb6c3-76d9-56ef-25a2-06e3456edf43&l=94). 

In my most recent PR I added a configure system locale, however I did not see that the current ML .NET ubuntu builds build from the commit made in [March 12 2019](https://github.com/dotnet/dotnet-buildtools-prereqs-docker/commit/207e097213bc9b1151a634eea7efd6529162d31b#diff-564ba60fecb15e91476bd8f0ecd2dcbc) where `libomp-dev` is used, whereas this `libomp-9-dev` was added in a commit made in [October 18, 2019](https://github.com/dotnet/dotnet-buildtools-prereqs-docker/commit/a50a721c89cd6767aee512c5deb5c85af60b14d3#diff-564ba60fecb15e91476bd8f0ecd2dcbc). This PR fixes this installation of the `libomp-dev` package.