### PR TITLE
Downgrade virtualenv to 16.6.0 for Fedora 32 images

### DIFF
--- a/src/fedora/32/helix/amd64/Dockerfile
+++ b/src/fedora/32/helix/amd64/Dockerfile
@@ -14,7 +14,7 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     curl https://bootstrap.pypa.io/get-pip.py -o ./get-pip.py && \
     python ./get-pip.py && rm ./get-pip.py && \
     python -m pip install --upgrade pip==20.1 && \
-    python -m pip install virtualenv==20.0.20 && \
+    python -m pip install virtualenv==16.6.0 && \
     python -m pip install helix-scripts --extra-index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
 
 # Needed for .NET corefx tests to pass
@@ -28,4 +28,4 @@ RUN /usr/sbin/adduser --uid 1000 --shell /bin/bash --group adm helixbot && \
 
 USER helixbot
 
-RUN python -m virtualenv /home/helixbot/.vsts-env
+RUN python -m virtualenv --no-site-packages /home/helixbot/.vsts-env


### PR DESCRIPTION
Needed so that when arcade scripts call it they don't fail because they include `--no-site-packages`.

If we ever want to upgrade to v20+, we'll need either version detection or to change the tool to not fail when the arg is specified.