### PR TITLE
Bug with Alpine 3.12 Docker image

### DIFF
--- a/src/alpine/3.12/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.12/helix/arm64v8/Dockerfile
@@ -55,7 +55,7 @@ ENV LANG=en-US.UTF-8
 
 # create helixbot user and give rights to sudo without password
 # Alpine does not support long options
-RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
+RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1001 helixbot && \
     chmod 755 /root && \
     echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot
 


### PR DESCRIPTION
Helix docker image user ids need to match the host, this was a copy/paste error from the AMD64 ones.