### PR TITLE
Pin ffi gem to a supported version

### DIFF
--- a/src/centos/7/rpmpkg/Dockerfile
+++ b/src/centos/7/rpmpkg/Dockerfile
@@ -7,6 +7,8 @@ RUN yum clean all \
         rpm-build \
         ruby-devel \
         rubygems \
-    && gem install --no-document fpm \
+    && gem install --no-document \
+        ffi:1.12.2 \
+        fpm \
     && yum clean all
 


### PR DESCRIPTION
The build for the CentOS 7 rpm image is failing with the error:
```
ERROR:  Error installing fpm:
	ffi requires Ruby version >= 2.3.
```

This happens because a recent update was made to the ffi gem that has a dependency on Ruby 2.3 but the CentOS 7 package feed only has Ruby 2.0.  The ffi gem gets installed as a dependency of fpm.  To fix this, I've explicitly set ffi to the last supported version that didn't require Ruby 2.3.