### PR TITLE
Add an image to build runtime on illumos

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -510,6 +510,18 @@
         {
           "platforms": [
             {
+              "dockerfile": "src/ubuntu/18.04/cross/illumos",
+              "os": "linux",
+              "osVersion": "bionic",
+              "tags": {
+                "ubuntu-18.04-cross-illumos-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
               "architecture": "arm64",
               "dockerfile": "src/alpine/3.8/helix/arm64v8",
               "os": "linux",

--- a/src/ubuntu/18.04/cross/illumos/Dockerfile
+++ b/src/ubuntu/18.04/cross/illumos/Dockerfile
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-crossdeps
+
+ADD rootfs.x64.tar crossrootfs

--- a/src/ubuntu/18.04/cross/illumos/hooks/post-build
+++ b/src/ubuntu/18.04/cross/illumos/hooks/post-build
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+rm -rf $PWD/rootfs*.tar

--- a/src/ubuntu/18.04/cross/illumos/hooks/pre-build
+++ b/src/ubuntu/18.04/cross/illumos/hooks/pre-build
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+SCRIPT=$(readlink -f "$0")
+SCRIPTPATH=$(dirname "$SCRIPT")
+$SCRIPTPATH/../../../../build-scripts/build-rootfs.sh ubuntu-18.04 illumos x64

--- a/src/ubuntu/18.04/crossdeps/Dockerfile
+++ b/src/ubuntu/18.04/crossdeps/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update \
         liblzma-dev \
         libarchive-dev \
         libbsd-dev \
+        libmpc-dev \
     && rm -rf /var/lib/apt/lists/*
 
 RUN apt-get update \

--- a/src/ubuntu/build-scripts/build-rootfs.sh
+++ b/src/ubuntu/build-scripts/build-rootfs.sh
@@ -31,7 +31,7 @@ fi
 
 echo "Using $dockerCrossDepsTag to clone arcade to fetch scripts used to build cross-toolset"
 docker exec $buildRootFSContainer \
-    git clone --depth 1 https://github.com/dotnet/arcade /scripts
+    git clone --depth 1 --single-branch https://github.com/dotnet/arcade /scripts
 
 if [ $? -ne 0 ]; then
     echo "Rootfs build failed: `git clone https://github.com/dotnet/arcade /scripts` returned error"


### PR DESCRIPTION
The image is built using illumos sysroot from dotnet/arcade, to build products from dotnet/runtime repo.

```sh
$ apt install powershell
$ pwsh -c '.\build.ps1 -DockerfilePath "src/ubuntu/16.04/coredeps"'
$ pwsh -c '.\build.ps1 -DockerfilePath "src/ubuntu/16.04/crossdeps"'
$ pwsh -c '.\build.ps1 -DockerfilePath "src/ubuntu/18.04/cross/illumos"'
$ docker history mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-illumos-20200602195605-6d5e290
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
68c74b23daf9        9 hours ago         /bin/sh -c #(nop) ADD file:5de8ed714224eb70a…   561MB
d306e647904b        10 hours ago        /bin/sh -c apt-get update     && apt-get ins…   895MB
fa9b26a00244        10 hours ago        /bin/sh -c apt-get update     && apt-get ins…   596MB
e005c6da8f75        10 hours ago        /bin/sh -c apt-get update     && apt-get ins…   166MB
6a7da23c946f        10 hours ago        /bin/sh -c apt-get update     && apt-get ins…   464MB
1a1778bdcf68        10 months ago       /bin/sh -c #(nop)  CMD ["pwsh"]                 0B
<missing>           10 months ago       /bin/sh -c #(nop)  LABEL maintainer=PowerShe…   0B
<missing>           10 months ago       /bin/sh -c #(nop)  ARG IMAGE_NAME=mcr.micros…   0B
<missing>           10 months ago       /bin/sh -c #(nop)  ARG VCS_REF=none             0B
<missing>           10 months ago       |3 PS_PACKAGE=powershell_6.2.1-1.ubuntu.18.0…   222MB
<missing>           10 months ago       /bin/sh -c #(nop)  ENV DOTNET_SYSTEM_GLOBALI…   0B
<missing>           10 months ago       /bin/sh -c #(nop) ADD f49113060ce8c3d68a2555…   57.9MB
<missing>           10 months ago       |3 PS_PACKAGE=powershell_6.2.1-1.ubuntu.18.0…   0B
<missing>           10 months ago       /bin/sh -c #(nop)  ARG PS_PACKAGE_URL=https:…   0B
<missing>           10 months ago       /bin/sh -c #(nop)  ARG PS_PACKAGE=powershell…   0B
<missing>           10 months ago       /bin/sh -c #(nop)  ARG PS_VERSION=6.2.0         0B
<missing>           11 months ago       /bin/sh -c #(nop)  CMD ["/bin/bash"]            0B
<missing>           11 months ago       /bin/sh -c mkdir -p /run/systemd && echo 'do…   7B
<missing>           11 months ago       /bin/sh -c set -xe   && echo '#!/bin/sh' > /…   745B
<missing>           11 months ago       /bin/sh -c [ -z "$(apt-get indextargets)" ]     987kB
<missing>           11 months ago       /bin/sh -c #(nop) ADD file:4e6b5d9ca371eb881…   63.2MB
```

Also optimized the dotnet/arcade clone command to make it fetch `depth=1` for one branch (instead of all branches).