### PR TITLE
Add Helix WASM image with v8

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -658,6 +658,19 @@
         {
           "platforms": [
             {
+              "architecture": "amd64",
+              "dockerfile": "src/ubuntu/20.04/helix/wasm/amd64",
+              "os": "linux",
+              "osVersion": "focal",
+              "tags": {
+                "ubuntu-20.04-helix-wasm-amd64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
+              }
+            }
+          ]
+        },        
+        {
+          "platforms": [
+            {
               "architecture": "arm",
               "dockerfile": "src/ubuntu/18.04/helix/arm32v7",
               "os": "linux",

--- a/src/ubuntu/20.04/helix/wasm/amd64/Dockerfile
+++ b/src/ubuntu/20.04/helix/wasm/amd64/Dockerfile
@@ -1,0 +1,64 @@
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# sources tweak is to work around very slow update
+
+RUN apt-get clean && \
+    mv /etc/apt/sources.list /etc/apt/sources.list1 && apt-get update && \
+    mv /etc/apt/sources.list1 /etc/apt/sources.list &&  apt-get update && \
+    apt-get install -qq -y \
+        autoconf \
+        automake \
+        build-essential \
+        cmake \
+        clang \
+        gcc \
+        gdb \
+        git \
+        gss-ntlmssp \
+        iputils-ping \
+        libcurl4 \
+        libffi-dev \
+        libgdiplus \
+        libicu-dev \
+        libtool \
+        libunwind8 \
+        libunwind-dev \
+        lldb-3.9 \
+        locales \
+        locales-all \
+        python3-dev \
+        python3-pip \
+        sudo \
+        tzdata \
+        unzip \
+        libnode-dev \
+        node-gyp npm \
+     && rm -rf /var/lib/apt/lists/* \
+     \
+     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+ENV LANG en_US.utf8
+
+RUN ln -sf /usr/bin/python3 /usr/bin/python && \
+    python -m pip install --upgrade pip==19.3.1 && \
+    python -m pip install virtualenv==16.6.0 && \
+    python -m pip install helix-scripts --extra-index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+
+# create helixbot user and give rights to sudo without password
+RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm helixbot && \
+    chmod 755 /root && \
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
+
+USER helixbot
+
+# Install V8 & other engines in the non-root context
+
+# This gets an ignorable warning described in https://github.com/sudo-project/sudo/issues/42
+RUN sudo npm install jsvu -g && \
+    jsvu --os=linux64 --engines=all
+
+ENV PATH="/home/helixbot/.jsvu:${PATH}"
+
+RUN python -m virtualenv --no-site-packages /home/helixbot/.vsts-env


### PR DESCRIPTION
https://github.com/dotnet/core-eng/issues/10034

This was sufficient to run @steveisok 's sample app so has a decent chance of passing the runtime's normal tests.  

I made the choice to not add this to all Helix machines / default docker images because this engine itself pumps up the image size ~500 MB and that's quite a tax to pay where it's only used in this specific case.