### PR TITLE
Define ARM64 version of testrunner

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -7,6 +7,7 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 pushd $PSScriptRoot
+$ImageBuilderCustomArgs = "$ImageBuilderCustomArgs --var UniqueId=$(Get-Date -Format yyyyMMddHHmmss)"
 try {
     ./eng/common/Invoke-ImageBuilder.ps1 "build --path '$DockerfilePath' $ImageBuilderCustomArgs"
 }

--- a/eng/pipelines/variables/common.yml
+++ b/eng/pipelines/variables/common.yml
@@ -10,6 +10,8 @@ variables:
   value: false
 - name: publicGitRepoUri
   value: https://github.com/dotnet/dotnet-buildtools-prereqs-docker
+- name: manifestVariables
+  value: --var UniqueId=$(sourceBuildId)
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
     - name: build.imageBuilderDockerRunExtraOptions
       value: -e DOCKER_REPO=$(acr.server)/$(stagingRepoPrefix)dotnet-buildtools/prereqs

--- a/manifest.json
+++ b/manifest.json
@@ -182,7 +182,7 @@
         },
         {
           "sharedTags": {
-            "debian-stretch-slim-docker-testrunner": {}
+            "debian-stretch-slim-docker-testrunner-$(UniqueId)": {}
           },
           "platforms": [
             {
@@ -190,7 +190,7 @@
               "os": "linux",
               "osVersion": "stretch",
               "tags": {
-                "debian-stretch-slim-docker-testrunner-amd64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
+                "debian-stretch-slim-docker-testrunner-amd64-$(UniqueId)": {}
               }
             },
             {
@@ -199,7 +199,7 @@
               "os": "linux",
               "osVersion": "stretch",
               "tags": {
-                "debian-stretch-slim-docker-testrunner-arm64v8-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
+                "debian-stretch-slim-docker-testrunner-arm64v8-$(UniqueId)": {}
               },
               "variant": "v8"
             }

--- a/manifest.json
+++ b/manifest.json
@@ -181,14 +181,27 @@
           ]
         },
         {
+          "sharedTags": {
+            "debian-stretch-slim-docker-testrunner-$(System:DockerfileGitCommitSha)": {}
+          },
           "platforms": [
             {
-              "dockerfile": "src/debian/stretch-slim/docker-testrunner",
+              "dockerfile": "src/debian/stretch-slim/docker-testrunner/amd64",
               "os": "linux",
               "osVersion": "stretch",
               "tags": {
-                "debian-stretch-slim-docker-testrunner-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
+                "debian-stretch-slim-docker-testrunner-amd64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
               }
+            },
+            {
+              "architecture": "arm64",
+              "dockerfile": "src/debian/stretch-slim/docker-testrunner/arm64v8",
+              "os": "linux",
+              "osVersion": "stretch",
+              "tags": {
+                "debian-stretch-slim-docker-testrunner-arm64v8-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
+              },
+              "variant": "v8"
             }
           ]
         },

--- a/manifest.json
+++ b/manifest.json
@@ -182,7 +182,7 @@
         },
         {
           "sharedTags": {
-            "debian-stretch-slim-docker-testrunner-$(System:DockerfileGitCommitSha)": {}
+            "debian-stretch-slim-docker-testrunner": {}
           },
           "platforms": [
             {

--- a/src/debian/stretch-slim/docker-testrunner/amd64/Dockerfile
+++ b/src/debian/stretch-slim/docker-testrunner/amd64/Dockerfile
@@ -23,5 +23,5 @@ RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
     && sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-stretch-prod stretch main" > /etc/apt/sources.list.d/microsoft.list' \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-        powershell=6.0.0-1.debian.9 \
+        powershell=7.0.2-1.debian.9 \
     && rm -rf /var/lib/apt/lists/*

--- a/src/debian/stretch-slim/docker-testrunner/arm64v8/Dockerfile
+++ b/src/debian/stretch-slim/docker-testrunner/arm64v8/Dockerfile
@@ -1,0 +1,28 @@
+# Dockerfile used to create a testrunner image that can perform Docker operations.
+# Usage:  docker run --rm -v /var/run/docker.sock:/var/run/docker.sock testrunner pwsh -File xyz.ps1
+
+FROM arm64v8/debian:stretch-slim
+
+# Install Docker
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        apt-transport-https \
+        ca-certificates \
+        curl \
+        gnupg2 \
+        libicu57 \
+        software-properties-common \
+    && curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
+    && add-apt-repository "deb [arch=arm64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        docker-ce=17.12.0~ce-0~debian \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install PowerShell
+RUN curl https://github.com/PowerShell/PowerShell/releases/download/v7.0.2/powershell-7.0.2-linux-arm64.tar.gz -Lo powershell.tar.gz \
+    && echo "8677301996B5335B872D267D41F588C145EEFFA6B9736962530480B4D15CC295  powershell.tar.gz" | sha256sum -c - \
+    && mkdir /usr/share/powershell \
+    && tar -zxf ./powershell.tar.gz -C /usr/share/powershell \
+    && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
+    && rm -f ./powershell-tar.gz


### PR DESCRIPTION
We need an ARM64 version of testrunner so that it can be run on ARM machines.

ARM builds of PowerShell are not available in the Debian package feeds so it is downloaded directly from the GitHub releases URL.  

Defined a multi-arch tag for testrunner to make it simpler to reference.  To avoid issues with needing to have the same timestamp value across multiple build jobs, I decided to just remove that segment of the tag.  Also had to remove the commit SHA from the tag because Image Builder doesn't support that built-in variable in shared tags since there's no build context from which to get a commit.  This uniqueness doesn't really seem necessary for how little this image gets updated.  Let me know what you think.  Otherwise, I'll need to add a custom variable to provide uniqueness.

Related to https://github.com/dotnet/docker-tools/issues/486