### PR TITLE
Add Docker image for PPC64 cross-compile

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -452,6 +452,18 @@
         {
           "platforms": [
             {
+              "dockerfile": "src/ubuntu/18.04/cross/ppc64",
+              "os": "linux",
+              "osVersion": "bionic",
+              "tags": {
+                "ubuntu-18.04-cross-ppc64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
               "dockerfile": "src/ubuntu/18.04/cross/arm64-alpine",
               "os": "linux",
               "osVersion": "bionic",

--- a/src/ubuntu/18.04/cross/ppc64/Dockerfile
+++ b/src/ubuntu/18.04/cross/ppc64/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu-18.04-crossdeps
+
+# Install binutils-powerpc64-linux-gnu
+RUN apt-get update \
+    && apt-get install -y \
+        binutils-powerpc64-linux-gnu \
+    && rm -rf /var/lib/apt/lists/*
+
+ADD rootfs.ppc64.tar crossrootfs

--- a/src/ubuntu/18.04/cross/ppc64/Dockerfile
+++ b/src/ubuntu/18.04/cross/ppc64/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu-18.04-crossdeps
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-crossdeps
 
 # Install binutils-powerpc64-linux-gnu
 RUN apt-get update \

--- a/src/ubuntu/18.04/cross/ppc64/hooks/post-build
+++ b/src/ubuntu/18.04/cross/ppc64/hooks/post-build
@@ -1,0 +1,1 @@
+../../../../build-scripts/build-rootfs-cleanup.sh

--- a/src/ubuntu/18.04/cross/ppc64/hooks/pre-build
+++ b/src/ubuntu/18.04/cross/ppc64/hooks/pre-build
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+SCRIPT=$(readlink -f "$0")
+SCRIPTPATH=$(dirname "$SCRIPT")
+$SCRIPTPATH/../../../../build-scripts/build-rootfs.sh ubuntu-18.04 sid ppc64 nolldb

--- a/src/ubuntu/18.04/crossdeps/Dockerfile
+++ b/src/ubuntu/18.04/crossdeps/Dockerfile
@@ -38,3 +38,7 @@ RUN apt-get update \
         python-lldb-6.0 \
     && rm -rf /var/lib/apt/lists/*
 
+RUN wget -O /tmp/keyring.deb http://http.us.debian.org/debian/pool/main/d/debian-ports-archive-keyring/debian-ports-archive-keyring_2019.11.05_all.deb \
+    && dpkg -i /tmp/keyring.deb \
+    && rm /tmp/keyring.deb
+


### PR DESCRIPTION
This targets a cross of Debian Unstable, because there's no easy way right now to produce a crossrootfs to target an RPM-based distribution (CentOS 7 would be preferred), and PPC64 is an unofficial Debian port without any stable release candidate.

s390x would be a nicer big-endian target to work with, but we have PPC inside corpnet, whilst we'd need to use externally hosted test hardware for s390x

Ref: https://github.com/dotnet/arcade/pull/5841
Ref: https://garagehackbox.azurewebsites.net/hackathons/2107/projects/91897