### PR TITLE
Add ARM MUSL cross-build image

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -440,6 +440,18 @@
         {
           "platforms": [
             {
+              "dockerfile": "src/ubuntu/18.04/cross/arm-alpine",
+              "os": "linux",
+              "osVersion": "bionic",
+              "tags": {
+                "ubuntu-18.04-cross-arm-alpine-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
               "dockerfile": "src/ubuntu/18.04/cross/arm64-alpine",
               "os": "linux",
               "osVersion": "bionic",

--- a/src/ubuntu/18.04/cross/arm-alpine/Dockerfile
+++ b/src/ubuntu/18.04/cross/arm-alpine/Dockerfile
@@ -1,0 +1,20 @@
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-crossdeps
+
+# Install bison. This is required to build musl-cross-make
+RUN apt-get update \
+    && apt-get install -y \
+        bison \
+    && rm -rf /var/lib/apt/lists/*
+
+# Workaround to build a functioning ld.gold which can link for linux-musl arm
+RUN cd /tmp \
+    && wget https://ftp.gnu.org/gnu/binutils/binutils-2.31.1.tar.gz \
+    && tar -xf binutils-2.31.1.tar.gz \
+    && cd binutils-2.31.1 \
+    && ./configure --disable-werror --target=armv7-alpine-linux-musleabihf --prefix=/usr --libdir=/lib --disable-multilib --with-sysroot=armv7-alpine-linux-musleabihf --enable-gold=yes --enable-plugins=yes --program-prefix=armv7-alpine-linux-musleabihf- \
+    && make \
+    && make install \
+    && cd .. \
+    && rm -r *
+
+ADD rootfs.arm.tar crossrootfs

--- a/src/ubuntu/18.04/cross/arm-alpine/Dockerfile
+++ b/src/ubuntu/18.04/cross/arm-alpine/Dockerfile
@@ -11,7 +11,16 @@ RUN cd /tmp \
     && wget https://ftp.gnu.org/gnu/binutils/binutils-2.31.1.tar.gz \
     && tar -xf binutils-2.31.1.tar.gz \
     && cd binutils-2.31.1 \
-    && ./configure --disable-werror --target=armv7-alpine-linux-musleabihf --prefix=/usr --libdir=/lib --disable-multilib --with-sysroot=armv7-alpine-linux-musleabihf --enable-gold=yes --enable-plugins=yes --program-prefix=armv7-alpine-linux-musleabihf- \
+    && ./configure \
+        --disable-werror \
+        --target=armv7-alpine-linux-musleabihf \
+        --prefix=/usr \
+        --libdir=/lib \
+        --disable-multilib \
+        --with-sysroot=armv7-alpine-linux-musleabihf \
+        --enable-gold=yes \
+        --enable-plugins=yes \
+        --program-prefix=armv7-alpine-linux-musleabihf- \
     && make \
     && make install \
     && cd .. \

--- a/src/ubuntu/18.04/cross/arm-alpine/hooks/post-build
+++ b/src/ubuntu/18.04/cross/arm-alpine/hooks/post-build
@@ -1,0 +1,1 @@
+../../../../build-scripts/build-rootfs-cleanup.sh

--- a/src/ubuntu/18.04/cross/arm-alpine/hooks/pre-build
+++ b/src/ubuntu/18.04/cross/arm-alpine/hooks/pre-build
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+SCRIPT=$(readlink -f "$0")
+SCRIPTPATH=$(dirname "$SCRIPT")
+$SCRIPTPATH/../../../../build-scripts/build-rootfs.sh ubuntu-18.04 alpine arm lldb3.9


### PR DESCRIPTION
Add new docker Ubuntu 18.04 image for cross-builds targetting
ARM MUSL distros.