### PR TITLE
Disable building of ARM32 Helix images

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -578,20 +578,6 @@
         {
           "platforms": [
             {
-              "architecture": "arm",
-              "dockerfile": "src/ubuntu/16.04/helix/arm32v7",
-              "os": "linux",
-              "osVersion": "xenial",
-              "tags": {
-                "ubuntu-16.04-helix-arm32v7-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
-              },
-              "variant": "v7"
-            }
-          ]
-        },
-        {
-          "platforms": [
-            {
               "architecture": "arm64",
               "dockerfile": "src/ubuntu/16.04/helix/arm64v8",
               "os": "linux",
@@ -680,20 +666,6 @@
               }
             }
           ]
-        },        
-        {
-          "platforms": [
-            {
-              "architecture": "arm",
-              "dockerfile": "src/ubuntu/18.04/helix/arm32v7",
-              "os": "linux",
-              "osVersion": "bionic",
-              "tags": {
-                "ubuntu-18.04-helix-arm32v7-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
-              },
-              "variant": "v7"
-            }
-          ]
         },
         {
           "platforms": [
@@ -740,20 +712,6 @@
         {
           "platforms": [
             {
-              "architecture": "arm",
-              "dockerfile": "src/debian/9/helix/arm32v7",
-              "os": "linux",
-              "osVersion": "stretch",
-              "tags": {
-                "debian-9-helix-arm32v7-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
-              },
-              "variant": "v7"
-            }
-          ]
-        },
-        {
-          "platforms": [
-            {
               "architecture": "arm64",
               "dockerfile": "src/debian/9/arm64v8",
               "os": "linux",
@@ -789,20 +747,6 @@
               "tags": {
                 "debian-10-helix-amd64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
               }
-            }
-          ]
-        },
-        {
-          "platforms": [
-            {
-              "architecture": "arm",
-              "dockerfile": "src/debian/10/helix/arm32v7",
-              "os": "linux",
-              "osVersion": "buster",
-              "tags": {
-                "debian-10-helix-arm32v7-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
-              },
-              "variant": "v7"
             }
           ]
         },


### PR DESCRIPTION
Disabling these images to workaround #359 and unblock builds.