### PR TITLE
Fix issue 359 - python wheel utilities have a bug where they infer architecture from host machine

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -578,6 +578,20 @@
         {
           "platforms": [
             {
+              "architecture": "arm",
+              "dockerfile": "src/ubuntu/16.04/helix/arm32v7",
+              "os": "linux",
+              "osVersion": "xenial",
+              "tags": {
+                "ubuntu-16.04-helix-arm32v7-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
+              },
+              "variant": "v7"
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
               "architecture": "arm64",
               "dockerfile": "src/ubuntu/16.04/helix/arm64v8",
               "os": "linux",
@@ -666,6 +680,20 @@
               }
             }
           ]
+        },        
+        {
+          "platforms": [
+            {
+              "architecture": "arm",
+              "dockerfile": "src/ubuntu/18.04/helix/arm32v7",
+              "os": "linux",
+              "osVersion": "bionic",
+              "tags": {
+                "ubuntu-18.04-helix-arm32v7-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
+              },
+              "variant": "v7"
+            }
+          ]
         },
         {
           "platforms": [
@@ -712,6 +740,20 @@
         {
           "platforms": [
             {
+              "architecture": "arm",
+              "dockerfile": "src/debian/9/helix/arm32v7",
+              "os": "linux",
+              "osVersion": "stretch",
+              "tags": {
+                "debian-9-helix-arm32v7-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
+              },
+              "variant": "v7"
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
               "architecture": "arm64",
               "dockerfile": "src/debian/9/arm64v8",
               "os": "linux",
@@ -747,6 +789,20 @@
               "tags": {
                 "debian-10-helix-amd64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
               }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "architecture": "arm",
+              "dockerfile": "src/debian/10/helix/arm32v7",
+              "os": "linux",
+              "osVersion": "buster",
+              "tags": {
+                "debian-10-helix-arm32v7-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
+              },
+              "variant": "v7"
             }
           ]
         },

--- a/src/alpine/3.9/arm32v7/Dockerfile
+++ b/src/alpine/3.9/arm32v7/Dockerfile
@@ -1,5 +1,8 @@
 FROM arm32v7/alpine:3.9
 
+# Workaround: https://github.com/pypa/wheel/issues/367
+ENV _PYTHON_HOST_PLATFORM linux_armv7l
+
 RUN apk update
 
 RUN apk add --no-cache \

--- a/src/debian/10/helix/arm32v7/Dockerfile
+++ b/src/debian/10/helix/arm32v7/Dockerfile
@@ -1,5 +1,8 @@
 FROM arm32v7/debian:buster
 
+# Workaround: https://github.com/pypa/wheel/issues/367
+ENV _PYTHON_HOST_PLATFORM linux_armv7l
+
 # Install Helix Dependencies
 
 RUN apt-get update && \

--- a/src/debian/9/helix/arm32v7/Dockerfile
+++ b/src/debian/9/helix/arm32v7/Dockerfile
@@ -2,6 +2,9 @@ FROM arm32v7/debian:9
 
 # Install Helix Dependencies
 
+# Workaround: https://github.com/pypa/wheel/issues/367
+ENV _PYTHON_HOST_PLATFORM linux_armv7l
+
 RUN apt-get update && \
     apt-get install -y \
         autoconf \

--- a/src/ubuntu/16.04/helix/arm32v7/Dockerfile
+++ b/src/ubuntu/16.04/helix/arm32v7/Dockerfile
@@ -2,6 +2,9 @@ FROM arm32v7/ubuntu:16.04
 
 # Install Helix Dependencies 
 
+# Workaround: https://github.com/pypa/wheel/issues/367
+ENV _PYTHON_HOST_PLATFORM linux_armv7l
+
 # Can remove the mono preview repo when we no longer depend on pre-release libgdiplus
 
 RUN apt-get update && \

--- a/src/ubuntu/18.04/helix/arm32v7/Dockerfile
+++ b/src/ubuntu/18.04/helix/arm32v7/Dockerfile
@@ -4,6 +4,9 @@ FROM arm32v7/ubuntu:18.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
+# Workaround: https://github.com/pypa/wheel/issues/367
+ENV _PYTHON_HOST_PLATFORM linux_armv7l
+
 # Can remove the mono preview repo when we no longer depend on pre-release libgdiplus
 
 RUN apt-get update && \


### PR DESCRIPTION
See https://github.com/pypa/wheel/issues/367 for motivations here.  Setting `_PYTHON_HOST_PLATFORM linux_armv7l` allows these images to build and install python correctly (hence adding it to one image that didn't break before, as it would later) for the architecture the docker image thinks it has (`arm32v7`) instead of the host (typically `arm64v8`)