### PR TITLE
Add locale gen to Ubuntu 18.04 and Debian stretch/9 to avoid MSBuild warning

### DIFF
--- a/src/debian/stretch/Dockerfile
+++ b/src/debian/stretch/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update \
             libunwind8-dev \
             lldb-3.9 \
             llvm \
+            locales \
             make \
             python-lldb-3.9 \
             sudo \
@@ -41,6 +42,13 @@ RUN apt-get update \
 RUN curl -sL https://deb.nodesource.com/setup_9.x | bash - \
     && apt-get install -y nodejs \
     && npm install -g azure-cli --unsafe-perm
+
+# .NET SDK MSBuild requires US.UTF-8 locale to execute tasks
+# These commands are from https://askubuntu.com/a/1027038
+RUN echo "locales locales/default_environment_locale select en_US.UTF-8" | debconf-set-selections \
+    && echo "locales locales/locales_to_be_generated multiselect en_US.UTF-8 UTF-8" | debconf-set-selections \
+    && rm "/etc/locale.gen" \
+    && dpkg-reconfigure --frontend noninteractive locales
 
 # Until official packages are available, we have to restore the ubuntu ones instead.
 ENV __PUBLISH_RID=ubuntu.14.04-x64

--- a/src/ubuntu/16.04/Dockerfile
+++ b/src/ubuntu/16.04/Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get install -y git \
     npm cache clean
 
 # .NET SDK MSBuild requires US.UTF-8 locale to execute tasks
-RUN locale-gen en_US.UTF-8 
+RUN locale-gen en_US.UTF-8
 
 # Dependencies for CoreCLR, Mono and CoreFX
 RUN apt-get install -y \

--- a/src/ubuntu/18.04/amd64/Dockerfile
+++ b/src/ubuntu/18.04/amd64/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
         liblldb-3.9-dev \
         lldb-3.9 \
         llvm-3.9 \
+        locales \
         make \
         python-lldb-3.9 \
         sudo \
@@ -28,6 +29,9 @@ RUN apt-get update \
         tar \
         zip \
     && rm -rf /var/lib/apt/lists/*
+
+# .NET SDK MSBuild requires US.UTF-8 locale to execute tasks
+RUN locale-gen en_US.UTF-8
 
 # Install Azure CLI
 RUN apt-get update \


### PR DESCRIPTION
Apply the locale generation workaround from https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/284 (Ubuntu 16.04) to Ubuntu 18.04 and Debian 9 as well, to prevent an MSBuild warning when it forces `en_US.UTF-8` (for no known good reason): https://github.com/dotnet/msbuild/issues/4194. This lets us treat warnings as errors, which is standard across Arcade-using repos. This will be useful for arcade-powered source-build because warnings can give good insight--we also probably want to avoid flooding the AzDO UI with warnings. Tested before/after locally, and this works.

(The Debian one took a little more work to track down--the Ubuntu workaround silently doesn't do anything useful.)

/cc @dseefeld @crummel 