### PR TITLE
Fix repo path to install cross build prereqs

### DIFF
--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -50,6 +50,7 @@ jobs:
         $manifest = "$buildRepoName/$(manifest)"
         $testResultsDirectory = "$buildRepoName/$testResultsDirectory"
 
+        echo "##vso[task.setvariable variable=buildRepoName]$buildRepoName"
         echo "##vso[task.setvariable variable=manifest]$manifest"
         echo "##vso[task.setvariable variable=engCommonPath]$engCommonPath"
         echo "##vso[task.setvariable variable=engPath]$engPath"

--- a/eng/pipelines/steps/install-cross-build-prereqs.yml
+++ b/eng/pipelines/steps/install-cross-build-prereqs.yml
@@ -1,4 +1,4 @@
 steps:
-- script: ./dotnet-buildtools-prereqs-docker/src/ubuntu/build-scripts/install-cross-build-prereqs.sh
+- script: ./$(buildRepoName)/src/ubuntu/build-scripts/install-cross-build-prereqs.sh
   displayName: Install Cross Build Pre-Reqs
   condition: and(succeeded(), contains(variables.imageBuilderPaths, '/cross'))


### PR DESCRIPTION
The path had been hardcoded but the name of the repo actually varies based on the name of the pipeline, of which there are several for this repo.