### PR TITLE
Install clang-tools-9 on Ubuntu 16.04 and 18.04 cross-building images.

### DIFF
--- a/src/ubuntu/16.04/crossdeps/Dockerfile
+++ b/src/ubuntu/16.04/crossdeps/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update \
     && apt-get update \
     && apt-get install -y \
         clang-9 \
+        clang-tools-9 \
         liblldb-6.0-dev \
         lldb-6.0 \
         llvm-9 \

--- a/src/ubuntu/18.04/crossdeps/Dockerfile
+++ b/src/ubuntu/18.04/crossdeps/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update \
 RUN apt-get update \
     && apt-get install -y \
         clang-9 \
+        clang-tools-9 \
         liblldb-6.0-dev \
         lldb-6.0 \
         llvm-9 \


### PR DESCRIPTION
clang-tools-9 depends on libclang-1-9 (among other things), which
contains libclang. Mono's offsets-tool generates data structure access
offsets for cross-compiled target architectures by parsing Mono headers
using libclang.