### PR TITLE
add libicu to Centos 8 Helix  image

### DIFF
--- a/src/centos/8/helix/amd64/Dockerfile
+++ b/src/centos/8/helix/amd64/Dockerfile
@@ -9,6 +9,7 @@ RUN dnf install --setopt tsflags=nodocs --refresh -y \
     && \
     dnf install --setopt tsflags=nodocs -y \
         gcc \
+        libicu \
         python3 \
         python3-devel \
         sudo \


### PR DESCRIPTION
This if follow-up on  #389. It seems like some tests are failing because of missing libicu. 
I don't see it in Centos7 Docker files but I think we use full VM instead of docker for testing. 
Hopefully this should fix:
```
===========================================================================================================
/root/helix/work/workitem /root/helix/work/workitem
CLR: Managed code called FailFast, saying "Couldn't find a valid ICU package installed on the system. Set the configuration flag System.Globalization.Invariant to true if you want to run with no globalization support."


``` 