### PR TITLE
Update devtoolset-7 to devtoolset-9

### DIFF
--- a/src/centos/7/Dockerfile
+++ b/src/centos/7/Dockerfile
@@ -11,7 +11,7 @@ RUN yum install -y \
         "perl(Time::HiRes)" \
         autoconf \
         automake \
-        devtoolset-7-gcc* \
+        devtoolset-9-gcc* \
         doxygen \
         gdb \
         git \
@@ -78,7 +78,7 @@ RUN wget ftp://sourceware.org/pub/binutils/snapshots/binutils-2.29.1.tar.xz && \
     \
     mkdir llvmbuild && \
     cd llvmbuild && \
-    scl enable devtoolset-7 'cmake \
+    scl enable devtoolset-9 'cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DLLVM_LIBDIR_SUFFIX=64\
         -DLLVM_ENABLE_EH=1 \
@@ -86,13 +86,18 @@ RUN wget ftp://sourceware.org/pub/binutils/snapshots/binutils-2.29.1.tar.xz && \
         -DLLVM_BINUTILS_INCDIR=../binutils-2.29.1/include \
         ../llvm-9.0.0.src' \
     && \
-    scl enable devtoolset-7 'make -j $(($(getconf _NPROCESSORS_ONLN)+1))' && \
+    scl enable devtoolset-9 'make -j $(($(getconf _NPROCESSORS_ONLN)+1))' && \
     make install && \
     cd .. && \
     rm -r llvmbuild && \
     rm -r llvm-9.0.0.src && \
     rm -r binutils-2.29.1
 
-# Create gcc-7 symlink available in PATH
-RUN ln -s /opt/rh/devtoolset-7/root/usr/bin/gcc /usr/local/bin/gcc-7 && \
-    ln -s /opt/rh/devtoolset-7/root/usr/bin/g++ /usr/local/bin/g++-7
+# Create gcc-9 symlink available in PATH
+RUN ln -s /opt/rh/devtoolset-9/root/usr/bin/gcc /usr/local/bin/gcc-9 && \
+    ln -s /opt/rh/devtoolset-9/root/usr/bin/g++ /usr/local/bin/g++-9
+
+# Create symlink for clang-9's gcc toolchain lookup (used for libgcc, libstdc++ etc.), which does not recognize devtoolset-9
+# https://github.com/llvm/llvm-project/blob/release/9.x/clang/lib/Driver/ToolChains/Gnu.cpp#L1906
+# (it was later added in clang-10 branch)
+RUN ln -s /opt/rh/devtoolset-9 /opt/rh/devtoolset-8

--- a/src/centos/7/source-build/Dockerfile
+++ b/src/centos/7/source-build/Dockerfile
@@ -11,7 +11,7 @@ RUN yum install -y \
         "perl(Time::HiRes)" \
         autoconf \
         automake \
-        devtoolset-7-gcc* \
+        devtoolset-9-gcc* \
         doxygen \
         gdb \
         git \


### PR DESCRIPTION
Currently, old gcc v7 is used to custom compile llvm-toolchian v9 (this llvm-toolchain is used for official builds). Same gcc version is used in a (single) leg that runtime repo has for gcc build validation.

This PR updates gcc to v9x (currently at 9.3), which continues to compile llvm-toolchain v9, and makes it possible to validate runtime build with recent gcc version.