### PR TITLE
add openssl executable to Centos 8 helix image

### DIFF
--- a/src/centos/8/helix/amd64/Dockerfile
+++ b/src/centos/8/helix/amd64/Dockerfile
@@ -10,6 +10,7 @@ RUN dnf install --setopt tsflags=nodocs --refresh -y \
     dnf install --setopt tsflags=nodocs -y \
         gcc \
         libicu \
+        openssl \
         python3 \
         python3-devel \
         sudo \


### PR DESCRIPTION
at least one of the runtime tests depends on openssl app to determined ciphers openssl was compiled with. This change adds 1M in size. 

contributes to https://github.com/dotnet/runtime/issues/972

 