### PR TITLE
Fix LLVM repo URL

### DIFF
--- a/src/ubuntu/16.04/Dockerfile
+++ b/src/ubuntu/16.04/Dockerfile
@@ -5,8 +5,8 @@ FROM ubuntu:16.04
 # them in a different layer.
 RUN apt-get update && \
     apt-get install -y apt-transport-https ca-certificates gnupg software-properties-common wget && \
-    echo "deb http://llvm.org/apt/xenial/ llvm-toolchain-xenial-9 main" | tee -a /etc/apt/sources.list.d/llvm.list && \
-    wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | apt-key add - && \
+    echo "deb https://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main" | tee -a /etc/apt/sources.list.d/llvm.list && \
+    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
     wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc | apt-key add - && \
     apt-add-repository 'deb https://apt.kitware.com/ubuntu/ xenial main' && \
     apt-get update && \

--- a/src/ubuntu/16.04/debpkg/Dockerfile
+++ b/src/ubuntu/16.04/debpkg/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # liblldb is needed so deb package build does not throw missing library info errors
-RUN echo "deb http://llvm.org/apt/xenial/ llvm-toolchain-xenial-3.9 main" > /etc/apt/sources.list.d/llvm-toolchain.list \
+RUN echo "deb https://apt.llvm.org/xenial/ llvm-toolchain-xenial-3.9 main" > /etc/apt/sources.list.d/llvm-toolchain.list \
     && apt-get update \
     && apt-get -y install liblldb-3.9 \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The build for Ubuntu 16.04 is failing with the error:
```
W: The repository 'http://llvm.org/apt/xenial llvm-toolchain-xenial-9 Release' does not have a Release file.
E: Failed to fetch https://llvm.org/apt/xenial/dists/llvm-toolchain-xenial-9/main/binary-amd64/Packages  Protocol "http" not supported or disabled in libcurl
E: Some index files failed to download. They have been ignored, or old ones used instead.
```

By updating the format of the URL from `http://llvm.org/apt` to `https://apt.llvm.org`, it fixes the issue.