### PR TITLE
Work around https://github.com/pypa/get-pip/issues/83

### DIFF
--- a/src/debian/9/helix/arm32v7/Dockerfile
+++ b/src/debian/9/helix/arm32v7/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && \
 ENV LANG en_US.utf8
 
 RUN ln -sf /usr/bin/python3 /usr/bin/python && \
-    curl https://bootstrap.pypa.io/get-pip.py -o ./get-pip.py --fail --silent --show-error && \
+    curl https://bootstrap.pypa.io/3.5/get-pip.py -o ./get-pip.py --fail --silent --show-error && \
     python ./get-pip.py && rm ./get-pip.py && \
     python -m pip install --upgrade pip==20.2 && \
     python -m pip install virtualenv==16.6.0 && \

--- a/src/debian/9/helix/arm64v8/Dockerfile
+++ b/src/debian/9/helix/arm64v8/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update && \
 ENV LANG en_US.utf8
 
 RUN ln -sf /usr/bin/python3 /usr/bin/python && \
-    curl https://bootstrap.pypa.io/get-pip.py -o ./get-pip.py --fail --silent --show-error && \
+    curl https://bootstrap.pypa.io/3.5/get-pip.py -o ./get-pip.py --fail --silent --show-error && \
     python ./get-pip.py && rm ./get-pip.py && \
     python -m pip install --upgrade pip==20.2 && \
     python -m pip install virtualenv==16.6.0 && \


### PR DESCRIPTION
These versions of Debian are stuck on Python 3.5.* in the base image, and until we have to, we won't force the update.