### PR TITLE
Adding V8 engine to webassembly container in order to run trimming tests

### DIFF
--- a/src/ubuntu/18.04/webassembly/Dockerfile
+++ b/src/ubuntu/18.04/webassembly/Dockerfile
@@ -24,3 +24,13 @@ RUN git clone https://github.com/emscripten-core/emsdk.git ${EMSDK_PATH} \
     && ./emsdk install ${EMSCRIPTEN_VERSION}-upstream \
     && ./emsdk activate ${EMSCRIPTEN_VERSION}-upstream \
     && chmod -R 777 ${EMSDK_PATH}
+
+# Install V8 Engine to be able to execute Trimming Tests
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \
+    && apt install -y nodejs \
+    && npm install jsvu -g \
+    && export PATH="${HOME}/.jsvu:${PATH}" \
+    && jsvu --os=linux64 --engines=javascriptcore,spidermonkey,v8 \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/root/.jsvu:${PATH}"


### PR DESCRIPTION
cc: @safern @mthalman @akoeplinger @MichaelSimons 

Contributes to https://github.com/dotnet/runtime/issues/39274

dotnet/runtime trimming tests are executing during build-time (not executed in Helix) and today we are not running them on the wasm vertical due to the fact that our webassembly build container doesn't have v8 installed in order to be able to execute webassmebly app bundles. This PR will add the v8 engine to the webassembly container, and a subsequent PR in dotnet/runtime will use this new container to add a wasm leg for our trimming tests.