### PR TITLE
Add Docker images for legacy Mono CI

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -664,7 +664,10 @@
               "os": "linux",
               "osVersion": "bionic",
               "tags": {
-                "ubuntu-18.04-helix-arm32v7-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
+                "ubuntu-18.04-helix-arm32v7-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "ubuntu-18.04-helix-arm32v7": {
+                    "isLocal": true
+                }
               },
               "variant": "v7"
             }
@@ -678,7 +681,10 @@
               "os": "linux",
               "osVersion": "bionic",
               "tags": {
-                "ubuntu-18.04-helix-arm64v8-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
+                "ubuntu-18.04-helix-arm64v8-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "ubuntu-18.04-helix-arm64v8": {
+                    "isLocal": true
+                }
               },
               "variant": "v8"
             }

--- a/manifest.json
+++ b/manifest.json
@@ -664,10 +664,7 @@
               "os": "linux",
               "osVersion": "bionic",
               "tags": {
-                "ubuntu-18.04-helix-arm32v7-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-18.04-helix-arm32v7": {
-                    "isLocal": true
-                }
+                "ubuntu-18.04-helix-arm32v7-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
               },
               "variant": "v7"
             }
@@ -681,10 +678,7 @@
               "os": "linux",
               "osVersion": "bionic",
               "tags": {
-                "ubuntu-18.04-helix-arm64v8-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-18.04-helix-arm64v8": {
-                    "isLocal": true
-                }
+                "ubuntu-18.04-helix-arm64v8-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
               },
               "variant": "v8"
             }

--- a/manifest.json
+++ b/manifest.json
@@ -709,6 +709,47 @@
         {
           "platforms": [
             {
+              "architecture": "arm",
+              "dockerfile": "src/ubuntu/18.04/mono/arm32v7",
+              "os": "linux",
+              "osVersion": "bionic",
+              "tags": {
+                "ubuntu-18.04-mono-arm32v7-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
+              },
+              "variant": "v7"
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "architecture": "arm64",
+              "dockerfile": "src/ubuntu/18.04/mono/arm64v8",
+              "os": "linux",
+              "osVersion": "bionic",
+              "tags": {
+                "ubuntu-18.04-mono-arm64v8-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
+              },
+              "variant": "v8"
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "architecture": "amd64",
+              "dockerfile": "src/ubuntu/18.04/mono/amd64",
+              "os": "linux",
+              "osVersion": "bionic",
+              "tags": {
+                "ubuntu-18.04-mono-amd64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
               "architecture": "amd64",
               "dockerfile": "src/ubuntu/18.04/helix/sqlserver/amd64",
               "os": "linux",

--- a/src/ubuntu/18.04/mono/amd64/Dockerfile
+++ b/src/ubuntu/18.04/mono/amd64/Dockerfile
@@ -1,17 +1,37 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-amd64
+FROM ubuntu:18.04
 
-USER root
+# Install Mono build dependencies
+ENV DEBIAN_FRONTEND noninteractive
 
-# Install additional Mono build dependencies
-RUN apt-get update \
-    && apt-get install -qq -y \
+RUN apt-get update && \
+    apt-get install -qq -y \
         autoconf \
-        libtool \
         automake \
-        build-essential \
-        gettext \
-        wget \
         bc \
-    && rm -rf /var/lib/apt/lists/*
+        build-essential \
+        cmake \
+        gcc \
+        gdb \
+        gettext \
+        git \
+        libgdiplus \
+        libtool \
+        locales \
+        locales-all \
+        python3 \
+        sudo \
+        tzdata \
+        unzip \
+        wget \
+    && rm -rf /var/lib/apt/lists/* \
+    \
+    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+ENV LANG en_US.utf8
+
+# create helixbot user and give rights to sudo without password
+RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm helixbot && \
+    chmod 755 /root && \
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
 
 USER helixbot

--- a/src/ubuntu/18.04/mono/amd64/Dockerfile
+++ b/src/ubuntu/18.04/mono/amd64/Dockerfile
@@ -1,0 +1,17 @@
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-amd64
+
+USER root
+
+# Install additional Mono build dependencies
+RUN apt-get update \
+    && apt-get install -qq -y \
+        autoconf \
+        libtool \
+        automake \
+        build-essential \
+        gettext \
+        wget \
+        bc \
+    && rm -rf /var/lib/apt/lists/*
+
+USER helixbot

--- a/src/ubuntu/18.04/mono/amd64/Dockerfile
+++ b/src/ubuntu/18.04/mono/amd64/Dockerfile
@@ -29,9 +29,9 @@ RUN apt-get update && \
 
 ENV LANG en_US.utf8
 
-# create helixbot user and give rights to sudo without password
-RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm helixbot && \
+# create monobot user and give rights to sudo without password
+RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm monobot && \
     chmod 755 /root && \
-    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
+    echo "monobot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
 
-USER helixbot
+USER monobot

--- a/src/ubuntu/18.04/mono/arm32v7/Dockerfile
+++ b/src/ubuntu/18.04/mono/arm32v7/Dockerfile
@@ -30,12 +30,12 @@ RUN apt-get update && \
 
 ENV LANG en_US.utf8
 
-# create helixbot user and give rights to sudo without password
-RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm helixbot && \
+# create monobot user and give rights to sudo without password
+RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm monobot && \
     chmod 755 /root && \
-    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
+    echo "monobot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
 
-USER helixbot
+USER monobot
 
 LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/bin/nodejs"
 

--- a/src/ubuntu/18.04/mono/arm32v7/Dockerfile
+++ b/src/ubuntu/18.04/mono/arm32v7/Dockerfile
@@ -1,25 +1,41 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm32v7
+FROM arm32v7/ubuntu:18.04
 
-USER root
+# Install Mono build dependencies
+ENV DEBIAN_FRONTEND noninteractive
 
-# Install additional Mono build dependencies
-RUN apt-get update \
-    && apt-get install -qq -y \
+RUN apt-get update && \
+    apt-get install -qq -y \
         autoconf \
-        libtool \
         automake \
-        build-essential \
-        gettext \
-        wget \
         bc \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install Node.js and configure it so AzDO knows to use it
-RUN apt-get update \
-    && apt-get install -qq -y \
+        build-essential \
+        cmake \
+        gcc \
+        gdb \
+        gettext \
+        git \
         nodejs \
-    && rm -rf /var/lib/apt/lists/*
+        libgdiplus \
+        libtool \
+        locales \
+        locales-all \
+        python3 \
+        sudo \
+        tzdata \
+        unzip \
+        wget \
+    && rm -rf /var/lib/apt/lists/* \
+    \
+    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+ENV LANG en_US.utf8
+
+# create helixbot user and give rights to sudo without password
+RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm helixbot && \
+    chmod 755 /root && \
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
+
+USER helixbot
 
 LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/bin/nodejs"
 
-USER helixbot

--- a/src/ubuntu/18.04/mono/arm32v7/Dockerfile
+++ b/src/ubuntu/18.04/mono/arm32v7/Dockerfile
@@ -1,0 +1,25 @@
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm32v7
+
+USER root
+
+# Install additional Mono build dependencies
+RUN apt-get update \
+    && apt-get install -qq -y \
+        autoconf \
+        libtool \
+        automake \
+        build-essential \
+        gettext \
+        wget \
+        bc \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js and configure it so AzDO knows to use it
+RUN apt-get update \
+    && apt-get install -qq -y \
+        nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/bin/nodejs"
+
+USER helixbot

--- a/src/ubuntu/18.04/mono/arm64v8/Dockerfile
+++ b/src/ubuntu/18.04/mono/arm64v8/Dockerfile
@@ -1,0 +1,17 @@
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8
+
+USER root
+
+# Install additional Mono build dependencies
+RUN apt-get update \
+    && apt-get install -qq -y \
+        autoconf \
+        libtool \
+        automake \
+        build-essential \
+        gettext \
+        wget \
+        bc \
+    && rm -rf /var/lib/apt/lists/*
+
+USER helixbot

--- a/src/ubuntu/18.04/mono/arm64v8/Dockerfile
+++ b/src/ubuntu/18.04/mono/arm64v8/Dockerfile
@@ -29,9 +29,9 @@ RUN apt-get update && \
 
 ENV LANG en_US.utf8
 
-# create helixbot user and give rights to sudo without password
-RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm helixbot && \
+# create monobot user and give rights to sudo without password
+RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm monobot && \
     chmod 755 /root && \
-    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
+    echo "monobot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
 
-USER helixbot
+USER monobot

--- a/src/ubuntu/18.04/mono/arm64v8/Dockerfile
+++ b/src/ubuntu/18.04/mono/arm64v8/Dockerfile
@@ -1,17 +1,37 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8
+FROM arm64v8/ubuntu:18.04
 
-USER root
+# Install Mono build dependencies
+ENV DEBIAN_FRONTEND noninteractive
 
-# Install additional Mono build dependencies
-RUN apt-get update \
-    && apt-get install -qq -y \
+RUN apt-get update && \
+    apt-get install -qq -y \
         autoconf \
-        libtool \
         automake \
-        build-essential \
-        gettext \
-        wget \
         bc \
-    && rm -rf /var/lib/apt/lists/*
+        build-essential \
+        cmake \
+        gcc \
+        gdb \
+        gettext \
+        git \
+        libgdiplus \
+        libtool \
+        locales \
+        locales-all \
+        python3 \
+        sudo \
+        tzdata \
+        unzip \
+        wget \
+    && rm -rf /var/lib/apt/lists/* \
+    \
+    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+ENV LANG en_US.utf8
+
+# create helixbot user and give rights to sudo without password
+RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm helixbot && \
+    chmod 755 /root && \
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
 
 USER helixbot


### PR DESCRIPTION
Legacy Mono has been kicked off Jenkins, so we need to use AzDO. Right now we're using existing Helix images and just have a step in our .yml to provision the extra packages we need on every build, but this is obviously a better technical solution.

The ARMv7 image is intended to allow us to run builds on our self-hosted ARM64 pool - according to the docs, correct use of LABEL allows a user-provided (distro-provided) Node binary, for cases where the VSTS-agent-provided Node binary might not work.