### PR TITLE
Changes to accommodate updated python cryptography dependency

### DIFF
--- a/src/alpine/3.10/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.10/helix/arm64v8/Dockerfile
@@ -52,6 +52,7 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     python -m pip install --upgrade pip==20.2 && \
     python -m pip install virtualenv==16.6.0 && \
     pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    export CRYPTOGRAPHY_DONT_BUILD_RUST=1 && \
     pip install ./helix_scripts-*-py3-none-any.whl
 
 # create helixbot user and give rights to sudo without password

--- a/src/alpine/3.11/helix/amd64/Dockerfile
+++ b/src/alpine/3.11/helix/amd64/Dockerfile
@@ -48,6 +48,7 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     python -m pip install --upgrade pip==20.2 && \
     python -m pip install virtualenv==16.6.0 && \
     pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    export CRYPTOGRAPHY_DONT_BUILD_RUST=1 && \
     pip install ./helix_scripts-*-py3-none-any.whl
 
 # Needed for corefx tests to pass

--- a/src/alpine/3.11/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.11/helix/arm64v8/Dockerfile
@@ -52,6 +52,7 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     python -m pip install --upgrade pip==20.2 && \
     python -m pip install virtualenv==16.6.0 && \
     pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    export CRYPTOGRAPHY_DONT_BUILD_RUST=1 && \
     pip install ./helix_scripts-*-py3-none-any.whl
 
 # create helixbot user and give rights to sudo without password

--- a/src/alpine/3.12/helix/amd64/Dockerfile
+++ b/src/alpine/3.12/helix/amd64/Dockerfile
@@ -49,6 +49,7 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     python -m pip install --upgrade pip==20.2 && \
     python -m pip install virtualenv==16.6.0 && \
     pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    export CRYPTOGRAPHY_DONT_BUILD_RUST=1 && \
     pip install ./helix_scripts-*-py3-none-any.whl
 
 # Needed for corefx tests to pass

--- a/src/alpine/3.12/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.12/helix/arm32v7/Dockerfile
@@ -51,6 +51,7 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     python -m pip install --upgrade pip==20.2 && \
     python -m pip install virtualenv==16.6.0 && \
     pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    export CRYPTOGRAPHY_DONT_BUILD_RUST=1 && \
     pip install ./helix_scripts-*-py3-none-any.whl
 
 # Needed for corefx tests to pass

--- a/src/alpine/3.12/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.12/helix/arm64v8/Dockerfile
@@ -49,6 +49,7 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     python -m pip install --upgrade pip==20.2 && \
     python -m pip install virtualenv==16.6.0 && \
     pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    export CRYPTOGRAPHY_DONT_BUILD_RUST=1 && \
     pip install ./helix_scripts-*-py3-none-any.whl
 
 # Needed for corefx tests to pass

--- a/src/debian/10/helix/arm32v7/Dockerfile
+++ b/src/debian/10/helix/arm32v7/Dockerfile
@@ -42,6 +42,7 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     python -m pip install --upgrade pip==20.2 && \
     python -m pip install virtualenv==16.6.0 && \
     pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    export CRYPTOGRAPHY_DONT_BUILD_RUST=1 && \
     pip install ./helix_scripts-*-py3-none-any.whl
 
 # Create helixbot user and give rights to sudo without password

--- a/src/debian/10/helix/arm64v8/Dockerfile
+++ b/src/debian/10/helix/arm64v8/Dockerfile
@@ -39,6 +39,7 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     python -m pip install --upgrade pip==20.2 && \
     python -m pip install virtualenv==16.6.0 && \
     pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    export CRYPTOGRAPHY_DONT_BUILD_RUST=1 && \
     pip install ./helix_scripts-*-py3-none-any.whl
 
 # Create helixbot user and give rights to sudo without password

--- a/src/debian/11/helix/arm32v7/Dockerfile
+++ b/src/debian/11/helix/arm32v7/Dockerfile
@@ -42,6 +42,7 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     python -m pip install --upgrade pip==20.2 && \
     python -m pip install virtualenv==16.6.0 && \
     pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    export CRYPTOGRAPHY_DONT_BUILD_RUST=1 && \
     pip install ./helix_scripts-*-py3-none-any.whl
 
 # Create helixbot user and give rights to sudo without password

--- a/src/debian/11/helix/arm64v8/Dockerfile
+++ b/src/debian/11/helix/arm64v8/Dockerfile
@@ -39,6 +39,7 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     python -m pip install --upgrade pip==20.2 && \
     python -m pip install virtualenv==16.6.0 && \
     pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    export CRYPTOGRAPHY_DONT_BUILD_RUST=1 && \
     pip install ./helix_scripts-*-py3-none-any.whl
 
 # Create helixbot user and give rights to sudo without password

--- a/src/debian/9/helix/arm32v7/Dockerfile
+++ b/src/debian/9/helix/arm32v7/Dockerfile
@@ -36,11 +36,12 @@ RUN apt-get update && \
 ENV LANG=en_US.utf8
 
 RUN ln -sf /usr/bin/python3 /usr/bin/python && \
-    curl https://bootstrap.pypa.io/3.5/get-pip.py -o ./get-pip.py --fail --silent --show-error && \
+    curl https://bootstrap.pypa.io/pip/3.5/get-pip.py -o ./get-pip.py --fail --silent --show-error && \
     python ./get-pip.py && rm ./get-pip.py && \
     python -m pip install --upgrade pip==20.2 && \
     python -m pip install virtualenv==16.6.0 && \
     pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    export CRYPTOGRAPHY_DONT_BUILD_RUST=1 && \
     pip install ./helix_scripts-*-py3-none-any.whl
 
 RUN adduser --disabled-password --gecos '' --uid 1001 --shell /bin/bash --ingroup adm helixbot && \

--- a/src/debian/9/helix/arm64v8/Dockerfile
+++ b/src/debian/9/helix/arm64v8/Dockerfile
@@ -35,11 +35,12 @@ RUN apt-get update && \
 ENV LANG=en_US.utf8
 
 RUN ln -sf /usr/bin/python3 /usr/bin/python && \
-    curl https://bootstrap.pypa.io/3.5/get-pip.py -o ./get-pip.py --fail --silent --show-error && \
+    curl https://bootstrap.pypa.io/pip/3.5/get-pip.py -o ./get-pip.py --fail --silent --show-error && \
     python ./get-pip.py && rm ./get-pip.py && \
     python -m pip install --upgrade pip==20.2 && \
     python -m pip install virtualenv==16.6.0 && \
     pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    export CRYPTOGRAPHY_DONT_BUILD_RUST=1 && \
     pip install ./helix_scripts-*-py3-none-any.whl
 
 RUN adduser --disabled-password --gecos '' --uid 1001 --shell /bin/bash --ingroup adm helixbot && \

--- a/src/ubuntu/16.04/helix/arm32v7/Dockerfile
+++ b/src/ubuntu/16.04/helix/arm32v7/Dockerfile
@@ -44,6 +44,7 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     python -m pip install --upgrade pip==20.2 && \
     python -m pip install virtualenv==16.6.0 && \
     pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    export CRYPTOGRAPHY_DONT_BUILD_RUST=1 && \
     pip install ./helix_scripts-*-py3-none-any.whl
 
 RUN adduser --disabled-password --gecos '' --uid 1001 --shell /bin/bash --ingroup adm helixbot && \

--- a/src/ubuntu/16.04/helix/arm64v8/Dockerfile
+++ b/src/ubuntu/16.04/helix/arm64v8/Dockerfile
@@ -36,6 +36,7 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     python -m pip install --upgrade pip==20.2 && \
     python -m pip install virtualenv==16.6.0 && \
     pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    export CRYPTOGRAPHY_DONT_BUILD_RUST=1 && \
     pip install ./helix_scripts-*-py3-none-any.whl
 
 RUN adduser --disabled-password --gecos '' --uid 1001 --shell /bin/bash --ingroup adm helixbot && \

--- a/src/ubuntu/18.04/helix/arm32v7/Dockerfile
+++ b/src/ubuntu/18.04/helix/arm32v7/Dockerfile
@@ -52,6 +52,7 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     python -m pip install --upgrade pip==20.2 && \
     python -m pip install virtualenv==16.6.0 && \
     pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    export CRYPTOGRAPHY_DONT_BUILD_RUST=1 && \
     pip install ./helix_scripts-*-py3-none-any.whl
 
 RUN adduser --disabled-password --gecos '' --uid 1001 --shell /bin/bash --ingroup adm helixbot && \

--- a/src/ubuntu/18.04/helix/arm64v8/Dockerfile
+++ b/src/ubuntu/18.04/helix/arm64v8/Dockerfile
@@ -44,6 +44,7 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     python -m pip install --upgrade pip==20.2 && \
     python -m pip install virtualenv==16.6.0 && \
     pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    export CRYPTOGRAPHY_DONT_BUILD_RUST=1 && \
     pip install ./helix_scripts-*-py3-none-any.whl
 
 RUN adduser --disabled-password --gecos '' --uid 1001 --shell /bin/bash --ingroup adm helixbot && \


### PR DESCRIPTION
Addresses https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/429.  See [context from Crytpography github repo](https://github.com/pyca/cryptography/issues/5797)

### Alpine changes:
1) Add cargo, rust from feed
2) Upgrade pip to 21.0.1 

### Debian changes

Strangely this doesn't seem to reproduce for all variants (just means pypi.org somehow had a prebuilt version).  Rust isn't on the package feed, and I don't feel like curling random scripts and running them so I took the env var option:

1) add "export CRYPTOGRAPHY_DONT_BUILD_RUST=1"
2) Upgrade pip to 21.0.1 

Reading the error messages and the linked issue, I think this simply defers doing something until the next time we want to update our version of cryptography, but perhaps pypi.org will have prebuilt ARM packages ready by next time we are forced to update dependency versions.

### Ubuntu changes

Same changes as debian, and like debian some of the images didn't seem to need it.

