### PR TITLE
Fix source-build image entrypoint for AzDO usage.

### DIFF
--- a/src/centos/7/source-build/Dockerfile
+++ b/src/centos/7/source-build/Dockerfile
@@ -51,3 +51,5 @@ RUN yum install -y \
     yum clean all
 
 ENTRYPOINT [ "scl", "enable", "llvm-toolset-7.0", "--" ]
+
+CMD [ "/bin/bash" ]

--- a/src/centos/7/source-build/Dockerfile
+++ b/src/centos/7/source-build/Dockerfile
@@ -50,4 +50,4 @@ RUN yum install -y \
     && \
     yum clean all
 
-ENTRYPOINT [ "scl", "enable", "llvm-toolset-7.0", "bash" ]
+ENTRYPOINT [ "scl", "enable", "llvm-toolset-7.0", "--" ]


### PR DESCRIPTION
We need to use `--` to tell scl that the rest of the command line is the command to run.

Blocking https://github.com/dotnet/runtime/pull/50811