### PR TITLE
Change ubuntu cross arm alpine to use 3.13 rootfs

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -312,6 +312,18 @@
         {
           "platforms": [
             {
+              "dockerfile": "src/ubuntu/16.04/cross/arm-alpine",
+              "os": "linux",
+              "osVersion": "xenial",
+              "tags": {
+                "ubuntu-16.04-cross-arm-alpine-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
               "dockerfile": "src/ubuntu/16.04/cross/arm64-alpine",
               "os": "linux",
               "osVersion": "xenial",

--- a/src/ubuntu/16.04/cross/arm-alpine/Dockerfile
+++ b/src/ubuntu/16.04/cross/arm-alpine/Dockerfile
@@ -1,0 +1,29 @@
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-crossdeps
+
+# Install bison. This is required to build musl-cross-make
+RUN apt-get update \
+    && apt-get install -y \
+        bison \
+    && rm -rf /var/lib/apt/lists/*
+
+# Workaround to build a functioning ld.gold which can link for linux-musl arm
+RUN cd /tmp \
+    && wget https://ftp.gnu.org/gnu/binutils/binutils-2.31.1.tar.gz \
+    && tar -xf binutils-2.31.1.tar.gz \
+    && cd binutils-2.31.1 \
+    && ./configure \
+        --disable-werror \
+        --target=armv7-alpine-linux-musleabihf \
+        --prefix=/usr \
+        --libdir=/lib \
+        --disable-multilib \
+        --with-sysroot=armv7-alpine-linux-musleabihf \
+        --enable-gold=yes \
+        --enable-plugins=yes \
+        --program-prefix=armv7-alpine-linux-musleabihf- \
+    && make \
+    && make install \
+    && cd .. \
+    && rm -r *
+
+ADD rootfs.arm.tar crossrootfs

--- a/src/ubuntu/16.04/cross/arm-alpine/hooks/post-build
+++ b/src/ubuntu/16.04/cross/arm-alpine/hooks/post-build
@@ -1,0 +1,1 @@
+../../../../build-scripts/build-rootfs-cleanup.sh

--- a/src/ubuntu/16.04/cross/arm-alpine/hooks/pre-build
+++ b/src/ubuntu/16.04/cross/arm-alpine/hooks/pre-build
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+SCRIPT=$(readlink -f "$0")
+SCRIPTPATH=$(dirname "$SCRIPT")
+$SCRIPTPATH/../../../../build-scripts/build-rootfs.sh ubuntu-16.04 alpine3.13 arm lldb3.9

--- a/src/ubuntu/18.04/cross/arm-alpine/hooks/pre-build
+++ b/src/ubuntu/18.04/cross/arm-alpine/hooks/pre-build
@@ -2,4 +2,4 @@
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
-$SCRIPTPATH/../../../../build-scripts/build-rootfs.sh ubuntu-18.04 alpine arm lldb3.9
+$SCRIPTPATH/../../../../build-scripts/build-rootfs.sh ubuntu-18.04 alpine3.13 arm lldb3.9


### PR DESCRIPTION
Due to the breaking change on Alpine 3.13 w.r.t. time_t type
size, we will only support ARM on Alpine >= 3.13.
This change updates the ROOTFS that the cross build uses
to be the one of Alpine 3.13.

I have also created cross image for Ubuntu 16.04, as we should
be cross building on 16.04 rather than 18.04 to get better coverage
of Linux distros where cross-tools like crossgen can be run.
Ideally, we would use CentOS 7, but we cannot run crossbuild on
that one.