### PR TITLE
Add Alpine 3.13 Helix image for ARM

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -566,6 +566,20 @@
         {
           "platforms": [
             {
+              "architecture": "arm",
+              "dockerfile": "src/alpine/3.13/helix/arm32v7",
+              "os": "linux",
+              "osVersion": "alpine3.13",
+              "tags": {
+                "alpine-3.13-helix-arm32v7-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
+              },
+              "variant": "v7"
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
               "dockerfile": "src/ubuntu/16.04/cross",
               "os": "linux",
               "osVersion": "xenial",

--- a/src/alpine/3.13/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.13/helix/arm32v7/Dockerfile
@@ -1,0 +1,67 @@
+FROM arm32v7/alpine:3.13
+
+# Install .NET Core Dependencies for Alpine
+
+RUN apk update && \
+    apk add --no-cache \
+        autoconf \
+        automake \
+        bash \
+        build-base \
+        clang \
+        clang-dev \
+        cmake \
+        coreutils \
+        curl \
+        gcc \
+        gettext-dev \
+        git \
+        icu-dev \
+        iputils \
+        krb5-dev \
+        libtool \
+        libunwind-dev \
+        libffi \
+        libffi-dev \
+        linux-headers \
+        llvm \
+        lttng-ust-dev \
+        make \
+        openssl \
+        openssl-dev \
+        py-cffi \
+        python3 \
+        python3-dev \
+        sudo \
+        tzdata \
+        userspace-rcu-dev \
+        util-linux-dev \
+        wget \
+        zlib-dev
+
+# Install Helix Dependencies
+
+# Workaround: https://github.com/pypa/wheel/issues/367
+ENV _PYTHON_HOST_PLATFORM=linux_armv7l
+
+RUN ln -sf /usr/bin/python3 /usr/bin/python && \
+    curl https://bootstrap.pypa.io/get-pip.py -o ./get-pip.py --fail --silent --show-error && \
+    python ./get-pip.py && rm ./get-pip.py && \
+    python -m pip install --upgrade pip==20.2 && \
+    python -m pip install virtualenv==16.6.0 && \
+    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    export CRYPTOGRAPHY_DONT_BUILD_RUST=1 && \
+    pip install ./helix_scripts-*-py3-none-any.whl
+
+# Needed for corefx tests to pass
+ENV LANG=en-US.UTF-8
+
+# create helixbot user and give rights to sudo without password
+# Alpine does not support long options
+RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1001 helixbot && \
+    chmod 755 /root && \
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot
+
+USER helixbot
+
+RUN python -m virtualenv --no-site-packages /home/helixbot/.vsts-env


### PR DESCRIPTION
For running Alpine ARM tests in the CI, we need Alpine 3.13 image since
this is the minimum supported version for Alpine ARM (due to the time_t
size breaking change).