### PR TITLE
Add lld linker to the centos, alpine and crossbuild images

### DIFF
--- a/eng/pipelines/dotnet-buildtools-prereqs-centos7-pr.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-centos7-pr.yml
@@ -22,4 +22,4 @@ variables:
 stages:
   - template: ../common/templates/stages/build-test-publish-repo.yml
     parameters:
-      linuxAmdBuildJobTimeout: 210
+      linuxAmdBuildJobTimeout: 300

--- a/eng/pipelines/dotnet-buildtools-prereqs-centos7.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-centos7.yml
@@ -15,4 +15,4 @@ variables:
 stages:
   - template: ../common/templates/stages/build-test-publish-repo.yml
     parameters:
-      linuxAmdBuildJobTimeout: 210
+      linuxAmdBuildJobTimeout: 300

--- a/src/alpine/3.13/WithNode/amd64/Dockerfile
+++ b/src/alpine/3.13/WithNode/amd64/Dockerfile
@@ -14,9 +14,8 @@ RUN apk add --no-cache --virtual .build-deps-yarn \
         && for key in \
             6A010C5166006599AA17F08146C2130DFD2497F5 \
         ; do \
-            gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" \
-            || gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" \
-            || gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+            gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" \
+            || gpg --keyserver hkps://keys.openpgp.org --recv-keys "$key"; \
         done \
             && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
             && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \

--- a/src/alpine/3.9/WithNode/amd64/Dockerfile
+++ b/src/alpine/3.9/WithNode/amd64/Dockerfile
@@ -25,9 +25,8 @@ RUN apk add --no-cache \
             77984A986EBC2AA786BC0F66B01FBB92821C587A \
             8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
         ; do \
-            gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" \
-            || gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" \
-            || gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+            gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" \
+            || gpg --keyserver hkps://keys.openpgp.org --recv-keys "$key"; \
         done \
             && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION.tar.xz" \
             && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \

--- a/src/alpine/3.9/amd64/Dockerfile
+++ b/src/alpine/3.9/amd64/Dockerfile
@@ -20,6 +20,7 @@ RUN apk add --no-cache \
         libtool \
         libunwind-dev \
         linux-headers \
+        lld \
         llvm \
         make \
         openssl \

--- a/src/centos/7/Dockerfile
+++ b/src/centos/7/Dockerfile
@@ -59,19 +59,23 @@ RUN wget -O cmake-install.sh https://github.com/Kitware/CMake/releases/download/
 RUN wget ftp://sourceware.org/pub/binutils/snapshots/binutils-2.29.1.tar.xz && \
     wget http://releases.llvm.org/9.0.0/cfe-9.0.0.src.tar.xz && \
     wget http://releases.llvm.org/9.0.0/llvm-9.0.0.src.tar.xz && \
+    wget http://releases.llvm.org/9.0.0/lld-9.0.0.src.tar.xz && \
     wget http://releases.llvm.org/9.0.0/lldb-9.0.0.src.tar.xz && \
     wget http://releases.llvm.org/9.0.0/compiler-rt-9.0.0.src.tar.xz && \
     \
     tar -xf binutils-2.29.1.tar.xz && \
     tar -xf llvm-9.0.0.src.tar.xz && \
     mkdir llvm-9.0.0.src/tools/clang && \
+    mkdir llvm-9.0.0.src/tools/lld && \
     mkdir llvm-9.0.0.src/tools/lldb && \
     mkdir llvm-9.0.0.src/projects/compiler-rt && \
     tar -xf cfe-9.0.0.src.tar.xz --strip 1 -C llvm-9.0.0.src/tools/clang && \
+    tar -xf lld-9.0.0.src.tar.xz --strip 1 -C llvm-9.0.0.src/tools/lld && \
     tar -xf lldb-9.0.0.src.tar.xz --strip 1 -C llvm-9.0.0.src/tools/lldb && \
     tar -xf compiler-rt-9.0.0.src.tar.xz --strip 1 -C llvm-9.0.0.src/projects/compiler-rt && \
     rm binutils-2.29.1.tar.xz && \
     rm cfe-9.0.0.src.tar.xz && \
+    rm lld-9.0.0.src.tar.xz && \
     rm lldb-9.0.0.src.tar.xz && \
     rm llvm-9.0.0.src.tar.xz && \
     rm compiler-rt-9.0.0.src.tar.xz && \

--- a/src/centos/7/rpmpkg/Dockerfile
+++ b/src/centos/7/rpmpkg/Dockerfile
@@ -8,6 +8,7 @@ RUN yum clean all \
         ruby-devel \
         rubygems \
     && gem install --no-document \
+        git:1.7.0 \
         ffi:1.12.2 \
         fpm \
     && yum clean all

--- a/src/centos/8/Dockerfile
+++ b/src/centos/8/Dockerfile
@@ -31,6 +31,7 @@ RUN dnf install --setopt tsflags=nodocs --refresh -y \
         libtool \
         libuuid-devel \
         libxml2-devel \
+        lld \
         lldb-devel \
         llvm \
         lttng-ust-devel \

--- a/src/ubuntu/18.04/crossdeps/Dockerfile
+++ b/src/ubuntu/18.04/crossdeps/Dockerfile
@@ -34,6 +34,7 @@ RUN apt-get update \
         clang-9 \
         clang-tools-9 \
         liblldb-6.0-dev \
+        lld-9 \
         lldb-6.0 \
         llvm-9 \
         python-lldb-6.0 \


### PR DESCRIPTION
We will be switching runtime build to using lld linker, so we need it in the images that we use to build it.