### PR TITLE
Add some dependencies into the Helix Mariner image

### DIFF
--- a/src/cbl-mariner/1.0/helix/amd64/Dockerfile
+++ b/src/cbl-mariner/1.0/helix/amd64/Dockerfile
@@ -6,8 +6,8 @@ ENV LANG=en_US.utf8
 
 RUN tdnf install --setopt tsflags=nodocs --refresh -y \
          gcc \
-         python3-pip \
          icu \
+         python3-pip \
          which \
     && tdnf clean all
 

--- a/src/cbl-mariner/1.0/helix/amd64/Dockerfile
+++ b/src/cbl-mariner/1.0/helix/amd64/Dockerfile
@@ -4,7 +4,12 @@ FROM cblmariner.azurecr.io/base/core:1.0
 
 ENV LANG=en_US.utf8
 
-RUN tdnf install -y python3-pip
+RUN tdnf install --setopt tsflags=nodocs --refresh -y \
+         gcc \
+         python3-pip \
+         icu \
+         which \
+    && tdnf clean all
 
 RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     python -m pip install --upgrade pip==21.1.2 && \


### PR DESCRIPTION
https://github.com/dotnet/core-eng/issues/13205 again.  

Adds all the plugins that had matches in Mariner's feed from https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/main/src/centos/8/helix/amd64/Dockerfile , since most .NET Core APIs depend on ICU and couldn't run without.