### PR TITLE
Add iputils, tzdata, and microsoft CA packages (needed by runtime tests) to Mariner image

### DIFF
--- a/src/cbl-mariner/1.0/helix/amd64/Dockerfile
+++ b/src/cbl-mariner/1.0/helix/amd64/Dockerfile
@@ -7,7 +7,9 @@ ENV LANG=en_US.utf8
 RUN tdnf install --setopt tsflags=nodocs --refresh -y \
          gcc \
          icu \
+         iputils \
          python3-pip \
+         tzdata \
          which \
     && tdnf clean all
 

--- a/src/cbl-mariner/1.0/helix/amd64/Dockerfile
+++ b/src/cbl-mariner/1.0/helix/amd64/Dockerfile
@@ -5,6 +5,7 @@ FROM cblmariner.azurecr.io/base/core:1.0
 ENV LANG=en_US.utf8
 
 RUN tdnf install --setopt tsflags=nodocs --refresh -y \
+         ca-certificates-microsoft \
          gcc \
          icu \
          iputils \


### PR DESCRIPTION
After performing a .NET Core Libraries test run on the image, I found a couple more utilities that Mariner leaves out by default.