### PR TITLE
[win/ltsc2019/webassembly] Add more tools

### DIFF
--- a/src/windowsservercore/ltsc2019/webassembly/Dockerfile
+++ b/src/windowsservercore/ltsc2019/webassembly/Dockerfile
@@ -1,4 +1,19 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:windowsservercore-ltsc2019-helix-amd64
+FROM mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019
+
+SHELL ["cmd", "/S", "/C"]
+
+USER ContainerAdministrator
+
+# Install python
+RUN curl -SL --output %TEMP%\python.zip https://www.nuget.org/api/v2/package/python/3.9.5 \
+    && md C:\Python C:\PythonTemp \
+    && tar -zxf %TEMP%\python.zip -C C:\PythonTemp \
+    && xcopy /s c:\PythonTemp\tools C:\Python \
+    && copy C:\Python\python.exe C:\Python\python3.exe \
+    && rd /s /q c:\PythonTemp \
+    && del /q %TEMP%\python.zip \
+    && setx /M PYTHONPATH "C:\Python\Lib;C:\Python\DLLs;" \
+    && setx /M PATH "C:\Python;%PATH%"
 
 # Install git
 ENV GIT_VERSION=2.32.0
@@ -8,6 +23,13 @@ RUN curl -SL --output %TEMP%\%GIT_INSTALLER% https://github.com/git-for-windows/
     && mkdir C:\git \
     && tar -C C:\git -zxf %TEMP%\%GIT_INSTALLER% \
     && setx PATH "%PATH%;C:\git\cmd"
+
+# Install ninja generator
+ENV NINJA_VERSION=1.10.2
+RUN curl -SL --output %TEMP%\ninja-win.zip https://github.com/ninja-build/ninja/releases/download/v%NINJA_VERSION%/ninja-win.zip \
+    && mkdir C:\ninja \
+    && tar -C C:\ninja -zxf %TEMP%\ninja-win.zip \
+    && setx PATH "%PATH%;C:\ninja"
 
 # fix certificates for python to be able to download emscripten files
 RUN certutil -generateSSTFromWU roots.sst && certutil -addstore -f root roots.sst && del roots.sst
@@ -34,3 +56,32 @@ RUN msiexec /i %TEMP%\nodejs.msi /quiet /passive /qn /norestart
 RUN npm install jsvu -g
 RUN npm exec -c "jsvu --os=win64 --engines=v8,spidermonkey"
 RUN setx PATH "%PATH%;%USERPROFILE%\.jsvu"
+
+# Install cmake
+ENV CMAKE_VERSION 3.20.3
+RUN curl -SL --output %TEMP%\cmake-win.zip https://github.com/Kitware/CMake/releases/download/v%CMAKE_VERSION%/cmake-%CMAKE_VERSION%-windows-x86_64.zip \
+    && mkdir C:\cmake \
+    && tar -C C:\cmake -zxf %TEMP%\cmake-win.zip \
+    && setx PATH "%PATH%;C:\cmake\cmake-%CMAKE_VERSION%-windows-x86_64\bin"
+
+# Download the Build Tools bootstrapper.
+ADD https://aka.ms/vs/16/release/vs_buildtools.exe vs_buildtools.exe
+
+# Visual Studio with .NET and C++ tools
+RUN mkdir C:\BuildTools
+
+RUN vs_buildtools.exe --quiet --wait --norestart --nocache \
+    --installPath C:\BuildTools \
+    --add Microsoft.VisualStudio.Workload.ManagedDesktopBuildTools \
+    --add Microsoft.VisualStudio.Workload.VCTools \
+    --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 \
+    --remove Microsoft.VisualStudio.Component.Windows10SDK.10240 \
+    --remove Microsoft.VisualStudio.Component.Windows10SDK.10586 \
+    --remove Microsoft.VisualStudio.Component.Windows10SDK.14393 \
+    --remove Microsoft.VisualStudio.Component.Windows81SDK \
+    --add Microsoft.VisualStudio.Component.Windows10SDK.17763 \
+|| IF "%ERRORLEVEL%"=="3010" EXIT 0
+
+# Define the entry point for the docker container.
+# This entry point starts the developer command prompt and launches the PowerShell shell.
+ENTRYPOINT ["C:\\BuildTools\\Common7\\Tools\\VsDevCmd.bat", "&&", "powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]

--- a/src/windowsservercore/ltsc2019/webassembly/Dockerfile
+++ b/src/windowsservercore/ltsc2019/webassembly/Dockerfile
@@ -84,4 +84,4 @@ RUN vs_buildtools.exe --quiet --wait --norestart --nocache \
 
 # Define the entry point for the docker container.
 # This entry point starts the developer command prompt and launches the PowerShell shell.
-ENTRYPOINT ["C:\\BuildTools\\Common7\\Tools\\VsDevCmd.bat", "&&", "powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]
+ENTRYPOINT ["C:\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools\\Common7\\Tools\\VsDevCmd.bat", "&&", "powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]

--- a/src/windowsservercore/ltsc2019/webassembly/Dockerfile
+++ b/src/windowsservercore/ltsc2019/webassembly/Dockerfile
@@ -5,12 +5,14 @@ SHELL ["cmd", "/S", "/C"]
 USER ContainerAdministrator
 
 # Install python
-RUN curl -SL --output %TEMP%\python.zip https://www.nuget.org/api/v2/package/python/3.9.5 \
-    && md C:\Python C:\PythonTemp \
-    && tar -zxf %TEMP%\python.zip -C C:\PythonTemp \
-    && xcopy /s c:\PythonTemp\tools C:\Python \
+ENV PYTHON_VERSION=3.9.5
+
+RUN curl -SL --output %TEMP%\python.zip https://www.nuget.org/api/v2/package/python/%PYTHON_VERSION% \
+    && md C:\PythonTemp \
+    && tar -C C:\PythonTemp -zxf %TEMP%\python.zip tools \
+    && move C:\PythonTemp\tools C:\Python \
+    && rd /q C:\PythonTemp \
     && copy C:\Python\python.exe C:\Python\python3.exe \
-    && rd /s /q c:\PythonTemp \
     && del /q %TEMP%\python.zip \
     && setx /M PYTHONPATH "C:\Python\Lib;C:\Python\DLLs;" \
     && setx /M PATH "C:\Python;%PATH%"
@@ -22,14 +24,16 @@ ENV GIT_INSTALLER=MinGit-${GIT_VERSION}-64-bit.zip
 RUN curl -SL --output %TEMP%\%GIT_INSTALLER% https://github.com/git-for-windows/git/releases/download/v%GIT_VERSION%.windows.1/%GIT_INSTALLER% \
     && mkdir C:\git \
     && tar -C C:\git -zxf %TEMP%\%GIT_INSTALLER% \
-    && setx PATH "%PATH%;C:\git\cmd"
+    && setx /M PATH "%PATH%;C:\git\cmd" \
+    && del /q %TEMP%\%GIT_INSTALLER%
 
 # Install ninja generator
 ENV NINJA_VERSION=1.10.2
 RUN curl -SL --output %TEMP%\ninja-win.zip https://github.com/ninja-build/ninja/releases/download/v%NINJA_VERSION%/ninja-win.zip \
     && mkdir C:\ninja \
     && tar -C C:\ninja -zxf %TEMP%\ninja-win.zip \
-    && setx PATH "%PATH%;C:\ninja"
+    && setx /M PATH "%PATH%;C:\ninja" \
+    && del /q %TEMP%\ninja-win.zip
 
 # fix certificates for python to be able to download emscripten files
 RUN certutil -generateSSTFromWU roots.sst && certutil -addstore -f root roots.sst && del roots.sst
@@ -55,23 +59,20 @@ RUN msiexec /i %TEMP%\nodejs.msi /quiet /passive /qn /norestart
 # install jsvu and engines
 RUN npm install jsvu -g
 RUN npm exec -c "jsvu --os=win64 --engines=v8,spidermonkey"
-RUN setx PATH "%PATH%;%USERPROFILE%\.jsvu"
+RUN setx /M PATH "%PATH%;%USERPROFILE%\.jsvu"
 
 # Install cmake
 ENV CMAKE_VERSION 3.20.3
 RUN curl -SL --output %TEMP%\cmake-win.zip https://github.com/Kitware/CMake/releases/download/v%CMAKE_VERSION%/cmake-%CMAKE_VERSION%-windows-x86_64.zip \
     && mkdir C:\cmake \
     && tar -C C:\cmake -zxf %TEMP%\cmake-win.zip \
-    && setx PATH "%PATH%;C:\cmake\cmake-%CMAKE_VERSION%-windows-x86_64\bin"
+    && setx /M PATH "%PATH%;C:\cmake\cmake-%CMAKE_VERSION%-windows-x86_64\bin" \
+    && del /q %TEMP%\cmake-win.zip
 
-# Download the Build Tools bootstrapper.
-ADD https://aka.ms/vs/16/release/vs_buildtools.exe vs_buildtools.exe
-
-# Visual Studio with .NET and C++ tools
-RUN mkdir C:\BuildTools
-
-RUN vs_buildtools.exe --quiet --wait --norestart --nocache \
-    --installPath C:\BuildTools \
+# Install Visual Studio .NET and C++ tools
+RUN curl -SL --output vs_buildtools.exe https://aka.ms/vs/15/release/vs_buildtools.exe \
+    && (start /w vs_buildtools.exe --quiet --wait --norestart --nocache modify \
+    --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools" \
     --add Microsoft.VisualStudio.Workload.ManagedDesktopBuildTools \
     --add Microsoft.VisualStudio.Workload.VCTools \
     --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 \
@@ -80,8 +81,9 @@ RUN vs_buildtools.exe --quiet --wait --norestart --nocache \
     --remove Microsoft.VisualStudio.Component.Windows10SDK.14393 \
     --remove Microsoft.VisualStudio.Component.Windows81SDK \
     --add Microsoft.VisualStudio.Component.Windows10SDK.17763 \
-|| IF "%ERRORLEVEL%"=="3010" EXIT 0
+|| IF "%ERRORLEVEL%"=="3010" EXIT 0) \
+    && del /q vs_buildtools.exe
 
 # Define the entry point for the docker container.
 # This entry point starts the developer command prompt and launches the PowerShell shell.
-ENTRYPOINT ["C:\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools\\Common7\\Tools\\VsDevCmd.bat", "&&", "powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]
+ENTRYPOINT ["C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools\\Common7\\Tools\\VsDevCmd.bat", "&&", "powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]

--- a/src/windowsservercore/ltsc2019/webassembly/Dockerfile
+++ b/src/windowsservercore/ltsc2019/webassembly/Dockerfile
@@ -39,7 +39,7 @@ RUN curl -SL --output %TEMP%\ninja-win.zip https://github.com/ninja-build/ninja/
 RUN certutil -generateSSTFromWU roots.sst && certutil -addstore -f root roots.sst && del roots.sst
 
 # Install Emscripten toolchain
-ENV EMSCRIPTEN_VERSION=2.0.23
+ENV EMSCRIPTEN_VERSION=2.0.21
 ENV EMSCRIPTEN_PATH="C:\emscripten"
 ENV EMSDK_PATH="C:\emscripten\emsdk"
 

--- a/src/windowsservercore/ltsc2019/webassembly/Dockerfile
+++ b/src/windowsservercore/ltsc2019/webassembly/Dockerfile
@@ -70,7 +70,7 @@ RUN curl -SL --output %TEMP%\cmake-win.zip https://github.com/Kitware/CMake/rele
     && del /q %TEMP%\cmake-win.zip
 
 # Install Visual Studio .NET and C++ tools
-RUN curl -SL --output vs_buildtools.exe https://aka.ms/vs/15/release/vs_buildtools.exe \
+RUN curl -SL --output vs_buildtools.exe https://aka.ms/vs/16/release/vs_buildtools.exe \
     && (start /w vs_buildtools.exe --quiet --wait --norestart --nocache modify \
     --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools" \
     --add Microsoft.VisualStudio.Workload.ManagedDesktopBuildTools \


### PR DESCRIPTION
To be able to build dotnet/runtime with mono/wasm in the container.

Adds cmake, ninja, python and VS build tools

Also base it on 4.8-windowsservercore-ltsc2019 to be able to run
VS build tools bootstrap