### PR TITLE
[win/ltsc2019/webassembly] Do not set entrypoint

### DIFF
--- a/src/windowsservercore/ltsc2019/webassembly/Dockerfile
+++ b/src/windowsservercore/ltsc2019/webassembly/Dockerfile
@@ -83,7 +83,3 @@ RUN curl -SL --output vs_buildtools.exe https://aka.ms/vs/16/release/vs_buildtoo
     --add Microsoft.VisualStudio.Component.Windows10SDK.17763 \
 || IF "%ERRORLEVEL%"=="3010" EXIT 0) \
     && del /q vs_buildtools.exe
-
-# Define the entry point for the docker container.
-# This entry point starts the developer command prompt and launches the PowerShell shell.
-ENTRYPOINT ["C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools\\Common7\\Tools\\VsDevCmd.bat", "&&", "powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]


### PR DESCRIPTION
Looks like the build machine doesn't interact well with the entrypoint.
The CI build failed like this: https://dev.azure.com/dnceng/public/_build/results?buildId=1181557&view=logs&j=f9ca8601-c4c2-5da2-61cf-0da7d83d7557&t=113debf1-d9c8-501d-86a4-aa499af3d86b

I have tested building wasm runtime in the container on image without
entrypoint set and it built the project fine locally.