### PR TITLE
[win/ltsc2019/webassembly] Reduce the image size

### DIFF
--- a/src/windowsservercore/ltsc2019/webassembly/Dockerfile
+++ b/src/windowsservercore/ltsc2019/webassembly/Dockerfile
@@ -81,3 +81,5 @@ RUN curl -SL --output vs_buildtools.exe https://aka.ms/vs/16/release/vs_buildtoo
     --add Microsoft.VisualStudio.Component.Windows10SDK.17763 \
 || IF "%ERRORLEVEL%"=="3010" EXIT 0) \
     && del /q vs_buildtools.exe
+
+RUN del /q /f /s %TEMP%\*

--- a/src/windowsservercore/ltsc2019/webassembly/Dockerfile
+++ b/src/windowsservercore/ltsc2019/webassembly/Dockerfile
@@ -45,21 +45,21 @@ ENV EMSDK_PATH="C:\emscripten\emsdk"
 
 RUN mkdir %EMSCRIPTEN_PATH% \
     && cd %EMSCRIPTEN_PATH% \
-    && git clone https://github.com/emscripten-core/emsdk.git %EMSDK_PATH%
-RUN cd %EMSDK_PATH% \
+    && git clone https://github.com/emscripten-core/emsdk.git %EMSDK_PATH% \
+    && cd %EMSDK_PATH% \
     && .\emsdk install %EMSCRIPTEN_VERSION%-upstream  \
     && .\emsdk activate %EMSCRIPTEN_VERSION%-upstream
 
 # install Node JS
 ENV NODE_VERSION 16.3.0
 
-RUN curl -SL --output %TEMP%\nodejs.msi https://nodejs.org/dist/v%NODE_VERSION%/node-v%NODE_VERSION%-x64.msi
-RUN msiexec /i %TEMP%\nodejs.msi /quiet /passive /qn /norestart
+RUN curl -SL --output %TEMP%\nodejs.msi https://nodejs.org/dist/v%NODE_VERSION%/node-v%NODE_VERSION%-x64.msi \
+    && msiexec /i %TEMP%\nodejs.msi /quiet /passive /qn /norestart
 
 # install jsvu and engines
-RUN npm install jsvu -g
-RUN npm exec -c "jsvu --os=win64 --engines=v8,spidermonkey"
-RUN setx /M PATH "%PATH%;%USERPROFILE%\.jsvu"
+RUN npm install jsvu -g \
+    && npm exec -c "jsvu --os=win64 --engines=v8,spidermonkey" \
+    && setx /M PATH "%PATH%;%USERPROFILE%\.jsvu"
 
 # Install cmake
 ENV CMAKE_VERSION 3.20.3

--- a/src/windowsservercore/ltsc2019/webassembly/Dockerfile
+++ b/src/windowsservercore/ltsc2019/webassembly/Dockerfile
@@ -79,7 +79,6 @@ RUN curl -SL --output vs_buildtools.exe https://aka.ms/vs/16/release/vs_buildtoo
     --remove Microsoft.VisualStudio.Component.Windows10SDK.14393 \
     --remove Microsoft.VisualStudio.Component.Windows81SDK \
     --add Microsoft.VisualStudio.Component.Windows10SDK.17763 \
-|| IF "%ERRORLEVEL%"=="3010" EXIT 0) \
-    && del /q vs_buildtools.exe
-
-RUN del /q /f /s %TEMP%\*
+    || IF "%ERRORLEVEL%"=="3010" EXIT 0) \
+    && del /q vs_buildtools.exe \
+    && del /q /f /s %TEMP%\*

--- a/src/windowsservercore/ltsc2019/webassembly/Dockerfile
+++ b/src/windowsservercore/ltsc2019/webassembly/Dockerfile
@@ -52,9 +52,9 @@ RUN mkdir %EMSCRIPTEN_PATH% \
 
 # install Node JS
 ENV NODE_VERSION 16.3.0
-
 RUN curl -SL --output %TEMP%\nodejs.msi https://nodejs.org/dist/v%NODE_VERSION%/node-v%NODE_VERSION%-x64.msi \
-    && msiexec /i %TEMP%\nodejs.msi /quiet /passive /qn /norestart
+    && msiexec /i %TEMP%\nodejs.msi /quiet /passive /qn /norestart \
+    && del /q %TEMP%\nodejs.msi
 
 # install jsvu and engines
 RUN npm install jsvu -g \

--- a/src/windowsservercore/ltsc2019/webassembly/Dockerfile
+++ b/src/windowsservercore/ltsc2019/webassembly/Dockerfile
@@ -73,8 +73,6 @@ RUN curl -SL --output %TEMP%\cmake-win.zip https://github.com/Kitware/CMake/rele
 RUN curl -SL --output vs_buildtools.exe https://aka.ms/vs/16/release/vs_buildtools.exe \
     && (start /w vs_buildtools.exe --quiet --wait --norestart --nocache modify \
     --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools" \
-    --add Microsoft.VisualStudio.Workload.ManagedDesktopBuildTools \
-    --add Microsoft.VisualStudio.Workload.VCTools \
     --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 \
     --remove Microsoft.VisualStudio.Component.Windows10SDK.10240 \
     --remove Microsoft.VisualStudio.Component.Windows10SDK.10586 \


### PR DESCRIPTION
The CI build is failing with:

    System.IO.IOException: There is not enough space on the disk. : 'C:\__w\1\s\artifacts\log\Release\Build.binlog'

Lets try to save some space. It looks like
the `Microsoft.VisualStudio.Component.VC.Tools.x86.x64` component pulls
enough dependencies for us. I was also able to build it without
`Microsoft.VisualStudio.Workload.ManagedDesktopBuildTools` component
locally. Let see if it will be enough. The size is reduced by cca 1.3GB.