### PR TITLE
add image to build MsQuic

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -564,6 +564,18 @@
         {
           "platforms": [
             {
+              "dockerfile": "src/ubuntu/18.04/msquic/amd64",
+              "os": "linux",
+              "osVersion": "bionic",
+              "tags": {
+                "ubuntu-18.04-msquic-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
               "architecture": "arm64",
               "dockerfile": "src/alpine/3.10/helix/arm64v8",
               "os": "linux",

--- a/src/ubuntu/18.04/msquic/amd64/Dockerfile
+++ b/src/ubuntu/18.04/msquic/amd64/Dockerfile
@@ -1,0 +1,31 @@
+FROM mcr.microsoft.com/powershell:lts-ubuntu-18.04
+
+# Install pwsh and the base toolchain we need to build anything (clang, cmake, make and the like)
+# this is similar to prepare-machine.ps1  -Configuration Build
+RUN curl -OL https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb \
+    && dpkg -i packages-microsoft-prod.deb \
+    && apt-get update \
+    && apt-get install -y \
+        apt-transport-https \
+        ca-certificates \
+        gnupg \
+        software-properties-common \
+        wget \
+    && apt-get update \
+    && apt-get install -y \
+        dotnet-sdk-5.0 \
+        git \
+        build-essential \
+        liblttng-ust-dev \
+        lttng-tools \
+        ruby ruby-dev rpm \
+        sudo \
+    && rm -rf /var/lib/apt/lists/* \
+    &&  gem install fpm \
+    && curl -OL https://cmake.org/files/v3.17/cmake-3.17.0-Linux-x86_64.tar.gz \
+    && tar -xf cmake-3.17.0-Linux-x86_64.tar.gz --strip 1 -C /usr/local \
+    && rm cmake-3.17.0-Linux-x86_64.tar.gz
+
+# .NET SDK MSBuild requires US.UTF-8 locale to execute tasks
+RUN locale-gen en_US.UTF-8
+

--- a/src/ubuntu/18.04/msquic/amd64/Dockerfile
+++ b/src/ubuntu/18.04/msquic/amd64/Dockerfile
@@ -13,12 +13,13 @@ RUN curl -OL https://packages.microsoft.com/config/ubuntu/18.04/packages-microso
         wget \
     && apt-get update \
     && apt-get install -y \
+        build-essential \
         dotnet-sdk-5.0 \
         git \
-        build-essential \
         liblttng-ust-dev \
         lttng-tools \
-        ruby ruby-dev rpm \
+        rpm \
+        ruby ruby-dev \
         sudo \
     && rm -rf /var/lib/apt/lists/* \
     &&  gem install fpm \


### PR DESCRIPTION
this is to build http://github.com/dotnet/msquic on Linux
(on Windows we use the build queue nodes directly) 
I did basic verification running build.sh from the repo.

cc: @ManickaP @safern 