### PR TITLE
[wasm] Bump python version

### DIFF
--- a/src/windowsservercore/2004/helix/amd64/Dockerfile
+++ b/src/windowsservercore/2004/helix/amd64/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/windows/servercore:2004-amd64
 
 USER ContainerAdministrator
 
-RUN curl -SL --output %TEMP%\python.zip https://www.nuget.org/api/v2/package/python/3.7.3 `
+RUN curl -SL --output %TEMP%\python.zip https://www.nuget.org/api/v2/package/python/3.9.6 `
     && md C:\Python C:\PythonTemp `
     && tar -zxf %TEMP%\python.zip -C C:\PythonTemp `
     && xcopy /s c:\PythonTemp\tools C:\Python `


### PR DESCRIPTION
The `src\windowsservercore\2004\helix\webassembly\Dockerfile` is based
on `src\windowsservercore\2004\helix\amd64\Dockerfile`, so bump
the version here.