### PR TITLE
[wasm] Add arial font for chrome

### DIFF
--- a/src/windowsservercore/2004/helix/webassembly/Dockerfile
+++ b/src/windowsservercore/2004/helix/webassembly/Dockerfile
@@ -1,5 +1,8 @@
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:windowsservercore-2004-helix-amd64
 
+# Install arial font for chrome
+COPY arial.ttf c:/windows/fonts
+
 # Install git
 ENV GIT_VERSION=2.31.1
 ENV GIT_INSTALLER=MinGit-${GIT_VERSION}-64-bit.zip

--- a/src/windowsservercore/2004/helix/webassembly/hooks/pre-build.ps1
+++ b/src/windowsservercore/2004/helix/webassembly/hooks/pre-build.ps1
@@ -1,0 +1,1 @@
+cp /windows/fonts/arial.ttf .


### PR DESCRIPTION
Considered using

    COPY --from=mcr.microsoft.com/windows:1903 /windows/fonts/arial.ttf c:/windows/fonts

That would need large download, so hopefully we can avoid it.