### PR TITLE
make ping suid so helix user can run it

### DIFF
--- a/src/fedora/32/helix/amd64/Dockerfile
+++ b/src/fedora/32/helix/amd64/Dockerfile
@@ -31,7 +31,8 @@ ENV LANG=en-US.UTF-8
 # Fedora does not have all options as other Linux systems
 RUN /usr/sbin/adduser --uid 1000 --shell /bin/bash --group adm helixbot && \
     chmod 755 /root && \
-    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers && \
+    chmod +s /usr/bin/ping
 
 USER helixbot
 


### PR DESCRIPTION
I found problem with previous image as it cannot run Ping test. 

the ping is no longer said and it depends on ping_group_range instead.
https://unix.stackexchange.com/questions/592911/how-does-ping-work-on-fedora-without-setuid-and-capabilities

That would have been set on real Fedora system but it may or may not be set for the container as it depends on base OS.

This is small change to make ping working for ordinary users again.

before
```
[helixbot@6e230f7158c4 /]$ ping6  ::1
ping6: socket: Operation not permitted
[helixbot@6e230f7158c4 /]$ ping 127.0.0.1
ping: socket: Operation not permitted
```

after 
```
[helixbot@6e230f7158c4 /]$ ping 127.0.0.1
PING 127.0.0.1 (127.0.0.1) 56(84) bytes of data.
64 bytes from 127.0.0.1: icmp_seq=1 ttl=64 time=0.047 ms
[helixbot@6e230f7158c4 /]$ ping6 ::1
PING ::1(::1) 56 data bytes
64 bytes from ::1: icmp_seq=1 ttl=64 time=0.044 ms
```