### PR TITLE
Add lld into Ubuntu 16.04 cross images

### DIFF
--- a/src/ubuntu/16.04/coredeps/Dockerfile
+++ b/src/ubuntu/16.04/coredeps/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update \
 
 # Dependencies for CoreCLR, Mono and CoreFX
 RUN apt-get update \
+    && apt-get -f install -y \
     && apt-get install -y \
         autoconf \
         automake \

--- a/src/ubuntu/16.04/cross/arm64/Dockerfile
+++ b/src/ubuntu/16.04/cross/arm64/Dockerfile
@@ -2,6 +2,7 @@ FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-crossdeps
 
 # Install binutils-aarch64-linux-gnu
 RUN apt-get update \
+    && apt-get -f install -y \
     && apt-get install -y \
         binutils-aarch64-linux-gnu \
     && rm -rf /var/lib/apt/lists/*

--- a/src/ubuntu/16.04/crossdeps/Dockerfile
+++ b/src/ubuntu/16.04/crossdeps/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update \
         clang-9 \
         clang-tools-9 \
         liblldb-6.0-dev \
+        lld-9 \
         lldb-6.0 \
         llvm-9 \
         python-lldb-6.0 \


### PR DESCRIPTION
In my previous change that added lld, I've missed the Ubuntu 16.04 that
we still use for building for arm/arm64. This will be used temporarily
until the cross build is moved to centos 7.