### PR TITLE
Fix node path in AzDO agent label for Alpine 3.13 with node image

### DIFF
--- a/src/alpine/3.13/WithNode/amd64/Dockerfile
+++ b/src/alpine/3.13/WithNode/amd64/Dockerfile
@@ -28,7 +28,7 @@ RUN apk add --no-cache --virtual .build-deps-yarn \
             && apk del .build-deps-yarn
 
 # Add label for bring your own node in azure devops
-LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/local/bin/node"
+LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/bin/node"
 
 # Start node
 CMD [ "node" ]


### PR DESCRIPTION
In our 3.9 image node resides in /usr/local/bin/, whereas in the 3.1.13 image it's in a different path - under /usr/bin. This was making it impossible to use this image as a container for the container-powered workloads in AzDO.