### PR TITLE
Add the lldb python support to Alpine 3.12/3.13

### DIFF
--- a/src/alpine/3.12/helix/amd64/Dockerfile
+++ b/src/alpine/3.12/helix/amd64/Dockerfile
@@ -24,12 +24,14 @@ RUN apk update && \
         libffi \
         libffi-dev \
         linux-headers \
+        lldb \
         lldb-dev \
         llvm \
         make \
         openssl \
         openssl-dev \
         py-cffi \
+        py3-lldb \
         python3 \
         python3-dev \
         sudo \

--- a/src/alpine/3.13/amd64/Dockerfile
+++ b/src/alpine/3.13/amd64/Dockerfile
@@ -20,12 +20,14 @@ RUN apk add --no-cache \
         libtool \
         libunwind-dev \
         linux-headers \
+        lldb \
         lldb-dev \
         llvm \
         make \
         openssl \
         openssl-dev \
         paxctl \
+        py3-lldb \
         python2 \
         python3 \
         python3-dev \


### PR DESCRIPTION
Needed to run the diagnostics SOS tests. Adding lldb-dev only allowed it to be built not run.

/cc: @hoyosjs