### PR TITLE
Symlink post-build hooks and quote strings

### DIFF
--- a/src/ubuntu/18.04/cross/s390x/hooks/post-build
+++ b/src/ubuntu/18.04/cross/s390x/hooks/post-build
@@ -1,3 +1,1 @@
-#!/usr/bin/env sh
-
-rm -rf $PWD/rootfs*.tar
+../../../../build-scripts/build-rootfs-cleanup.sh

--- a/src/ubuntu/18.04/mlnet/cross/arm/hooks/post-build
+++ b/src/ubuntu/18.04/mlnet/cross/arm/hooks/post-build
@@ -1,3 +1,1 @@
-#!/usr/bin/env sh
-
-rm -rf $PWD/rootfs*.tar
+../../../../../build-scripts/build-rootfs-cleanup.sh

--- a/src/ubuntu/18.04/mlnet/cross/arm64/hooks/post-build
+++ b/src/ubuntu/18.04/mlnet/cross/arm64/hooks/post-build
@@ -1,3 +1,1 @@
-#!/usr/bin/env sh
-
-rm -rf $PWD/rootfs*.tar
+../../../../../build-scripts/build-rootfs-cleanup.sh

--- a/src/ubuntu/build-scripts/build-rootfs.sh
+++ b/src/ubuntu/build-scripts/build-rootfs.sh
@@ -17,7 +17,7 @@ dockerCrossDepsTag="${DOCKER_REPO:-mcr.microsoft.com/dotnet-buildtools/prereqs}:
 arch=${archArg:-'arm'}
 
 # If argument five was set, use that as the rootfsBinDir, otherwise use default : '/rootfs/$arch/bin'
-rootfsBinDir=${rootfsBinDirArg:-"/rootfs/$arch/bin"}
+rootfsBinDir="${rootfsBinDirArg:-"/rootfs/$arch/bin"}"
 
 rm -rf $PWD/rootfs.$arch.tar
 
@@ -55,7 +55,7 @@ fi
 
 echo "Checking existence of $rootfsBinDir"
 docker exec $buildRootFSContainer \
-    [ -d $rootfsBinDir ]
+    [ -d "$rootfsBinDir" ]
 
 if [ $? -ne 0 ]; then
     echo "Rootfs build failed: $rootfsBinDir empty"


### PR DESCRIPTION
$rootfsBinDir quoting is to work with path with spaces.