### PR TITLE
Added libssl-dev to msquic build image

### DIFF
--- a/src/ubuntu/18.04/msquic/amd64/Dockerfile
+++ b/src/ubuntu/18.04/msquic/amd64/Dockerfile
@@ -18,11 +18,12 @@ RUN curl -OL https://packages.microsoft.com/config/ubuntu/18.04/packages-microso
         git \
         liblttng-ust-dev \
         lttng-tools \
+        libssl-dev \
         rpm \
         ruby ruby-dev \
         sudo \
     && rm -rf /var/lib/apt/lists/* \
-    &&  gem install fpm \
+    && gem install fpm \
     && curl -OL https://cmake.org/files/v3.17/cmake-3.17.0-Linux-x86_64.tar.gz \
     && tar -xf cmake-3.17.0-Linux-x86_64.tar.gz --strip 1 -C /usr/local \
     && rm cmake-3.17.0-Linux-x86_64.tar.gz

--- a/src/ubuntu/18.04/msquic/amd64/Dockerfile
+++ b/src/ubuntu/18.04/msquic/amd64/Dockerfile
@@ -17,8 +17,8 @@ RUN curl -OL https://packages.microsoft.com/config/ubuntu/18.04/packages-microso
         dotnet-sdk-5.0 \
         git \
         liblttng-ust-dev \
-        lttng-tools \
         libssl-dev \
+        lttng-tools \
         rpm \
         ruby ruby-dev \
         sudo \


### PR DESCRIPTION
In order to build msquic without statically linking crypto functions we need libssl-dev in the image.
Unblocks https://github.com/dotnet/msquic/pull/31

I locally tested the image that it can build msquic with `QUIC_USE_SYSTEM_LIBCRYPTO=true`