### PR TITLE
Add required common pipeline variables

### DIFF
--- a/eng/pipelines/variables/common.yml
+++ b/eng/pipelines/variables/common.yml
@@ -15,3 +15,5 @@ variables:
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
     - name: build.imageBuilderDockerRunExtraOptions
       value: -e DOCKER_REPO=$(acr.server)/$(stagingRepoPrefix)dotnet-buildtools/prereqs
+    - group: DotNet-Docker-Common
+    - group: DotNet-Docker-Secrets 


### PR DESCRIPTION
Due to the changes in https://github.com/dotnet/docker-tools/pull/841, the common pipeline variables have been removed out of eng/common/templates/variables/common.yml and now need to be located in eng/pipelines/variables/common.yml.