### PR TITLE
Add missing tzdata in alpine 3.13 and 3.14 amd64

### DIFF
--- a/src/alpine/3.13/WithNode/amd64/Dockerfile
+++ b/src/alpine/3.13/WithNode/amd64/Dockerfile
@@ -1,34 +1,9 @@
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.13
-RUN apk update
 
-ENV NODE_VERSION=14.16.1
-
-### INSTALL NODE
-RUN apk add --no-cache nodejs
-
-ENV YARN_VERSION=1.10.1
-
-RUN apk add --no-cache --virtual .build-deps-yarn \
-        gnupg \
-        tar \
-        && for key in \
-            6A010C5166006599AA17F08146C2130DFD2497F5 \
-        ; do \
-            gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" \
-            || gpg --keyserver hkps://keys.openpgp.org --recv-keys "$key"; \
-        done \
-            && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
-            && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
-            && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
-            && mkdir -p /opt \
-            && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
-            && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
-            && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
-            && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
-            && apk del .build-deps-yarn
+RUN apk update && apk add --no-cache nodejs yarn
 
 # Add label for bring your own node in azure devops
 LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/bin/node"
 
-# Start node
+# Set node as a default command
 CMD [ "node" ]

--- a/src/alpine/3.13/WithNode/amd64/Dockerfile
+++ b/src/alpine/3.13/WithNode/amd64/Dockerfile
@@ -1,6 +1,9 @@
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.13
 
-RUN apk update && apk add --no-cache nodejs yarn
+RUN apk update && \
+    apk add --no-cache \
+        nodejs \
+        yarn
 
 # Add label for bring your own node in azure devops
 LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/bin/node"

--- a/src/alpine/3.13/amd64/Dockerfile
+++ b/src/alpine/3.13/amd64/Dockerfile
@@ -1,8 +1,7 @@
 FROM alpine:3.13
 
-RUN apk update
-
-RUN apk add --no-cache \
+RUN apk update && \
+    apk add --no-cache \
         autoconf \
         automake \
         bash \
@@ -12,7 +11,6 @@ RUN apk add --no-cache \
         cmake \
         coreutils \
         curl \
-        curl-dev \
         gcc \
         gettext-dev \
         git \
@@ -21,7 +19,7 @@ RUN apk add --no-cache \
         libtool \
         libunwind-dev \
         linux-headers \
-        lldb \
+        lld \
         lldb-dev \
         llvm \
         lttng-ust-dev \
@@ -31,7 +29,6 @@ RUN apk add --no-cache \
         openssl-dev \
         paxctl \
         py3-lldb \
-        python3 \
         python3-dev \
         shadow \
         sudo \

--- a/src/alpine/3.13/amd64/Dockerfile
+++ b/src/alpine/3.13/amd64/Dockerfile
@@ -35,6 +35,7 @@ RUN apk add --no-cache \
         python3-dev \
         shadow \
         sudo \
+        tzdata \
         util-linux-dev \
         which \
         zlib-dev

--- a/src/alpine/3.13/helix/amd64/Dockerfile
+++ b/src/alpine/3.13/helix/amd64/Dockerfile
@@ -2,8 +2,7 @@ FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.13
 RUN apk update && apk add --no-cache \
     cargo \
     iputils \
-    libffi-dev \
-    rust
+    libffi-dev
 
 # Install Helix Dependencies
 

--- a/src/alpine/3.13/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.13/helix/arm32v7/Dockerfile
@@ -1,7 +1,5 @@
 FROM arm32v7/alpine:3.13
 
-# Install .NET Core Dependencies for Alpine
-
 RUN apk update && \
     apk add --no-cache \
         autoconf \
@@ -22,7 +20,6 @@ RUN apk update && \
         krb5-dev \
         libtool \
         libunwind-dev \
-        libffi \
         libffi-dev \
         linux-headers \
         llvm \
@@ -32,9 +29,7 @@ RUN apk update && \
         openssl-dev \
         paxctl \
         py-cffi \
-        python3 \
         python3-dev \
-        rust \
         sudo \
         tzdata \
         util-linux-dev \

--- a/src/alpine/3.13/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.13/helix/arm64v8/Dockerfile
@@ -1,7 +1,5 @@
 FROM arm64v8/alpine:3.13
 
-# Install .NET Core Dependencies for Alpine
-
 RUN apk update && \
     apk add --no-cache \
         autoconf \
@@ -22,7 +20,6 @@ RUN apk update && \
         krb5-dev \
         libtool \
         libunwind-dev \
-        libffi \
         libffi-dev \
         linux-headers \
         llvm \
@@ -33,9 +30,7 @@ RUN apk update && \
         openssl-dev \
         paxctl \
         py-cffi \
-        python3 \
         python3-dev \
-        rust \
         sudo \
         tzdata \
         util-linux-dev \

--- a/src/alpine/3.14/WithNode/amd64/Dockerfile
+++ b/src/alpine/3.14/WithNode/amd64/Dockerfile
@@ -1,6 +1,9 @@
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.14
 
-RUN apk update && apk add --no-cache nodejs yarn
+RUN apk update && \
+    apk add --no-cache \
+        nodejs \
+        yarn
 
 # Add label for bring your own node in azure devops
 LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/bin/node"

--- a/src/alpine/3.14/amd64/Dockerfile
+++ b/src/alpine/3.14/amd64/Dockerfile
@@ -1,8 +1,7 @@
 FROM alpine:3.14
 
-RUN apk update
-
-RUN apk add --no-cache \
+RUN apk update && \
+    apk add --no-cache \
         autoconf \
         automake \
         bash \
@@ -12,7 +11,6 @@ RUN apk add --no-cache \
         cmake \
         coreutils \
         curl \
-        curl-dev \
         gcc \
         gettext-dev \
         git \
@@ -22,6 +20,7 @@ RUN apk add --no-cache \
         libunwind-dev \
         linux-headers \
         lld \
+        lldb-dev \
         llvm \
         lttng-ust-dev \
         make \
@@ -29,7 +28,7 @@ RUN apk add --no-cache \
         openssl \
         openssl-dev \
         paxctl \
-        python3 \
+        py3-lldb \
         python3-dev \
         shadow \
         sudo \
@@ -37,5 +36,3 @@ RUN apk add --no-cache \
         util-linux-dev \
         which \
         zlib-dev
-
-RUN ln -sf /usr/bin/python3 /usr/bin/python

--- a/src/alpine/3.14/amd64/Dockerfile
+++ b/src/alpine/3.14/amd64/Dockerfile
@@ -33,6 +33,7 @@ RUN apk add --no-cache \
         python3-dev \
         shadow \
         sudo \
+        tzdata \
         util-linux-dev \
         which \
         zlib-dev

--- a/src/alpine/3.14/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.14/helix/arm32v7/Dockerfile
@@ -1,7 +1,5 @@
 FROM arm32v7/alpine:3.14
 
-# Install .NET Core Dependencies for Alpine
-
 RUN apk update && \
     apk add --no-cache \
         autoconf \
@@ -22,7 +20,6 @@ RUN apk update && \
         krb5-dev \
         libtool \
         libunwind-dev \
-        libffi \
         libffi-dev \
         linux-headers \
         llvm \
@@ -33,9 +30,7 @@ RUN apk update && \
         openssl-dev \
         paxctl \
         py-cffi \
-        python3 \
         python3-dev \
-        rust \
         sudo \
         tzdata \
         util-linux-dev \

--- a/src/alpine/3.14/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.14/helix/arm64v8/Dockerfile
@@ -1,6 +1,4 @@
-FROM arm64v8/alpine:3.13
-
-# Install .NET Core Dependencies for Alpine
+FROM arm64v8/alpine:3.14
 
 RUN apk update && \
     apk add --no-cache \
@@ -22,7 +20,6 @@ RUN apk update && \
         krb5-dev \
         libtool \
         libunwind-dev \
-        libffi \
         libffi-dev \
         linux-headers \
         llvm \
@@ -33,9 +30,7 @@ RUN apk update && \
         openssl-dev \
         paxctl \
         py-cffi \
-        python3 \
         python3-dev \
-        rust \
         sudo \
         tzdata \
         util-linux-dev \


### PR DESCRIPTION
@ViktorHofer, this one got missed in the refactoring, which is why the ICU test was failing to find `Europe/London` timezone (amd64-only issue).