### PR TITLE
Use node.js from a shared location

### DIFF
--- a/src/alpine/3.13/WithNode/amd64/Dockerfile
+++ b/src/alpine/3.13/WithNode/amd64/Dockerfile
@@ -4,18 +4,19 @@ RUN apk update && \
     apk add --no-cache \
         yarn
 
-# We need to pin node.js to v10.24.1, because ExtractFiles AzDO task is currently failing with ENOBUFS
-# see https://github.com/microsoft/azure-pipelines-tasks/issues/15261
+# We need to pin node.js to v10.24.1, because ExtractFiles AzDO task is currently failing with ENOBUFS;
+# see https://github.com/microsoft/azure-pipelines-tasks/issues/15261.
 ARG NODEJS_VERSION=10.24.1
 
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.1/install.sh | bash; \
-    echo 'export NVM_NODEJS_ORG_MIRROR=https://unofficial-builds.nodejs.org/download/release;' >> $HOME/.profile; \
-    echo 'nvm_get_arch() { nvm_echo "x64-musl"; }' >> $HOME/.profile; \
-    NVM_DIR="$HOME/.nvm"; source $HOME/.nvm/nvm.sh; source $HOME/.profile; \
-    nvm install $NODEJS_VERSION
+# yarn has a dependency on node.js LTS version from packages, which gets installed at /usr/bin/node
+# so we download and extract the desired node.js version at /usr/share/node/bin/node and symlink
+# at /usr/local/bin/node. /usr/local/bin has precedence over /usr/bin in $PATH.
+RUN mkdir /usr/share/node && \
+    curl -sSL https://unofficial-builds.nodejs.org/download/release/v$NODEJS_VERSION/node-v$NODEJS_VERSION-linux-x64-musl.tar.gz | tar xzf - --strip-components=1 -C /usr/share/node && \
+    ln -s /usr/share/node/bin/node /usr/local/bin/node
 
 # Add label for bring your own node in azure devops
-LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/root/.nvm/versions/node/v$NODEJS_VERSION/bin/node"
+LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/local/bin/node"
 
 # Set node as a default command
 CMD [ "node" ]

--- a/src/alpine/3.14/WithNode/amd64/Dockerfile
+++ b/src/alpine/3.14/WithNode/amd64/Dockerfile
@@ -4,18 +4,19 @@ RUN apk update && \
     apk add --no-cache \
         yarn
 
-# We need to pin node.js to v10.24.1, because ExtractFiles AzDO task is currently failing with ENOBUFS
-# see https://github.com/microsoft/azure-pipelines-tasks/issues/15261
+# We need to pin node.js to v10.24.1, because ExtractFiles AzDO task is currently failing with ENOBUFS;
+# see https://github.com/microsoft/azure-pipelines-tasks/issues/15261.
 ARG NODEJS_VERSION=10.24.1
 
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.1/install.sh | bash; \
-    echo 'export NVM_NODEJS_ORG_MIRROR=https://unofficial-builds.nodejs.org/download/release;' >> $HOME/.profile; \
-    echo 'nvm_get_arch() { nvm_echo "x64-musl"; }' >> $HOME/.profile; \
-    NVM_DIR="$HOME/.nvm"; source $HOME/.nvm/nvm.sh; source $HOME/.profile; \
-    nvm install $NODEJS_VERSION
+# yarn has a dependency on node.js LTS version from packages, which gets installed at /usr/bin/node
+# so we download and extract the desired node.js version at /usr/share/node/bin/node and symlink
+# at /usr/local/bin/node. /usr/local/bin has precedence over /usr/bin in $PATH.
+RUN mkdir /usr/share/node && \
+    curl -sSL https://unofficial-builds.nodejs.org/download/release/v$NODEJS_VERSION/node-v$NODEJS_VERSION-linux-x64-musl.tar.gz | tar xzf - --strip-components=1 -C /usr/share/node && \
+    ln -s /usr/share/node/bin/node /usr/local/bin/node
 
 # Add label for bring your own node in azure devops
-LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/root/.nvm/versions/node/v$NODEJS_VERSION/bin/node"
+LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/local/bin/node"
 
 # Set node as a default command
 CMD [ "node" ]


### PR DESCRIPTION
Upon consuming the new images, it turned out `helixbot_azpcontainer` (the user created during `Initialize containers` step) does not have access to `/root`, although the logs [do suggest](https://dev.azure.com/dnceng/public/_build/results?buildId=1353034&view=logs&j=174348cd-3455-59d8-c7f7-32c969b0807d&t=8a37b7b6-cca0-42a9-93a4-6c86eb692846&l=45) as if it has same access as root..

Simpler way is to just download the version we need in `/usr/share/node/` directory, and symlink the binary at `/usr/local/bin/node`.