### PR TITLE
Add a separate image for gcc 11

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1127,6 +1127,19 @@
           "platforms": [
             {
               "architecture": "amd64",
+              "dockerfile": "src/debian/11/gcc11",
+              "os": "linux",
+              "osVersion": "bullseye",
+              "tags": {
+                "debian-11-gcc11-amd64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "architecture": "amd64",
               "dockerfile": "src/debian/11/helix/amd64",
               "os": "linux",
               "osVersion": "bullseye",

--- a/src/debian/11/gcc11/Dockerfile
+++ b/src/debian/11/gcc11/Dockerfile
@@ -1,0 +1,31 @@
+FROM gcc:11-bullseye
+
+# Dependencies for dotnet/runtime native components.
+RUN apt-get update && \
+    apt-get install -y \
+        cmake \
+        curl \
+        gdb \
+        git \
+        iputils-ping \
+        libicu-dev \
+        libkrb5-dev \
+        liblttng-ust-dev \
+        libssl-dev \
+        liblldb-dev \
+        lttng-tools \
+        locales \
+        locales-all \
+        python3-dev \
+        python3-pip \
+        sudo \
+        tzdata \
+    && rm -rf /var/lib/apt/lists/* \
+    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+ENV LANG=en_US.utf8
+
+# These symlinks are required because this docker has gcc-10 suffixed with version and gcc-11 unsuffixed in PATH.
+# In the runtime repo, we (by design) give precedence to suffixed compilers before selecting unsuffixed one in PATH.
+RUN ln -s $(command -v gcc) /usr/bin/gcc-11 && \
+    ln -s $(command -v g++) /usr/bin/g++-11


### PR DESCRIPTION
GNU compiler toolchain is used in runtime for native build validation. The LLVM toolchain is default one to build the shipping product.

Currently we are using gcc9 from `centos-7` image, which we install from YUM packages when building the prereq image for two purposes:
1. to compile custom llvm toolchain
2. to use it in for the said validation leg in runtime repo

Therefore, it is non-trivial to upgrade gcc independently, as first we need to wait fro `devtoolset` to pick up the GNU version, then we need to make sure our custom llvm toolchain's build is intact.

This PR adds gcc 11 leg based on official library layer (https://hub.docker.com/_/gcc), which uses Debian 11 (buillseye) for gcc 11. In future, we can add `src/debian/{version}/gcc/Dockerfile` when needed, without affecting anything else.