### PR TITLE
Fix mono repository host name

### DIFF
--- a/src/ubuntu/16.04/helix/arm32v7/Dockerfile
+++ b/src/ubuntu/16.04/helix/arm32v7/Dockerfile
@@ -10,7 +10,7 @@ ENV _PYTHON_HOST_PLATFORM=linux_armv7l
 RUN apt-get update && \
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
     apt-get install -y apt-transport-https ca-certificates && \
-    echo "deb https://origin-download.mono-project.com/repo/ubuntu stable-xenial main" | tee /etc/apt/sources.list.d/mono-official-preview.list  && \
+    echo "deb https://download.mono-project.com/repo/ubuntu stable-xenial main" | tee /etc/apt/sources.list.d/mono-official-preview.list  && \
     apt-get update && \
     apt-get install -y \
         autoconf \

--- a/src/ubuntu/18.04/helix/arm32v7/Dockerfile
+++ b/src/ubuntu/18.04/helix/arm32v7/Dockerfile
@@ -12,7 +12,7 @@ ENV _PYTHON_HOST_PLATFORM=linux_armv7l
 RUN apt-get update && \
     apt-get install -qq -y gnupg ca-certificates && \
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
-    echo "deb https://origin-download.mono-project.com/repo/ubuntu stable-bionic main" | tee /etc/apt/sources.list.d/mono-official-preview.list && \
+    echo "deb https://download.mono-project.com/repo/ubuntu stable-bionic main" | tee /etc/apt/sources.list.d/mono-official-preview.list && \
     apt-get update && \
     apt-get install -qq -y \
         autoconf \


### PR DESCRIPTION
The Helix Ubuntu Arm32 Dockerfiles are failing to build when accessing the Mono package repository.  Error message: `E: Failed to fetch https://origin-download.mono-project.com/repo/ubuntu/dists/stable-xenial/main/binary-armhf/Packages  server certificate verification failed. CAfile: /etc/ssl/certs/ca-certificates.crt CRLfile: none`

This is resolved by updating the host name from `origin-download.mono-project.com` to `download.mono-project.com`.