### PR TITLE
Skip installing pip from weak deps

### DIFF
--- a/src/fedora/34/amd64/Dockerfile
+++ b/src/fedora/34/amd64/Dockerfile
@@ -3,7 +3,7 @@ FROM registry.fedoraproject.org/fedora:34
 # Install the base toolchain we need to build anything (clang, cmake, make and the like)
 # this does not include libraries that we need to compile different projects, we'd like
 # them in a different layer.
-RUN dnf install -y \
+RUN dnf --setopt=install_weak_deps=False install -y \
         clang \
         cmake \
         dnf-plugins-core \
@@ -24,7 +24,7 @@ RUN dnf config-manager --add-repo https://packages.microsoft.com/fedora/34/prod/
     rm /tmp/microsoft.asc
 
 # Install tools used by build automation.
-RUN dnf install -y \
+RUN dnf --setopt=install_weak_deps=False install -y \
         git \
         tar \
         procps \
@@ -32,7 +32,7 @@ RUN dnf install -y \
     && dnf clean all
 
 # Dependencies of CoreCLR, Mono and CoreFX.
-RUN dnf install -y \
+RUN dnf --setopt=install_weak_deps=False install -y \
         autoconf \
         automake \
         glibc-locale-source \
@@ -41,6 +41,7 @@ RUN dnf install -y \
         libcurl-devel \
         libgdiplus \
         libicu-devel \
+        libomp-devel \
         libtool \
         libunwind-devel \
         libuuid-devel \


### PR DESCRIPTION
Fedora 34 build started to fail recently https://dev.azure.com/dnceng/public/_build/results?buildId=1356807&view=logs&j=713d3e5f-f6a4-56d6-79f4-bba7fa11838c&t=8bb88579-afd7-5860-9e3c-89c6414081a4&l=1927:

```
Installing collected packages: wheel, pip
  Attempting uninstall: pip
    Found existing installation: pip 21.0.1
ERROR: Cannot uninstall pip 21.0.1, RECORD file not found. Hint: The package was installed by rpm.
```

apparently until yesterday it was fine .. https://dev.azure.com/dnceng/public/_build/results?buildId=1350156&view=logs&j=713d3e5f-f6a4-56d6-79f4-bba7fa11838c

Seems like maintainers have recently marked `python-pip` as an optional/weak dependency:

```
2021-09-11T07:14:22.4929004Z Installing weak dependencies:
2021-09-11T07:14:22.4929613Z  compiler-rt                 x86_64  12.0.1-1.fc34               updates  2.3 M
2021-09-11T07:14:22.4930291Z  gcc-gdb-plugin              x86_64  11.2.1-1.fc34               updates  143 k
2021-09-11T07:14:22.4930942Z  libomp                      x86_64  12.0.1-1.fc34               updates  353 k
2021-09-11T07:14:22.4931617Z  libomp-devel                x86_64  12.0.1-1.fc34               updates   24 k
2021-09-11T07:14:22.4932285Z  libxcrypt-compat            x86_64  4.4.25-1.fc34               updates   89 k
2021-09-11T07:14:22.4932941Z  mkpasswd                    x86_64  5.5.10-1.fc34               updates   41 k
2021-09-11T07:14:22.4933613Z  python3-pip                 noarch  21.0.1-3.fc34               updates  1.8 M
2021-09-11T07:14:22.4933892Z 
2021-09-11T07:14:22.4934559Z Transaction Summary
2021-09-11T07:14:22.4934952Z ================================================================================
``` 
(python3-pip is new between [yesterday's logs](https://dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_apis/build/builds/1350156/logs/1036) and [today's logs](https://dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_apis/build/builds/1356807/logs/1286))

Fix is to skip weak deps, and explicitly specify stuff we need. Just to be on the safe side, I have kept `libomp-dev` as it's used by ML.NET, however we only explicitly require it on Ubuntu (see, e.g. rootfs setup https://github.com/dotnet/arcade/blob/054309cb477a969df1197b9286a625827217af5f/eng/common/cross/build-rootfs.sh#L78-L80).