### PR TITLE
Use Alpine 3.13 (now default) for cross-build image

### DIFF
--- a/src/ubuntu/16.04/cross/arm-alpine/hooks/pre-build
+++ b/src/ubuntu/16.04/cross/arm-alpine/hooks/pre-build
@@ -2,4 +2,4 @@
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
-$SCRIPTPATH/../../../../build-scripts/build-rootfs.sh ubuntu-16.04 alpine3.13 arm lldb3.9
+$SCRIPTPATH/../../../../build-scripts/build-rootfs.sh ubuntu-16.04 alpine arm lldb3.9

--- a/src/ubuntu/16.04/cross/arm64-alpine/hooks/pre-build
+++ b/src/ubuntu/16.04/cross/arm64-alpine/hooks/pre-build
@@ -2,4 +2,4 @@
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
-$SCRIPTPATH/../../../../build-scripts/build-rootfs.sh ubuntu-16.04 alpine arm64 lldb3.9
+$SCRIPTPATH/../../../../build-scripts/build-rootfs.sh ubuntu-16.04 alpine3.13 arm64 lldb3.9

--- a/src/ubuntu/18.04/cross/arm-alpine/hooks/pre-build
+++ b/src/ubuntu/18.04/cross/arm-alpine/hooks/pre-build
@@ -2,4 +2,4 @@
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
-$SCRIPTPATH/../../../../build-scripts/build-rootfs.sh ubuntu-18.04 alpine3.13 arm lldb3.9
+$SCRIPTPATH/../../../../build-scripts/build-rootfs.sh ubuntu-18.04 alpine arm lldb3.9

--- a/src/ubuntu/18.04/cross/arm64-alpine/hooks/pre-build
+++ b/src/ubuntu/18.04/cross/arm64-alpine/hooks/pre-build
@@ -2,4 +2,4 @@
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
-$SCRIPTPATH/../../../../build-scripts/build-rootfs.sh ubuntu-18.04 alpine arm64 lldb3.9
+$SCRIPTPATH/../../../../build-scripts/build-rootfs.sh ubuntu-18.04 alpine3.13 arm64 lldb3.9


### PR DESCRIPTION
cross-build of arm32 is currently using 3.13 and arm64 is using 3.9. We have updated rootfs script to set 3.13 as a minimum version https://github.com/dotnet/arcade/pull/7849. This PR aims to rebuild both arm and arm64 cross-build Alpine images, so 3.13 is used consistently for alpine on all supported architectures.