### PR TITLE
Add CentOS Stream 9

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -172,6 +172,18 @@
         {
           "platforms": [
             {
+              "dockerfile": "src/centos/stream9",
+              "os": "linux",
+              "osVersion": "centos-stream9",
+              "tags": {
+                "centos-stream9-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
               "dockerfile": "src/centos/8",
               "os": "linux",
               "osVersion": "centos8",

--- a/src/centos/stream9/Dockerfile
+++ b/src/centos/stream9/Dockerfile
@@ -1,0 +1,53 @@
+FROM quay.io/centos/centos:stream9-development
+
+# Install dependencies
+
+RUN dnf install --setopt tsflags=nodocs --refresh -y \
+        dnf-plugins-core \
+    && \
+    dnf config-manager --set-enabled crb \
+    && \
+    dnf install --setopt tsflags=nodocs -y \
+        "perl(Time::HiRes)" \
+        autoconf \
+        automake \
+        clang \
+        cmake \
+        curl-devel \
+        doxygen \
+        findutils \
+        gcc \
+        gdb \
+        git \
+        glibc-langpack-en \
+        hostname \
+        krb5-devel \
+        libcurl-devel \
+        libedit-devel \
+        libicu-devel \
+        libidn2-devel \
+        libnghttp2-devel \
+        libtool \
+        libuuid-devel \
+        libxml2-devel \
+        lld \
+        lldb-devel \
+        llvm \
+        lttng-ust-devel \
+        lzma \
+        make \
+        ncurses-devel \
+        numactl-devel \
+        openssl-devel \
+        python3 \
+        python3-devel \
+        readline-devel \
+        sudo \
+        swig \
+        tar \
+        wget \
+        which \
+        xz \
+        zlib-devel \
+    && \
+    dnf clean all


### PR DESCRIPTION
Which is different from CentOS 9. From the FAQ [1]:

> There will not be a CentOS Linux 9.
>
> CentOS Stream 9 will launch in Q2 2021 as part of the RHEL 9 development process.

In other words, this will let us target/test against the development versions of RHEL 9.

In particular, this would be useful for adding to source-build test matrix: https://github.com/dotnet/source-build/issues/2299

[1] https://www.redhat.com/en/blog/faq-centos-stream-updates