### PR TITLE
Adding ML.NET ubuntu 18.04 helix docker image

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -799,7 +799,10 @@
               "os": "linux",
               "osVersion": "bionic",
               "tags": {
-                "ubuntu-18.04-mlnet-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
+                "ubuntu-18.04-mlnet-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "ubuntu-18.04-mlnet": {
+                  "isLocal": true
+                }
               }
             }
           ]
@@ -824,6 +827,18 @@
               "osVersion": "bionic",
               "tags": {
                 "ubuntu-18.04-mlnet-cross-arm64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/18.04/mlnet/helix",
+              "os": "linux",
+              "osVersion": "bionic",
+              "tags": {
+                "ubuntu-18.04-mlnet-helix-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
               }
             }
           ]

--- a/src/ubuntu/18.04/mlnet/helix/Dockerfile
+++ b/src/ubuntu/18.04/mlnet/helix/Dockerfile
@@ -1,0 +1,53 @@
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-mlnet
+
+# Install Helix Dependencies
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -qq -y \
+        autoconf \
+        automake \
+        build-essential \
+        cmake \
+        clang \
+        gcc \
+        gdb \
+        git \
+        gss-ntlmssp \
+        iputils-ping \
+        libcurl4 \
+        libffi-dev \
+        libgdiplus \
+        libicu-dev \
+        libssl-dev \
+        libtool \
+        libunwind8 \
+        libunwind-dev \
+        lldb-3.9 \
+        locales \
+        locales-all \
+        python3-dev \
+        python3-pip \
+        sudo \
+        tzdata \
+        unzip \
+    && rm -rf /var/lib/apt/lists/* \
+    \
+    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+ENV LANG=en_US.utf8
+
+RUN ln -sf /usr/bin/python3 /usr/bin/python && \
+    python -m pip install --upgrade pip==20.2 && \
+    python -m pip install virtualenv==16.6.0 && \
+    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    pip install ./helix_scripts-*-py3-none-any.whl
+
+# create helixbot user and give rights to sudo without password
+RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm helixbot && \
+    chmod 755 /root && \
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
+
+USER helixbot
+
+RUN python -m virtualenv --no-site-packages /home/helixbot/.vsts-env


### PR DESCRIPTION
With Ubuntu 16.04 no longer being supported and its queues are being removed from Azure Devops we need to start using Ubuntu 18.04 for ML.NET. This PR adds in a new docker image that adds the required dependencies for helix/ML.NET in Ubuntu 18.04.