### PR TITLE
Fix font installation for wasm Dockerfile build

### DIFF
--- a/src/windowsservercore/2004/helix/webassembly/hooks/pre-build.ps1
+++ b/src/windowsservercore/2004/helix/webassembly/hooks/pre-build.ps1
@@ -1,1 +1,1 @@
-cp /windows/fonts/arial.ttf .
+cp $env:windir/fonts/arial.ttf .


### PR DESCRIPTION
The build of the wasm Dockerfile for Windows is failing when attempting to copy a font from the build context at https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/4bcda2eb01adb700d7c55c9c114d1252301562d1/src/windowsservercore/2004/helix/webassembly/Dockerfile#L12.  The file doesn't exist because the pre-build hook didn't execute successfully:
```
-- EXECUTING: PowerShell -NoProfile -File "D:\a\_work\1\s\dotnet-buildtools-prereqs-docker\src\windowsservercore\2004\helix\webassembly\hooks\pre-build.ps1"
cp : Cannot find path 'D:\windows\fonts\arial.ttf' because it does not exist.
At D:\a\_work\1\s\dotnet-buildtools-prereqs-docker\src\windowsservercore\2004\helix\webassembly\hooks\pre-build.ps1:1 
char:1
+ cp /windows/fonts/arial.ttf .
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (D:\windows\fonts\arial.ttf:String) [Copy-Item], ItemNotFoundException
    + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.CopyItemCommand
```

There must have been a change in the build agent so that the source is now contained on D: drive when it was C: drive before which allowed this script to previously work but now fail because it's looking for the `windows` directory on the D: drive.

I've fixed this by using an env var to get the windows directory.