### PR TITLE
openSUSE- Add font and missing build packages package

### DIFF
--- a/src/opensuse/15.2/helix/amd64/Dockerfile
+++ b/src/opensuse/15.2/helix/amd64/Dockerfile
@@ -15,14 +15,16 @@ RUN zypper ref && \
         glibc-i18ndata \
         gssntlmssp \
         iputils \
+        krb5-devel \
         lato-fonts \
         libffi-devel \
         libgdiplus-devel \
         libicu-devel \
-        libssl48 \
+        libopenssl-devel \
         libtool \
         libunwind \
         lldb-devel \
+        lttng-ust-devel \
         python3-devel \
         python3-pip \
         sudo \


### PR DESCRIPTION
- Adds fonts for System.Drawing tests
- Adds missing build packages

part of https://github.com/dotnet/runtime/pull/60161