### PR TITLE
Disable Kusto ingestion during publish

### DIFF
--- a/eng/pipelines/variables/common.yml
+++ b/eng/pipelines/variables/common.yml
@@ -14,6 +14,8 @@ variables:
   value: --var UniqueId=$(sourceBuildId)
 - name: publicSourceBranch
   value: main
+- name: ingestKustoImageInfo
+  value: false
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
     - name: build.imageBuilderDockerRunExtraOptions
       value: -e DOCKER_REPO=$(acr.server)/$(stagingRepoPrefix)dotnet-buildtools/prereqs


### PR DESCRIPTION
Kusto ingestion is not needed for the images in this repo because no analysis is done on the data. Disabling Kusto ingestion removes the need to update Image Builder to support each possible OS display name that this repo requires (see https://github.com/dotnet/docker-tools/issues/906).