### PR TITLE
Add pkill and friends to CentOS Stream 9

### DIFF
--- a/src/centos/stream9/Dockerfile
+++ b/src/centos/stream9/Dockerfile
@@ -39,6 +39,7 @@ RUN dnf install --setopt tsflags=nodocs --refresh -y \
         ncurses-devel \
         numactl-devel \
         openssl-devel \
+        procps-ng \
         python3 \
         python3-devel \
         readline-devel \


### PR DESCRIPTION
It was included in the default CentOS 8 container images and .NET builds
make use of it, so make sure it's included in CentOS Stream 9 too.

There are many other binaries/packages present in CentOS 8 that are
missing in CentOS Stream 9 too, but blindly adding all of them
(including systemd and dbus) will bloat the image for no reason. So
let's just add this one and see if others are needed too.