### PR TITLE
Fix Arm variant for raspbian crossdeps manifest entry

### DIFF
--- a/src/raspbian/manifest.json
+++ b/src/raspbian/manifest.json
@@ -16,7 +16,7 @@
                   "isLocal": true
                 }
               },
-              "variant": "v6"
+              "variant": "v7"
             }
           ]
         },


### PR DESCRIPTION
The validation that was added by https://github.com/dotnet/docker-tools/pull/940 revealed that the variant setting for the raspbian/10/crossdeps Dockerfile isn't set correctly. It's set to v6 but the the base image variant is v7.