### PR TITLE
Increase Ubuntu build timeout.

### DIFF
--- a/eng/pipelines/dotnet-buildtools-prereqs-ubuntu-pr.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-ubuntu-pr.yml
@@ -24,6 +24,6 @@ stages:
   parameters:
     internalProjectName: ${{ variables.internalProjectName }}
     publicProjectName: ${{ variables.publicProjectName }}
-    linuxAmdBuildJobTimeout: 150
+    linuxAmdBuildJobTimeout: 180
     customBuildInitSteps:
     - template: /eng/pipelines/steps/install-cross-build-prereqs.yml

--- a/eng/pipelines/dotnet-buildtools-prereqs-ubuntu.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-ubuntu.yml
@@ -23,6 +23,6 @@ stages:
   parameters:
     internalProjectName: ${{ variables.internalProjectName }}
     publicProjectName: ${{ variables.publicProjectName }}
-    linuxAmdBuildJobTimeout: 150
+    linuxAmdBuildJobTimeout: 180
     customBuildInitSteps:
     - template: /eng/pipelines/steps/install-cross-build-prereqs.yml


### PR DESCRIPTION
Since most of our cross-build infra happens on Ubuntu, a change to
a low-level component of the graph (i.e. the coredeps image) will
cause so many cache misses for downstream image builds that the build
cannot complete before the timeout times out.

See also: the build failing after merging PPC64 support