### PR TITLE
Increase Ubuntu build timeout

### DIFF
--- a/eng/pipelines/dotnet-buildtools-prereqs-ubuntu-pr.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-ubuntu-pr.yml
@@ -24,6 +24,6 @@ stages:
   parameters:
     internalProjectName: ${{ variables.internalProjectName }}
     publicProjectName: ${{ variables.publicProjectName }}
-    linuxAmdBuildJobTimeout: 180
+    linuxAmdBuildJobTimeout: 240
     customBuildInitSteps:
     - template: /eng/pipelines/steps/install-cross-build-prereqs.yml

--- a/eng/pipelines/dotnet-buildtools-prereqs-ubuntu.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-ubuntu.yml
@@ -23,6 +23,6 @@ stages:
   parameters:
     internalProjectName: ${{ variables.internalProjectName }}
     publicProjectName: ${{ variables.publicProjectName }}
-    linuxAmdBuildJobTimeout: 180
+    linuxAmdBuildJobTimeout: 240
     customBuildInitSteps:
     - template: /eng/pipelines/steps/install-cross-build-prereqs.yml


### PR DESCRIPTION
The previous build timeout update in #573 wasn't sufficient. The build is still timing out after 3 hrs. Increasing to 4 hrs.