### PR TITLE
Increase timeout further

### DIFF
--- a/eng/pipelines/dotnet-buildtools-prereqs-ubuntu-pr.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-ubuntu-pr.yml
@@ -24,6 +24,6 @@ stages:
   parameters:
     internalProjectName: ${{ variables.internalProjectName }}
     publicProjectName: ${{ variables.publicProjectName }}
-    linuxAmdBuildJobTimeout: 180
+    linuxAmdBuildJobTimeout: 210
     customBuildInitSteps:
     - template: /eng/pipelines/steps/install-cross-build-prereqs.yml

--- a/eng/pipelines/dotnet-buildtools-prereqs-ubuntu.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-ubuntu.yml
@@ -23,6 +23,6 @@ stages:
   parameters:
     internalProjectName: ${{ variables.internalProjectName }}
     publicProjectName: ${{ variables.publicProjectName }}
-    linuxAmdBuildJobTimeout: 180
+    linuxAmdBuildJobTimeout: 210
     customBuildInitSteps:
     - template: /eng/pipelines/steps/install-cross-build-prereqs.yml


### PR DESCRIPTION
Looks like last time it failed on the x86 root image, which is pretty late in the process.

Again, technically not PPC64's fault - any bump to the coredeps image would have cascaded this way