### PR TITLE
Take the timeout up to five hours

### DIFF
--- a/eng/pipelines/dotnet-buildtools-prereqs-ubuntu-pr.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-ubuntu-pr.yml
@@ -24,6 +24,6 @@ stages:
   parameters:
     internalProjectName: ${{ variables.internalProjectName }}
     publicProjectName: ${{ variables.publicProjectName }}
-    linuxAmdBuildJobTimeout: 240
+    linuxAmdBuildJobTimeout: 300
     customBuildInitSteps:
     - template: /eng/pipelines/steps/install-cross-build-prereqs.yml

--- a/eng/pipelines/dotnet-buildtools-prereqs-ubuntu.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-ubuntu.yml
@@ -23,6 +23,6 @@ stages:
   parameters:
     internalProjectName: ${{ variables.internalProjectName }}
     publicProjectName: ${{ variables.publicProjectName }}
-    linuxAmdBuildJobTimeout: 240
+    linuxAmdBuildJobTimeout: 300
     customBuildInitSteps:
     - template: /eng/pipelines/steps/install-cross-build-prereqs.yml


### PR DESCRIPTION
This whole adventure has highlighted a fragility in how we deal with changes lower down the stack which impact many many images requiring many many rebuilds. Obviously on a normal day, a five hour timeout is way too long and indicates a problem, but occasionally it's needed. Is there a better way to codify that?

As discussed on Teams, the build needs 3h50 to complete, but needs more than 10 minutes to upload the results. So with this, we're giving a nice chunky 1h10 for the upload. Plenty of time. Let's finally get the repo green again.