### PR TITLE
Add Ubuntu 22.04 helix containers

### DIFF
--- a/src/ubuntu/22.04/helix/amd64/Dockerfile
+++ b/src/ubuntu/22.04/helix/amd64/Dockerfile
@@ -1,0 +1,53 @@
+FROM ubuntu:22.04
+
+# Install Helix Dependencies
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -qq -y \
+        autoconf \
+        automake \
+        build-essential \
+        cmake \
+        clang \
+        gcc \
+        gdb \
+        git \
+        gss-ntlmssp \
+        iputils-ping \
+        libcurl4 \
+        libffi-dev \
+        libgdiplus \
+        libicu-dev \
+        libssl-dev \
+        libtool \
+        libunwind8 \
+        libunwind-dev \
+        lldb-12 \
+        locales \
+        locales-all \
+        python3-dev \
+        python3-pip \
+        sudo \
+        tzdata \
+        unzip \
+    && rm -rf /var/lib/apt/lists/* \
+    \
+    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+ENV LANG=en_US.utf8
+
+RUN ln -sf /usr/bin/python3 /usr/bin/python && \
+    python -m pip install --upgrade pip==22.0.4 && \
+    python -m pip install virtualenv==20.14.0 && \
+    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    pip install ./helix_scripts-*-py3-none-any.whl
+
+# create helixbot user and give rights to sudo without password
+RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm helixbot && \
+    chmod 755 /root && \
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
+
+USER helixbot
+
+RUN python -m virtualenv /home/helixbot/.vsts-env

--- a/src/ubuntu/22.04/helix/arm64v8/Dockerfile
+++ b/src/ubuntu/22.04/helix/arm64v8/Dockerfile
@@ -1,0 +1,55 @@
+FROM arm64v8/ubuntu:22.04
+
+# Install Helix Dependencies
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -qq -y \
+        autoconf \
+        automake \
+        build-essential \
+        cmake \
+        clang \
+        gcc \
+        gdb \
+        git \
+        gss-ntlmssp \
+        iputils-ping \
+        libcurl4 \
+        libffi-dev \
+        libgdiplus \
+        libicu-dev \
+        libnuma-dev \
+        libssl-dev \
+        libtool \
+        libunwind8 \
+        libunwind-dev \
+        lldb-12 \
+        locales \
+        locales-all \
+        python3-dev \
+        python3-pip \
+        sudo \
+        tzdata \
+        unzip \
+        curl \
+    && rm -rf /var/lib/apt/lists/* \
+    \
+    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+ENV LANG=en_US.utf8
+
+RUN ln -sf /usr/bin/python3 /usr/bin/python && \
+    python -m pip install --upgrade pip==22.0.4 && \
+    python -m pip install virtualenv==20.14.0 && \
+    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    export CRYPTOGRAPHY_DONT_BUILD_RUST=1 && \
+    pip install ./helix_scripts-*-py3-none-any.whl
+
+RUN adduser --disabled-password --gecos '' --uid 1001 --shell /bin/bash --ingroup adm helixbot && \
+    chmod -R +x /root && \
+    echo 'helixbot ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+USER helixbot
+
+RUN python -m virtualenv /home/helixbot/.vsts-env

--- a/src/ubuntu/manifest.json
+++ b/src/ubuntu/manifest.json
@@ -729,6 +729,33 @@
               "variant": "v8"
             }
           ]
+        },
+        {
+          "platforms": [
+            {
+              "architecture": "amd64",
+              "dockerfile": "src/ubuntu/22.04/helix/amd64",
+              "os": "linux",
+              "osVersion": "jammy",
+              "tags": {
+                "ubuntu-22.04-helix-amd64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "architecture": "arm64",
+              "dockerfile": "src/ubuntu/22.04/helix/arm64v8",
+              "os": "linux",
+              "osVersion": "jammy",
+              "tags": {
+                "ubuntu-22.04-helix-arm64v8-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
+              },
+              "variant": "v8"
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
Ubuntu 22.04, which should be released some time in April 2022, might be the first LTS distro with OpenSSL 3.0. Having a platform with OpenSSL 3.0 will help us ensure dotnet/runtime CI is run against OpenSSL 3.0 continuously. It would have helped us catch https://github.com/dotnet/runtime/issues/67304 earlier.

The dockerfiles are a copy of 21.10, with a few changes:

- Update pip and virtualenv packages to work around compat issues with Python 3.10
- Remove --no-site-packages flag, which is no longer supported and already the default behaviour