### PR TITLE
Adding sudo to webassembly image

### DIFF
--- a/src/ubuntu/18.04/webassembly/Dockerfile
+++ b/src/ubuntu/18.04/webassembly/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update \
         nodejs-dev \
         node-gyp \
         npm \
+        sudo \
         wget \
         unzip \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
https://helixre8s23ayyeko0k025g8.blob.core.windows.net/dotnet-runtime-refs-pull-61776-merge-5f47beb01b2d462f82/DebuggerTests.ArrayTests/1/console.42c32ea4.log?sv=2019-07-07&se=2022-04-26T14%3A04%3A53Z&sr=c&sp=rl&sig=ZEde1BC5xDK%2F%2FQgjYtUu4AjHSHfY2wVNBt71T5J3usE%3D


This is the error: `/root/commands/helix_docker_work.sh: 3: /root/commands/helix_docker_work.sh: sudo: not found`