### PR TITLE
Upgrade pip3

### DIFF
--- a/src/ubuntu/18.04/webassembly/Dockerfile
+++ b/src/ubuntu/18.04/webassembly/Dockerfile
@@ -51,3 +51,5 @@ RUN curl -sSL "https://netcorenativeassets.blob.core.windows.net/resource-packag
     && chmod +x /usr/local/bin/v8
 
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+
+RUN pip3 install --upgrade pip


### PR DESCRIPTION
To fix this:
  =============================DEBUG ASSISTANCE==========================
            If you are seeing an error here please try the following to
            successfully install cryptography:
    
            Upgrade to the latest pip and try again. This will fix errors for most
            users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip
            =============================DEBUG ASSISTANCE==========================
    
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-mmc6xvsu/cryptography/setup.py", line 14, in <module>
        from setuptools_rust import RustExtension
    ModuleNotFoundError: No module named 'setuptools_rust'