### PR TITLE
Bring back CentOS Stream 9

### DIFF
--- a/src/centos/manifest.json
+++ b/src/centos/manifest.json
@@ -119,6 +119,18 @@
               }
             }
           ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/centos/stream9",
+              "os": "linux",
+              "osVersion": "centos-stream9",
+              "tags": {
+                "centos-stream9-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
+              }
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
The [build issue](https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/581#issuecomment-1061069818) associated with CentOS Stream 9 has been resolved as part of the work from https://github.com/dotnet/docker-tools/pull/998. We can now bring back the CentOS Stream 9 Dockerfile.