### PR TITLE
upgrade llvm from 3.9 to 9

### DIFF
--- a/src/ubuntu/18.04/amd64/Dockerfile
+++ b/src/ubuntu/18.04/amd64/Dockerfile
@@ -5,20 +5,20 @@ FROM ubuntu:18.04
 # them in a different layer.
 RUN apt-get update \
     && apt-get install -y \
-        clang-3.9 \
+        clang-9 \
         gdb \
-        liblldb-3.9-dev \
-        lldb-3.9 \
-        llvm-3.9 \
+        liblldb-9-dev \
+        lldb-9 \
+        llvm-9 \
         locales \
         make \
-        python-lldb-3.9 \
+        python-lldb-9 \
         sudo \
         wget \
     && rm -rf /var/lib/apt/lists/* \
-    && wget https://cmake.org/files/v3.10/cmake-3.10.2-Linux-x86_64.tar.gz \
-    && tar -xf cmake-3.10.2-Linux-x86_64.tar.gz --strip 1 -C /usr/local \
-    && rm cmake-3.10.2-Linux-x86_64.tar.gz
+    && wget https://cmake.org/files/v3.23/cmake-3.23.1-linux-x86_64.tar.gz \
+    && tar -xf cmake-3.23.1-linux-x86_64.tar.gz --strip 1 -C /usr/local \
+    && rm cmake-3.23.1-linux-x86_64.tar.gz
 
 # Install tools used by the VSO build automation.
 RUN apt-get update \
@@ -56,6 +56,7 @@ RUN apt-get update \
     && apt-get install -y \
         autoconf \
         automake \
+        curl \
         build-essential \
         gettext \
         libgdiplus \
@@ -69,35 +70,3 @@ RUN apt-get update \
         libunwind8-dev \
         uuid-dev \
     && rm -rf /var/lib/apt/lists/*
-
-# Build and install curl 7.45.0
-RUN wget https://curl.haxx.se/download/curl-7.45.0.tar.lzma \
-    && tar -xf curl-7.45.0.tar.lzma \
-    && rm curl-7.45.0.tar.lzma \
-    && cd curl-7.45.0 \
-    && ./configure \
-        --disable-dict \
-        --disable-ftp \
-        --disable-gopher \
-        --disable-imap \
-        --disable-ldap \
-        --disable-ldaps \
-        --disable-libcurl-option \
-        --disable-manual \
-        --disable-pop3 \
-        --disable-rtsp \
-        --disable-smb \
-        --disable-smtp \
-        --disable-telnet \
-        --disable-tftp \
-        --enable-ipv6 \
-        --enable-optimize \
-        --enable-symbol-hiding \
-        --with-ca-path=/etc/ssl/certs/ \
-        --with-nghttp2 \
-        --with-gssapi \
-        --with-ssl \
-        --without-librtmp \
-    && make install \
-    && cd .. \
-    && rm -r curl-7.45.0


### PR DESCRIPTION
upgrade llvm to avoid coreclr crashes.
related to https://github.com/dotnet/runtime/issues/66970

curl is already on 7.45.0 so I removed the custom build and added distro package