### PR TITLE
Add Ubuntu 22.04 debpkg images

### DIFF
--- a/src/ubuntu/22.04/amd64/Dockerfile
+++ b/src/ubuntu/22.04/amd64/Dockerfile
@@ -1,0 +1,53 @@
+FROM ubuntu:22.04
+
+# Install the base toolchain we need to build anything (clang, cmake, make and the like)
+# this does not include libraries that we need to compile different projects, we'd like
+# them in a different layer.
+RUN apt-get update \
+    && apt-get install -y \
+        cmake \
+        clang-14 \
+        gdb \
+        liblldb-14-dev \
+        lldb-14 \
+        llvm-14 \
+        locales \
+        make \
+        sudo
+
+# Install tools used by the VSO build automation.
+RUN apt-get update \
+    && apt-get install -y \
+        git \
+        nodejs \
+        npm \
+        zip \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# .NET SDK MSBuild requires US.UTF-8 locale to execute tasks
+RUN locale-gen en_US.UTF-8
+
+# Install Azure CLI
+RUN curl -L -o azure-cli_jammy_all.deb https://aka.ms/InstallAzureCliJammyEdge \
+    && dpkg -i azure-cli_jammy_all.deb
+
+# Runtime dependencies
+RUN apt-get update \
+    && apt-get install -y \
+        autoconf \
+        automake \
+        curl \
+        build-essential \
+        gettext \
+        libgdiplus \
+        libicu-dev \
+        libkrb5-dev \
+        liblttng-ust-dev \
+        libnuma-dev \
+        libssl-dev \
+        libtool \
+        libunwind8 \
+        libunwind8-dev \
+        uuid-dev \
+    && rm -rf /var/lib/apt/lists/*

--- a/src/ubuntu/22.04/debpkg/Dockerfile
+++ b/src/ubuntu/22.04/debpkg/Dockerfile
@@ -1,0 +1,10 @@
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04
+
+# Install the deb packaging toolchain we need to build debs
+RUN apt-get update \
+    && apt-get -y install \
+        build-essential \
+        debhelper \
+        devscripts \
+        liblldb-14 \
+    && rm -rf /var/lib/apt/lists/*

--- a/src/ubuntu/manifest.json
+++ b/src/ubuntu/manifest.json
@@ -733,6 +733,21 @@
         {
           "platforms": [
             {
+              "dockerfile": "src/ubuntu/22.04/amd64",
+              "os": "linux",
+              "osVersion": "jammy",
+              "tags": {
+                "ubuntu-22.04-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "ubuntu-22.04": {
+                  "isLocal": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
               "architecture": "amd64",
               "dockerfile": "src/ubuntu/22.04/helix/amd64",
               "os": "linux",
@@ -754,6 +769,18 @@
                 "ubuntu-22.04-helix-arm64v8-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
               },
               "variant": "v8"
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/22.04/debpkg",
+              "os": "linux",
+              "osVersion": "jammy",
+              "tags": {
+                "ubuntu-22.04-debpkg-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
+              }
             }
           ]
         }


### PR DESCRIPTION
This will be used in the runtime repo to build debpkg.