### PR TITLE
Adding zlib1g-dev package to ubuntu-18.04

### DIFF
--- a/src/ubuntu/18.04/helix/amd64/Dockerfile
+++ b/src/ubuntu/18.04/helix/amd64/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update && \
         sudo \
         tzdata \
         unzip \
+        zlib1g-dev \
     && rm -rf /var/lib/apt/lists/* \
     \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8


### PR DESCRIPTION
A SDK [test ](https://github.com/dotnet/sdk/blob/main/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs#L71)requires couple of packages (clang and zlib1g-dev) as part of pre-requisites. Adding these packages to the Ubuntu 18.04 Helix docker file so that I can change SDK tests to use this container.

The following is the result from my local build,

```
 .\build.ps1 -DockerfilePath "*ubuntu/18.04/helix/amd64*"

IMAGES BUILT
------------
mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-amd64-20220427114023-0ece9b3
mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-amd64
```