### PR TITLE
Creating a 20.04 helix container

### DIFF
--- a/src/ubuntu/20.04/helix/amd64/Dockerfile
+++ b/src/ubuntu/20.04/helix/amd64/Dockerfile
@@ -1,0 +1,54 @@
+FROM ubuntu:20.04
+
+# Install Helix Dependencies
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -qq -y \
+        autoconf \
+        automake \
+        build-essential \
+        cmake \
+        clang \
+        gcc \
+        gdb \
+        git \
+        gss-ntlmssp \
+        iputils-ping \
+        libcurl4 \
+        libffi-dev \
+        libgdiplus \
+        libicu-dev \
+        libssl-dev \
+        libtool \
+        libunwind8 \
+        libunwind-dev \
+        lldb-3.9 \
+        locales \
+        locales-all \
+        python3-dev \
+        python3-pip \
+        sudo \
+        tzdata \
+        unzip \
+        zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    \
+    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+ENV LANG=en_US.utf8
+
+RUN ln -sf /usr/bin/python3 /usr/bin/python && \
+    python -m pip install --upgrade pip==20.2 && \
+    python -m pip install virtualenv==16.6.0 && \
+    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    pip install ./helix_scripts-*-py3-none-any.whl
+
+# create helixbot user and give rights to sudo without password
+RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm helixbot && \
+    chmod 755 /root && \
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
+
+USER helixbot
+
+RUN python -m virtualenv --no-site-packages /home/helixbot/.vsts-env

--- a/src/ubuntu/20.04/helix/wasm/amd64/Dockerfile
+++ b/src/ubuntu/20.04/helix/wasm/amd64/Dockerfile
@@ -1,8 +1,11 @@
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-helix-amd64
 
+
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Need some additional packages
+
+USER root
 
 RUN apt-get clean && \
     mv /etc/apt/sources.list /etc/apt/sources.list1 && apt-get update && \
@@ -24,3 +27,4 @@ RUN sudo npm install jsvu -g && \
 
 ENV PATH="/home/helixbot/.jsvu:${PATH}"
 
+USER helixbot

--- a/src/ubuntu/20.04/helix/wasm/amd64/Dockerfile
+++ b/src/ubuntu/20.04/helix/wasm/amd64/Dockerfile
@@ -17,11 +17,9 @@ RUN apt-get clean && \
      \
      && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
-
 # Install V8 & other engines in the non-root context
 
-# This gets an ignorable warning described in https://github.com/sudo-project/sudo/issues/42
-RUN sudo npm install jsvu -g && \
+RUN npm install jsvu -g && \
     jsvu --os=linux64 --engines=all
 
 ENV PATH="/home/helixbot/.jsvu:${PATH}"

--- a/src/ubuntu/20.04/helix/wasm/amd64/Dockerfile
+++ b/src/ubuntu/20.04/helix/wasm/amd64/Dockerfile
@@ -1,59 +1,20 @@
-FROM ubuntu:20.04
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-helix-amd64
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# sources tweak is to work around very slow update
+# Need some additional packages
 
 RUN apt-get clean && \
     mv /etc/apt/sources.list /etc/apt/sources.list1 && apt-get update && \
     mv /etc/apt/sources.list1 /etc/apt/sources.list &&  apt-get update && \
     apt-get install -qq -y \
-        autoconf \
-        automake \
-        build-essential \
-        cmake \
-        clang \
-        gcc \
-        gdb \
-        git \
-        gss-ntlmssp \
-        iputils-ping \
-        libcurl4 \
-        libffi-dev \
-        libgdiplus \
-        libicu-dev \
         libnode-dev \
-        libtool \
-        libunwind8 \
-        libunwind-dev \
-        lldb-3.9 \
-        locales \
-        locales-all \
         node-gyp \
         npm \
-        python3-dev \
-        python3-pip \
-        sudo \
-        tzdata \
-        unzip \
      && rm -rf /var/lib/apt/lists/* \
      \
      && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
-ENV LANG=en_US.utf8
-
-RUN ln -sf /usr/bin/python3 /usr/bin/python && \
-    python -m pip install --upgrade pip==20.2 && \
-    python -m pip install virtualenv==16.6.0 && \
-    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    pip install ./helix_scripts-*-py3-none-any.whl
-
-# create helixbot user and give rights to sudo without password
-RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm helixbot && \
-    chmod 755 /root && \
-    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
-
-USER helixbot
 
 # Install V8 & other engines in the non-root context
 
@@ -63,4 +24,3 @@ RUN sudo npm install jsvu -g && \
 
 ENV PATH="/home/helixbot/.jsvu:${PATH}"
 
-RUN python -m virtualenv --no-site-packages /home/helixbot/.vsts-env

--- a/src/ubuntu/20.04/helix/wasm/amd64/Dockerfile
+++ b/src/ubuntu/20.04/helix/wasm/amd64/Dockerfile
@@ -1,6 +1,5 @@
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-helix-amd64
 
-
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Need some additional packages

--- a/src/ubuntu/manifest.json
+++ b/src/ubuntu/manifest.json
@@ -676,6 +676,22 @@
           "platforms": [
             {
               "architecture": "amd64",
+              "dockerfile": "src/ubuntu/20.04/helix/amd64",
+              "os": "linux",
+              "osVersion": "focal",
+              "tags": {
+                "ubuntu-20.04-helix-amd64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "ubuntu-20.04-helix-amd64": {
+                  "isLocal": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "architecture": "amd64",
               "dockerfile": "src/ubuntu/20.04/helix/wasm/amd64",
               "os": "linux",
               "osVersion": "focal",


### PR DESCRIPTION
SDK has moved to Ubuntu 20.04 and creating a docker container with some requires pre-requisites to run a SDK test