### PR TITLE
Update ca-certificates in CentOS7 images

### DIFF
--- a/src/centos/7/Dockerfile
+++ b/src/centos/7/Dockerfile
@@ -5,6 +5,7 @@ FROM centos:7
 RUN yum install -y \
         centos-release-scl \
         epel-release \
+        ca-certificates \
         scl-utils-build \
     && \
     yum install -y \


### PR DESCRIPTION
This makes sure validation of TLS/SSL certificates succeeds when making requests to 3rd party servers.