### PR TITLE
Get newer v8 engine

### DIFF
--- a/src/windowsservercore/ltsc2022/helix/webassembly/Dockerfile
+++ b/src/windowsservercore/ltsc2022/helix/webassembly/Dockerfile
@@ -43,5 +43,5 @@ RUN msiexec /i %TEMP%\nodejs.msi /quiet /passive /qn /norestart
 
 # install jsvu and engines
 RUN npm install jsvu -g
-RUN npm exec -c "jsvu --os=win64 --engines=v8,spidermonkey"
+RUN npm exec -c "jsvu --os=win64 --engines=v8"
 RUN setx PATH "%PATH%;%USERPROFILE%\.jsvu"


### PR DESCRIPTION
Also don't install spidermonkey, we don't use it now

Older v8 versions are hanging in some tests, newer v8 don't do that
locally.