### PR TITLE
Increase Ubuntu build timeout

### DIFF
--- a/eng/pipelines/dotnet-buildtools-prereqs-ubuntu.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-ubuntu.yml
@@ -24,6 +24,6 @@ stages:
   parameters:
     internalProjectName: ${{ variables.internalProjectName }}
     publicProjectName: ${{ variables.publicProjectName }}
-    linuxAmdBuildJobTimeout: 300
+    linuxAmdBuildJobTimeout: 330
     customBuildInitSteps:
     - template: /eng/pipelines/steps/install-cross-build-prereqs.yml


### PR DESCRIPTION
SBOM generation is taking some more time now and leading to build timeouts. Increasing the time to account for this.