### PR TITLE
Reintroduce devtoolset 7, for Ubuntu 18.04 compatibility

### DIFF
--- a/src/centos/7/Dockerfile
+++ b/src/centos/7/Dockerfile
@@ -12,6 +12,7 @@ RUN yum install -y \
         autoconf \
         automake \
         ca-certificates \
+        devtoolset-7-gcc* \
         devtoolset-9-gcc* \
         doxygen \
         gdb \
@@ -97,6 +98,10 @@ RUN wget ftp://sourceware.org/pub/binutils/snapshots/binutils-2.29.1.tar.xz && \
     rm -r llvmbuild && \
     rm -r llvm-9.0.0.src && \
     rm -r binutils-2.29.1
+
+# Create gcc-7 symlink available in PATH
+RUN ln -s /opt/rh/devtoolset-7/root/usr/bin/gcc /usr/local/bin/gcc-7 && \
+    ln -s /opt/rh/devtoolset-7/root/usr/bin/g++ /usr/local/bin/g++-7
 
 # Create gcc-9 symlink available in PATH
 RUN ln -s /opt/rh/devtoolset-9/root/usr/bin/gcc /usr/local/bin/gcc-9 && \


### PR DESCRIPTION
If we build a C++ library against devtoolset 9, it introduces a dependency on libstdc++ 9 (and a linker ABI dependency on the GCC 9 C++11 string ABI) - this is not compatible with Ubuntu 18.04, which ships with libstdc++ 7. As a result, it becomes impossible to link a C++ library (say libllvm) built in one of our Centos builders on a container with an Ubuntu 18.04 base (say our WebAssembly cross builders, or ARM64 builders if we link LLVM into the runtime).

Clang is capable of making a decision at runtime as to which underlying G++ version to use as its ABI model, so it is safe to have multiple versions installed in parallel - it just needs a bunch of extra flags to convince Clang not to use the latest available.

Making this available will help us with updating to LLVM 14, which does not build on the last published version of the CentOS container with Devtoolset 7. It should have no effect at all without explicit opt-in.