### PR TITLE
Increase Ubuntu pipeline timeout

### DIFF
--- a/eng/pipelines/dotnet-buildtools-prereqs-ubuntu.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-ubuntu.yml
@@ -24,6 +24,6 @@ stages:
   parameters:
     internalProjectName: ${{ variables.internalProjectName }}
     publicProjectName: ${{ variables.publicProjectName }}
-    linuxAmdBuildJobTimeout: 330
+    linuxAmdBuildJobTimeout: 360
     customBuildInitSteps:
     - template: /eng/pipelines/steps/install-cross-build-prereqs.yml


### PR DESCRIPTION
Timeout for internal Ubuntu build needs to be increased due to additional image being added (#638) and the extra time that is now needed for SBOM generation.