### PR TITLE
Add jq in runtime dependencies

### DIFF
--- a/src/alpine/3.13/amd64/Dockerfile
+++ b/src/alpine/3.13/amd64/Dockerfile
@@ -15,6 +15,7 @@ RUN apk update && \
         gettext-dev \
         git \
         icu-dev \
+        jq \
         krb5-dev \
         libtool \
         libunwind-dev \

--- a/src/alpine/3.13/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.13/helix/arm32v7/Dockerfile
@@ -17,6 +17,7 @@ RUN apk update && \
         git \
         icu-dev \
         iputils \
+        jq \
         krb5-dev \
         libtool \
         libunwind-dev \

--- a/src/alpine/3.13/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.13/helix/arm64v8/Dockerfile
@@ -17,6 +17,7 @@ RUN apk update && \
         git \
         icu-dev \
         iputils \
+        jq \
         krb5-dev \
         libtool \
         libunwind-dev \

--- a/src/alpine/3.14/amd64/Dockerfile
+++ b/src/alpine/3.14/amd64/Dockerfile
@@ -15,6 +15,7 @@ RUN apk update && \
         gettext-dev \
         git \
         icu-dev \
+        jq \
         krb5-dev \
         libtool \
         libunwind-dev \

--- a/src/alpine/3.14/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.14/helix/arm32v7/Dockerfile
@@ -17,6 +17,7 @@ RUN apk update && \
         git \
         icu-dev \
         iputils \
+        jq \
         krb5-dev \
         libtool \
         libunwind-dev \

--- a/src/alpine/3.14/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.14/helix/arm64v8/Dockerfile
@@ -17,6 +17,7 @@ RUN apk update && \
         git \
         icu-dev \
         iputils \
+        jq \
         krb5-dev \
         libtool \
         libunwind-dev \

--- a/src/alpine/3.15/amd64/Dockerfile
+++ b/src/alpine/3.15/amd64/Dockerfile
@@ -15,6 +15,7 @@ RUN apk update && \
         gettext-dev \
         git \
         icu-dev \
+        jq \
         krb5-dev \
         libtool \
         libunwind-dev \

--- a/src/alpine/3.15/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.15/helix/arm32v7/Dockerfile
@@ -17,6 +17,7 @@ RUN apk update && \
         git \
         icu-dev \
         iputils \
+        jq \
         krb5-dev \
         libtool \
         libunwind-dev \

--- a/src/alpine/3.15/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.15/helix/arm64v8/Dockerfile
@@ -17,6 +17,7 @@ RUN apk update && \
         git \
         icu-dev \
         iputils \
+        jq \
         krb5-dev \
         libtool \
         libunwind-dev \

--- a/src/centos/7/Dockerfile
+++ b/src/centos/7/Dockerfile
@@ -17,6 +17,7 @@ RUN yum install -y \
         doxygen \
         gdb \
         git \
+        jq \
         krb5-devel \
         libcurl-devel \
         libedit-devel \

--- a/src/centos/7/source-build/amd64/Dockerfile
+++ b/src/centos/7/source-build/amd64/Dockerfile
@@ -15,6 +15,7 @@ RUN yum install -y \
         doxygen \
         gdb \
         git \
+        jq \
         krb5-devel \
         libcurl-devel \
         libedit-devel \

--- a/src/centos/stream9/Dockerfile
+++ b/src/centos/stream9/Dockerfile
@@ -21,6 +21,7 @@ RUN dnf install --setopt tsflags=nodocs --refresh -y \
         git \
         glibc-langpack-en \
         hostname \
+        jq \
         krb5-devel \
         libcurl-devel \
         libedit-devel \

--- a/src/debian/9/amd64/Dockerfile
+++ b/src/debian/9/amd64/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:stretch
 
-# Dependencies for generic .NET Core builds and the base toolchain we need to 
+# Dependencies for generic .NET Core builds and the base toolchain we need to
 # build anything (clang, cmake, make and the like)
 RUN apt-get update \
     && apt-get install -y \
@@ -15,6 +15,7 @@ RUN apt-get update \
             gdb \
             git \
             gnupg \
+            jq \
             libcurl4-openssl-dev \
             libgdiplus \
             libicu-dev \

--- a/src/debian/9/arm32v7/Dockerfile
+++ b/src/debian/9/arm32v7/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update \
             build-essential \
             curl \
             gettext \
+            jq \
             libcurl4-openssl-dev \
             libgdiplus \
             libicu-dev \

--- a/src/debian/9/arm64v8/Dockerfile
+++ b/src/debian/9/arm64v8/Dockerfile
@@ -1,6 +1,6 @@
 FROM arm64v8/debian:9
 
-# Dependencies for generic .NET Core builds and the base toolchain we need to 
+# Dependencies for generic .NET Core builds and the base toolchain we need to
 # build anything (clang, cmake, make and the like)
 RUN apt-get update \
     && apt-get install -y \
@@ -15,6 +15,7 @@ RUN apt-get update \
             gdb \
             git \
             gnupg \
+            jq \
             libcurl4-openssl-dev \
             libgdiplus \
             libicu-dev \

--- a/src/fedora/34/amd64/Dockerfile
+++ b/src/fedora/34/amd64/Dockerfile
@@ -31,12 +31,13 @@ RUN dnf --setopt=install_weak_deps=False install -y \
         zip \
     && dnf clean all
 
-# Dependencies of CoreCLR, Mono and CoreFX.
+# Runtime dependencies
 RUN dnf --setopt=install_weak_deps=False install -y \
         autoconf \
         automake \
         glibc-locale-source \
         iputils \
+        jq \
         krb5-devel \
         libcurl-devel \
         libgdiplus \

--- a/src/ubuntu/16.04/Dockerfile
+++ b/src/ubuntu/16.04/Dockerfile
@@ -36,12 +36,13 @@ RUN apt-get install -y git \
 # .NET SDK MSBuild requires US.UTF-8 locale to execute tasks
 RUN locale-gen en_US.UTF-8
 
-# Dependencies for CoreCLR, Mono and CoreFX
+# Runtime dependencies
 RUN apt-get install -y \
             autoconf \
             automake \
             build-essential \
             gettext \
+            jq \
             libcurl4-openssl-dev \
             libgdiplus \
             libicu-dev \

--- a/src/ubuntu/16.04/coredeps/Dockerfile
+++ b/src/ubuntu/16.04/coredeps/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update \
     && npm install -g azure-cli@0.9.20 \
     && npm cache clean
 
-# Dependencies for CoreCLR, Mono and CoreFX
+# Runtime dependencies
 RUN apt-get update \
     && apt-get -f install -y \
     && apt-get install -y \
@@ -22,6 +22,7 @@ RUN apt-get update \
         automake \
         build-essential \
         gettext \
+        jq \
         libcurl4-openssl-dev \
         libgdiplus \
         libicu-dev \

--- a/src/ubuntu/18.04/amd64/Dockerfile
+++ b/src/ubuntu/18.04/amd64/Dockerfile
@@ -51,7 +51,7 @@ RUN apt-get update \
         azure-cli \
     && rm -rf /var/lib/apt/lists/*
 
-# Dependencies for CoreCLR, Mono and CoreFX
+# Runtime dependencies
 RUN apt-get update \
     && apt-get install -y \
         autoconf \
@@ -59,6 +59,7 @@ RUN apt-get update \
         curl \
         build-essential \
         gettext \
+        jq \
         libgdiplus \
         libicu-dev \
         libkrb5-dev \

--- a/src/ubuntu/18.04/coredeps/Dockerfile
+++ b/src/ubuntu/18.04/coredeps/Dockerfile
@@ -12,13 +12,14 @@ RUN apt-get update \
     && npm install -g azure-cli@0.9.20 \
     && npm cache clean
 
-# Dependencies for CoreCLR, Mono and CoreFX
+# Runtime dependencies
 RUN apt-get update \
     && apt-get install -y \
         autoconf \
         automake \
         build-essential \
         gettext \
+        jq \
         libcurl4-openssl-dev \
         libgdiplus \
         libicu-dev \

--- a/src/ubuntu/18.04/mono/amd64/Dockerfile
+++ b/src/ubuntu/18.04/mono/amd64/Dockerfile
@@ -15,8 +15,8 @@ RUN apt-get update && \
         gdb \
         gettext \
         git \
-        jq \
         iputils-ping \
+        jq \
         libgdiplus \
         libtool \
         locales \

--- a/src/ubuntu/18.04/mono/amd64/Dockerfile
+++ b/src/ubuntu/18.04/mono/amd64/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && \
         gdb \
         gettext \
         git \
+        jq \
         iputils-ping \
         libgdiplus \
         libtool \

--- a/src/ubuntu/18.04/mono/arm32v7/Dockerfile
+++ b/src/ubuntu/18.04/mono/arm32v7/Dockerfile
@@ -15,8 +15,8 @@ RUN apt-get update && \
         gdb \
         gettext \
         git \
-        jq \
         iputils-ping \
+        jq \
         libgdiplus \
         libtool \
         locales \

--- a/src/ubuntu/18.04/mono/arm32v7/Dockerfile
+++ b/src/ubuntu/18.04/mono/arm32v7/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && \
         gdb \
         gettext \
         git \
+        jq \
         iputils-ping \
         libgdiplus \
         libtool \

--- a/src/ubuntu/18.04/mono/arm64v8/Dockerfile
+++ b/src/ubuntu/18.04/mono/arm64v8/Dockerfile
@@ -15,8 +15,8 @@ RUN apt-get update && \
         gdb \
         gettext \
         git \
-        jq \
         iputils-ping \
+        jq \
         libgdiplus \
         libtool \
         locales \

--- a/src/ubuntu/18.04/mono/arm64v8/Dockerfile
+++ b/src/ubuntu/18.04/mono/arm64v8/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && \
         gdb \
         gettext \
         git \
+        jq \
         iputils-ping \
         libgdiplus \
         libtool \

--- a/src/ubuntu/20.04/coredeps/Dockerfile
+++ b/src/ubuntu/20.04/coredeps/Dockerfile
@@ -12,13 +12,14 @@ RUN apt-get update \
     && npm install -g azure-cli@0.9.20 \
     && npm cache clean --force
 
-# Dependencies for CoreCLR, Mono and CoreFX
+# Runtime dependencies
 RUN apt-get update \
     && apt-get install -y \
         autoconf \
         automake \
         build-essential \
         gettext \
+        jq \
         libcurl4-openssl-dev \
         libgdiplus \
         libicu-dev \

--- a/src/ubuntu/22.04/amd64/Dockerfile
+++ b/src/ubuntu/22.04/amd64/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get update \
         curl \
         build-essential \
         gettext \
+        jq \
         libgdiplus \
         libicu-dev \
         libkrb5-dev \


### PR DESCRIPTION
`jq` is a tiny (< 100 KB) recommended tool to parse JSON in shell scripts.

In dotnet/arcade, we are using jq in a few places with a fallback to 'unrecommended' manual parsing path in bash scripts.

This PR is adding `jq` to base dependency lists, so we use the recommended code path.