### PR TITLE
Use Ubuntu 20.04 (or better) repositories on host

### DIFF
--- a/src/ubuntu/build-scripts/install-cross-build-prereqs.sh
+++ b/src/ubuntu/build-scripts/install-cross-build-prereqs.sh
@@ -9,8 +9,7 @@ set -u
 # which are available in Ubuntu 20.04+ repositories
 . /etc/os-release
 if [ "$(echo "$VERSION_ID" | tr -d .)" -lt 2004 ]; then
-    cat /etc/apt/sources.list | sed "s/$UBUNTU_CODENAME/focal/g" > /tmp/focal.list
-    sudo mv /tmp/focal.list /etc/apt/sources.list.d/
+    sed "s/$UBUNTU_CODENAME/focal/g" /etc/apt/sources.list | sudo dd of=/etc/apt/sources.list.d/focal.list
 fi
 
 # see (see https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/120)

--- a/src/ubuntu/build-scripts/install-cross-build-prereqs.sh
+++ b/src/ubuntu/build-scripts/install-cross-build-prereqs.sh
@@ -7,7 +7,11 @@ set -u
 
 # we need to make sure that we install binfmt >= 2.2.0 and qemu-user-static >= 1.4.2,
 # which are available in Ubuntu 20.04+ repositories
-sudo sh -c '(. /etc/os-release && [ "$(echo "$VERSION_ID" | tr -d .)" -lt 2004 ] && sed -i "s/$UBUNTU_CODENAME/focal/g" /etc/apt/sources.list)'
+. /etc/os-release
+if [ "$(echo "$VERSION_ID" | tr -d .)" -lt 2004 ]; then
+    cat /etc/apt/sources.list | sed "s/$UBUNTU_CODENAME/focal/g" > /tmp/focal.list
+    sudo mv /tmp/focal.list /etc/apt/sources.list.d/
+fi
 
 # see (see https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/120)
 sudo apt-get update

--- a/src/ubuntu/build-scripts/install-cross-build-prereqs.sh
+++ b/src/ubuntu/build-scripts/install-cross-build-prereqs.sh
@@ -5,6 +5,10 @@ set -e
 # Stop script if unbound variable found (use ${var:-} if intentional)
 set -u
 
+# we need to make sure that we install binfmt >= 2.2.0 and qemu-user-static >= 1.4.2,
+# which are available in Ubuntu 20.04+ repositories
+sudo sh -c '(. /etc/os-release && [ "$(echo "$VERSION_ID" | tr -d .)" -lt 2004 ] && sed -i "s/$UBUNTU_CODENAME/focal/g" /etc/apt/sources.list)'
+
 # see (see https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/120)
 sudo apt-get update
 sudo apt-get install -y \


### PR DESCRIPTION
This is a workaround for official machine host, which is still running Ubuntu 18.04: https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/644#issuecomment-1201520888.