### PR TITLE
add msquic to Alpine Helix image

### DIFF
--- a/src/alpine/3.14/helix/amd64/Dockerfile
+++ b/src/alpine/3.14/helix/amd64/Dockerfile
@@ -15,6 +15,18 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
     pip install ./helix_scripts-*-py3-none-any.whl
 
+# build MsQuic as we don't have packages
+RUN cd /tmp && \
+    mkdir pwsh && \
+    cd pwsh && \
+    curl -L https://github.com/PowerShell/PowerShell/releases/download/v7.2.5/powershell-7.2.5-linux-alpine-x64.tar.gz | tar xfz - && \
+    cd .. && \
+    git clone --depth 1 --single-branch --recursive https://github.com/dotnet/msquic && \
+    cd msquic/src/msquic  &&  PATH=~/.dotnet/tools:$PATH /tmp/pwsh/pwsh scripts/build.ps1 -Config Release && \
+    cp artifacts/bin/linux/x64_Release_openssl/libmsquic.so.2 artifacts/bin/linux/x64_Release_openssl/libmsquic.lttng.so.2.1.0 /usr/lib && \
+    cd /tmp && \
+    rm -r pwsh msquic
+
 # Needed for corefx tests to pass
 ENV LANG=en-US.UTF-8
 


### PR DESCRIPTION
This is similar to what we do for fedora/34. There is no package so we build msquic from our clone. 
This change should allow us to run HTTP/3 & Quic tests on Alpine.
We may need to update this when MsQuic has new release (and we update our clone) 

contributes to https://github.com/dotnet/runtime/issues/55639


I was also looking to add it to arm64 but there is no PowerShell so we would either need to compile it from sources or somehow avoid use of pwsh. 