### PR TITLE
Install llvm-15 in riscv64 image

### DIFF
--- a/src/ubuntu/20.04/cross/riscv64/Dockerfile
+++ b/src/ubuntu/20.04/cross/riscv64/Dockerfile
@@ -1,3 +1,12 @@
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-crossdeps
 
 ADD rootfs.riscv64.tar crossrootfs
+
+# Install llvm 15 so we get the 'Relax R_RISCV_ALIGN' fix 
+#   * https://github.com/llvm/llvm-project/issues/44181
+#   * https://github.com/llvm/llvm-project/commit/6611d58f5bbcbec77262d392e2923e1d680f6985
+#
+# Use installation script from llvm.org and cleanup apt lists because
+# it uses apt's update and install commands.
+RUN wget -O- https://apt.llvm.org/llvm.sh | bash -s -- 15 all \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
TL;DR - this is needed to build dotnet/runtime.

Details:

clang 9 with gcc 9:
although clang-9 was the fist version which supported riscv64, there were some rough edges around .eh_frame handling in lld linker (LLVM linker). Using GNU's gold linker is an option, but we would need to install gcc-12 toolchain just for that, Currently we have clang-9 and gcc-9, so there is no way we can proceed with this combination.

clang 14 (current latest stable):
We get this error at the very beginning of cmake invocation:

```
-- Check for working C compiler: /usr/bin/clang-14 - broken
CMake Error at /usr/share/cmake-3.23/Modules/CMakeTestCCompiler.cmake:69 (message):
  The C compiler

    "/usr/bin/clang-14"

  is not able to compile a simple test program.

  It fails with the following output:

    Change Dir: /runtime/artifacts/obj/coreclr/Linux.riscv64.Debug/CMakeFiles/CMakeTmp
    
    Run Build Command(s):/usr/bin/make -f Makefile cmTC_b5692/fast && /usr/bin/make  -f CMakeFiles/cmTC_b5692.dir/build.make CMakeFiles/cmTC_b5692.dir/build
    make[1]: Entering directory '/runtime/artifacts/obj/coreclr/Linux.riscv64.Debug/CMakeFiles/CMakeTmp'
    Building C object CMakeFiles/cmTC_b5692.dir/testCCompiler.c.o
    /usr/bin/clang-14 --target=riscv64-linux-gnu --gcc-toolchain=/crossrootfs/riscv64/usr --sysroot=/crossrootfs/riscv64   -mno-relax  -MD -MT CMakeFiles/cmTC_b5692.dir/testCCompiler.c.o -MF CMakeFiles/cmTC_b5692.dir/testCCompiler.c.o.d -o CMakeFiles/cmTC_b5692.dir/testCCompiler.c.o -c /runtime/artifacts/obj/coreclr/Linux.riscv64.Debug/CMakeFiles/CMakeTmp/testCCompiler.c
    Linking C executable cmTC_b5692
    /usr/bin/cmake -E cmake_link_script CMakeFiles/cmTC_b5692.dir/link.txt --verbose=1
    /usr/bin/clang-14 --target=riscv64-linux-gnu --gcc-toolchain=/crossrootfs/riscv64/usr --sysroot=/crossrootfs/riscv64 -mno-relax  -Wl,--rpath-link=/crossrootfs/riscv64/lib/riscv64-linux-gnu -Wl,--rpath-link=/crossrootfs/riscv64/usr/lib/riscv64-linux-gnu -Wl,--rpath-link=/crossrootfs/riscv64/lib/riscv64-linux-gnu -Wl,--rpath-link=/crossrootfs/riscv64/usr/lib/riscv64-linux-gnu -fuse-ld=lld  CMakeFiles/cmTC_b5692.dir/testCCompiler.c.o -o cmTC_b5692 
    ld.lld: error: /crossrootfs/riscv64/lib/riscv64-linux-gnu/Scrt1.o:(.text+0x0): relocation R_RISCV_ALIGN requires unimplemented linker relaxation; recompile with -mno-relax
    clang: error: linker command failed with exit code 1 (use -v to see invocation)
    make[1]: *** [CMakeFiles/cmTC_b5692.dir/build.make:100: cmTC_b5692] Error 1
    make[1]: Leaving directory '/runtime/artifacts/obj/coreclr/Linux.riscv64.Debug/CMakeFiles/CMakeTmp'
    make: *** [Makefile:127: cmTC_b5692/fast] Error 2
```

turned out this `relax`ation support is fixed in llvm-15: https://github.com/llvm/llvm-project/issues/44181. Note that the error emerges from `Scrt1.o` (provided by `debootstrap -arch riscv64`) in gcc-12 riscv64 toolchain installed in the rootfs. This is the default C runtime object which cmake links against in test, so the error message suggestion "recompile with -mno-relax" has no affect if we set `set(CMAKE_C_FLAGS _INIT "-mno-relax")` in toolchain.cmake, since this object file is prebuilt.

There are other hacks to workaround it, but this is the cleanest and proper fix in my opinion.

cc @akoeplinger, @janvorli I will push the initial configuration patch to runtime once this goes in (still wrapping up mono configs)