### PR TITLE
update msquic to release/7.0 -> 2.1

### DIFF
--- a/src/alpine/3.14/helix/amd64/Dockerfile
+++ b/src/alpine/3.14/helix/amd64/Dockerfile
@@ -21,7 +21,7 @@ RUN cd /tmp && \
     cd pwsh && \
     curl -L https://github.com/PowerShell/PowerShell/releases/download/v7.2.5/powershell-7.2.5-linux-alpine-x64.tar.gz | tar xfz - && \
     cd .. && \
-    git clone --depth 1 --single-branch --recursive https://github.com/dotnet/msquic && \
+    git clone --depth 1 --single-branch --branch release/7.0 --recursive https://github.com/dotnet/msquic && \
     cd msquic/src/msquic  &&  PATH=~/.dotnet/tools:$PATH /tmp/pwsh/pwsh scripts/build.ps1 -Config Release && \
     cp artifacts/bin/linux/x64_Release_openssl/libmsquic.so.2 artifacts/bin/linux/x64_Release_openssl/libmsquic.lttng.so.2.1.0 /usr/lib && \
     cd /tmp && \

--- a/src/fedora/34/helix/amd64/Dockerfile
+++ b/src/fedora/34/helix/amd64/Dockerfile
@@ -25,7 +25,7 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
 RUN dnf install -y dotnet gem lttng-tools perl-FindBin rpmdevtools ruby-devel && \
     rpm -i https://github.com/PowerShell/PowerShell/releases/download/v7.0.6/powershell-lts-7.0.6-1.rhel.7.x86_64.rpm && \
     gem  install fpm && \
-    git clone --depth 1 --single-branch --recursive https://github.com/dotnet/msquic && \
+    git clone --depth 1 --single-branch --branch release/7.0 --recursive https://github.com/dotnet/msquic && \
     cd msquic/src/msquic  &&  PATH=~/.dotnet/tools:$PATH pwsh scripts/build.ps1 -Config Release -DisableLogs && \
     touch artifacts/bin/linux/x64_Release_openssl/libmsquic.lttng.so && ./scripts/make-packages.sh --output /tmp && \
     rpm -i /tmp/libmsquic*rpm  && \


### PR DESCRIPTION
msquic released 2.1 on Friday and main becomes 2.2-rolling. 
This change updates the test images to version we intend for 7.0. (msquic/dotnet) already branches as preparation (since we do not expect more updates https://github.com/dotnet/msquic/pull/99) 
