### PR TITLE
add fpm to coredeps

### DIFF
--- a/src/ubuntu/18.04/coredeps/Dockerfile
+++ b/src/ubuntu/18.04/coredeps/Dockerfile
@@ -3,11 +3,14 @@ FROM mcr.microsoft.com/powershell:lts-ubuntu-18.04
 # Install tools used by the VSO build automation.
 RUN apt-get update \
     && apt-get install -y \
+        curl \
         git \
         nodejs \
         npm \
+        ruby-dev \
         tar \
         zip \
+    && gem install fpm \
     && rm -rf /var/lib/apt/lists/* \
     && npm install -g azure-cli@0.9.20 \
     && npm cache clean


### PR DESCRIPTION
follow-up on #652. msquic can now cross-compile and that opens new avenues for Azure pipelines. 
Instead of adding to arm and arm64 I put it to coredeps to get it ion one show for both. 