### PR TITLE
Add zlib to the Ubuntu 20 image.

### DIFF
--- a/src/ubuntu/20.04/amd64/Dockerfile
+++ b/src/ubuntu/20.04/amd64/Dockerfile
@@ -53,4 +53,5 @@ RUN apt-get update \
         libunwind8 \
         libunwind8-dev \
         uuid-dev \
+        zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This is required to build runtime.