### PR TITLE
build msquic for Debian Helix arm64

### DIFF
--- a/src/debian/10/helix/arm64v8/Dockerfile
+++ b/src/debian/10/helix/arm64v8/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && \
         libffi-dev \
         libgdiplus \
         libicu-dev \
+        liblttng-ust-dev \
         libssl-dev \
         libtool \
         libunwind8 \
@@ -29,6 +30,10 @@ RUN apt-get update && \
         tzdata \
         unzip \
     && rm -rf /var/lib/apt/lists/* \
+    && curl -O https://cmake.org/files/v3.23/cmake-3.23.1-linux-aarch64.tar.gz \
+    && cat cmake-3.23.1-linux-aarch64.tar.gz  | sha256sum -c <(echo "74062efddeb935bce3d33694a4db534cef9a650f77a9a153a9f217d9dc385c75  -") \
+    && tar -xf cmake-3.23.1-linux-aarch64.tar.gz  --strip 1 -C /usr/local \
+    && rm cmake-3.23.1-linux-aarch64.tar.gz \
     \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
@@ -42,6 +47,20 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
     export CRYPTOGRAPHY_DONT_BUILD_RUST=1 && \
     pip install ./helix_scripts-*-py3-none-any.whl
+
+# build MsQuic as we don't have packages
+RUN cd /tmp && \
+    mkdir pwsh && \
+    cd pwsh && \
+    curl -LO https://github.com/PowerShell/PowerShell/releases/download/v7.2.5/powershell-7.2.5-linux-arm64.tar.gz && \
+    cat powershell-7.2.5-linux-arm64.tar.gz | sha256sum -c <(echo "709265A0B99232CD8AB6F8A02C01F3AEE94262B959E1A4B0FD871C8789C07396 -") && \
+    tar xf powershell-7.2.5-linux-arm64.tar.gz && \
+    cd .. && \
+    git clone --depth 1 --single-branch --branch release/7.0 --recursive https://github.com/dotnet/msquic && \
+    cd msquic/src/msquic  &&  PATH=~/.dotnet/tools:$PATH /tmp/pwsh/pwsh scripts/build.ps1 -arch arm64 -Config Release && \
+    cp artifacts/bin/linux/arm64_Release_openssl/libmsquic.so.2 artifacts/bin/linux/arm64_Release_openssl/libmsquic.lttng.so.2.1.0 /usr/lib/aarch64-linux-gnu && \
+    cd /tmp && \
+    rm -r pwsh msquic powershell-7.2.5-linux-arm64.tar.gz
 
 # Create helixbot user and give rights to sudo without password
 # additionally, preinstall the virtualenv packages used for VSTS reporting to save time

--- a/src/debian/10/helix/arm64v8/Dockerfile
+++ b/src/debian/10/helix/arm64v8/Dockerfile
@@ -57,7 +57,7 @@ RUN cd /tmp && \
     tar xf powershell-7.2.5-linux-arm64.tar.gz && \
     cd .. && \
     git clone --depth 1 --single-branch --branch release/7.0 --recursive https://github.com/dotnet/msquic && \
-    cd msquic/src/msquic  &&  PATH=~/.dotnet/tools:$PATH /tmp/pwsh/pwsh scripts/build.ps1 -arch arm64 -Config Release && \
+    cd msquic/src/msquic  &&  PATH=~/.dotnet/tools:$PATH /tmp/pwsh/pwsh scripts/build.ps1 -arch arm64 -Config Release -UseSystemOpenSSLCrypto -DisableTools -DisableTest -DisablePerf && \
     cp artifacts/bin/linux/arm64_Release_openssl/libmsquic.so.2 artifacts/bin/linux/arm64_Release_openssl/libmsquic.lttng.so.2.1.0 /usr/lib/aarch64-linux-gnu && \
     cd /tmp && \
     rm -r pwsh msquic powershell-7.2.5-linux-arm64.tar.gz

--- a/src/debian/10/helix/arm64v8/Dockerfile
+++ b/src/debian/10/helix/arm64v8/Dockerfile
@@ -60,7 +60,7 @@ RUN cd /tmp && \
     cd msquic/src/msquic  &&  PATH=~/.dotnet/tools:$PATH /tmp/pwsh/pwsh scripts/build.ps1 -arch arm64 -Config Release -UseSystemOpenSSLCrypto -DisableTools -DisableTest -DisablePerf && \
     cp artifacts/bin/linux/arm64_Release_openssl/libmsquic.so.2 artifacts/bin/linux/arm64_Release_openssl/libmsquic.lttng.so.2.1.0 /usr/lib/aarch64-linux-gnu && \
     cd /tmp && \
-    rm -r pwsh msquic powershell-7.2.5-linux-arm64.tar.gz
+    rm -rf pwsh msquic
 
 # Create helixbot user and give rights to sudo without password
 # additionally, preinstall the virtualenv packages used for VSTS reporting to save time

--- a/src/debian/10/helix/arm64v8/Dockerfile
+++ b/src/debian/10/helix/arm64v8/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update && \
         unzip \
     && rm -rf /var/lib/apt/lists/* \
     && curl -O https://cmake.org/files/v3.23/cmake-3.23.1-linux-aarch64.tar.gz \
-    && cat cmake-3.23.1-linux-aarch64.tar.gz  | sha256sum -c <(echo "74062efddeb935bce3d33694a4db534cef9a650f77a9a153a9f217d9dc385c75  -") \
+    && echo "74062efddeb935bce3d33694a4db534cef9a650f77a9a153a9f217d9dc385c75 cmake-3.23.1-linux-aarch64.tar.gz" | sha256sum --check - \
     && tar -xf cmake-3.23.1-linux-aarch64.tar.gz  --strip 1 -C /usr/local \
     && rm cmake-3.23.1-linux-aarch64.tar.gz \
     \
@@ -53,7 +53,7 @@ RUN cd /tmp && \
     mkdir pwsh && \
     cd pwsh && \
     curl -LO https://github.com/PowerShell/PowerShell/releases/download/v7.2.5/powershell-7.2.5-linux-arm64.tar.gz && \
-    cat powershell-7.2.5-linux-arm64.tar.gz | sha256sum -c <(echo "709265A0B99232CD8AB6F8A02C01F3AEE94262B959E1A4B0FD871C8789C07396 -") && \
+    echo "709265A0B99232CD8AB6F8A02C01F3AEE94262B959E1A4B0FD871C8789C07396 powershell-7.2.5-linux-arm64.tar.gz" | sha256sum --check - && \
     tar xf powershell-7.2.5-linux-arm64.tar.gz && \
     cd .. && \
     git clone --depth 1 --single-branch --branch release/7.0 --recursive https://github.com/dotnet/msquic && \

--- a/src/debian/11/helix/arm64v8/Dockerfile
+++ b/src/debian/11/helix/arm64v8/Dockerfile
@@ -49,7 +49,7 @@ RUN cd /tmp && \
     mkdir pwsh && \
     cd pwsh && \
     curl -LO https://github.com/PowerShell/PowerShell/releases/download/v7.2.5/powershell-7.2.5-linux-arm64.tar.gz && \
-    cat powershell-7.2.5-linux-arm64.tar.gz | sha256sum -c <(echo "709265A0B99232CD8AB6F8A02C01F3AEE94262B959E1A4B0FD871C8789C07396 -") && \
+    echo "709265A0B99232CD8AB6F8A02C01F3AEE94262B959E1A4B0FD871C8789C07396 powershell-7.2.5-linux-arm64.tar.gz" | sha256sum --check - && \
     tar xf powershell-7.2.5-linux-arm64.tar.gz && \
     cd .. && \
     git clone --depth 1 --single-branch --branch release/7.0 --recursive https://github.com/dotnet/msquic && \

--- a/src/debian/11/helix/arm64v8/Dockerfile
+++ b/src/debian/11/helix/arm64v8/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && \
         automake \
         at \
         build-essential \
+        cmake \
         curl \
         gcc \
         gdb \
@@ -17,6 +18,7 @@ RUN apt-get update && \
         libffi-dev \
         libgdiplus \
         libicu-dev \
+        liblttng-ust-dev \
         libssl-dev \
         libtool \
         libunwind8 \
@@ -41,6 +43,20 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
     export CRYPTOGRAPHY_DONT_BUILD_RUST=1 && \
     pip install ./helix_scripts-*-py3-none-any.whl
+
+# build MsQuic as we don't have packages
+RUN cd /tmp && \
+    mkdir pwsh && \
+    cd pwsh && \
+    curl -LO https://github.com/PowerShell/PowerShell/releases/download/v7.2.5/powershell-7.2.5-linux-arm64.tar.gz && \
+    cat powershell-7.2.5-linux-arm64.tar.gz | sha256sum -c <(echo "709265A0B99232CD8AB6F8A02C01F3AEE94262B959E1A4B0FD871C8789C07396 -") && \
+    tar xf powershell-7.2.5-linux-arm64.tar.gz && \
+    cd .. && \
+    git clone --depth 1 --single-branch --branch release/7.0 --recursive https://github.com/dotnet/msquic && \
+    cd msquic/src/msquic  &&  PATH=~/.dotnet/tools:$PATH /tmp/pwsh/pwsh scripts/build.ps1 -arch arm64 -Config Release && \
+    cp artifacts/bin/linux/arm64_Release_openssl/libmsquic.so.2 artifacts/bin/linux/arm64_Release_openssl/libmsquic.lttng.so.2.1.0 /usr/lib/aarch64-linux-gnu && \
+    cd /tmp && \
+    rm -r pwsh msquic powershell-7.2.5-linux-arm64.tar.gz
 
 # Create helixbot user and give rights to sudo without password
 # additionally, preinstall the virtualenv packages used for VSTS reporting to save time

--- a/src/debian/11/helix/arm64v8/Dockerfile
+++ b/src/debian/11/helix/arm64v8/Dockerfile
@@ -56,7 +56,7 @@ RUN cd /tmp && \
     cd msquic/src/msquic  &&  PATH=~/.dotnet/tools:$PATH /tmp/pwsh/pwsh scripts/build.ps1 -arch arm64 -Config Release -UseSystemOpenSSLCrypto -DisableTools -DisableTest -DisablePerf && \
     cp artifacts/bin/linux/arm64_Release_openssl/libmsquic.so.2 artifacts/bin/linux/arm64_Release_openssl/libmsquic.lttng.so.2.1.0 /usr/lib/aarch64-linux-gnu && \
     cd /tmp && \
-    rm -r pwsh msquic powershell-7.2.5-linux-arm64.tar.gz
+    rm -rf pwsh msquic
 
 # Create helixbot user and give rights to sudo without password
 # additionally, preinstall the virtualenv packages used for VSTS reporting to save time

--- a/src/debian/11/helix/arm64v8/Dockerfile
+++ b/src/debian/11/helix/arm64v8/Dockerfile
@@ -53,7 +53,7 @@ RUN cd /tmp && \
     tar xf powershell-7.2.5-linux-arm64.tar.gz && \
     cd .. && \
     git clone --depth 1 --single-branch --branch release/7.0 --recursive https://github.com/dotnet/msquic && \
-    cd msquic/src/msquic  &&  PATH=~/.dotnet/tools:$PATH /tmp/pwsh/pwsh scripts/build.ps1 -arch arm64 -Config Release && \
+    cd msquic/src/msquic  &&  PATH=~/.dotnet/tools:$PATH /tmp/pwsh/pwsh scripts/build.ps1 -arch arm64 -Config Release -UseSystemOpenSSLCrypto -DisableTools -DisableTest -DisablePerf && \
     cp artifacts/bin/linux/arm64_Release_openssl/libmsquic.so.2 artifacts/bin/linux/arm64_Release_openssl/libmsquic.lttng.so.2.1.0 /usr/lib/aarch64-linux-gnu && \
     cd /tmp && \
     rm -r pwsh msquic powershell-7.2.5-linux-arm64.tar.gz


### PR DESCRIPTION
separating Debian from #662.
Arm does not have packages at the moment -> build msquic from sources.