### PR TITLE
fix failing fpm install

### DIFF
--- a/src/ubuntu/18.04/amd64/Dockerfile
+++ b/src/ubuntu/18.04/amd64/Dockerfile
@@ -3,6 +3,8 @@ FROM ubuntu:18.04
 # Install the base toolchain we need to build anything (clang, cmake, make and the like)
 # this does not include libraries that we need to compile different projects, we'd like
 # them in a different layer.
+# fpm install may fail without adding public_suffix explicitly. May be remove in the future.
+# https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/675
 RUN apt-get update \
     && apt-get install -y \
         clang-9 \

--- a/src/ubuntu/18.04/amd64/Dockerfile
+++ b/src/ubuntu/18.04/amd64/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update \
         sudo \
         wget \
     && rm -rf /var/lib/apt/lists/* \
+    && gem install public_suffix -v 4.0.7 \
     && gem install fpm \
     && wget https://cmake.org/files/v3.23/cmake-3.23.1-linux-x86_64.tar.gz \
     && tar -xf cmake-3.23.1-linux-x86_64.tar.gz --strip 1 -C /usr/local \

--- a/src/ubuntu/18.04/arm32v7/Dockerfile
+++ b/src/ubuntu/18.04/arm32v7/Dockerfile
@@ -16,5 +16,6 @@ RUN apt-get update && \
         libtool \
         libkrb5-dev \
         ruby-dev \
+    && gem install public_suffix -v 4.0.7 \
     && gem install fpm \
     && rm -rf /var/lib/apt/lists/*

--- a/src/ubuntu/18.04/arm32v7/Dockerfile
+++ b/src/ubuntu/18.04/arm32v7/Dockerfile
@@ -1,5 +1,7 @@
 FROM arm32v7/ubuntu:18.04
 
+# fpm install may fail without adding public_suffix explicitly. May be remove in the future.
+# https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/675
 RUN apt-get update && \
     apt-get install -y \
         autoconf \

--- a/src/ubuntu/18.04/arm64v8/Dockerfile
+++ b/src/ubuntu/18.04/arm64v8/Dockerfile
@@ -1,5 +1,7 @@
 FROM arm64v8/ubuntu:18.04
 
+# fpm install may fail without adding public_suffix explicitly. May be remove in the future.
+# https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/675
 RUN apt-get update && \
     apt-get install -y \
         autoconf \

--- a/src/ubuntu/18.04/arm64v8/Dockerfile
+++ b/src/ubuntu/18.04/arm64v8/Dockerfile
@@ -16,5 +16,6 @@ RUN apt-get update && \
         libtool \
         libkrb5-dev \
         ruby-dev \
+    && gem install public_suffix -v 4.0.7 \
     && gem install fpm \
     && rm -rf /var/lib/apt/lists/*

--- a/src/ubuntu/18.04/coredeps/Dockerfile
+++ b/src/ubuntu/18.04/coredeps/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update \
         ruby-dev \
         tar \
         zip \
+    && gem install public_suffix -v 4.0.7 \
     && gem install fpm \
     && rm -rf /var/lib/apt/lists/* \
     && npm install -g azure-cli@0.9.20 \

--- a/src/ubuntu/18.04/coredeps/Dockerfile
+++ b/src/ubuntu/18.04/coredeps/Dockerfile
@@ -1,6 +1,8 @@
 FROM mcr.microsoft.com/powershell:lts-ubuntu-18.04
 
 # Install tools used by the VSO build automation.
+# fpm install may fail without adding public_suffix explicitly. May be remove in the future.
+# https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/675
 RUN apt-get update \
     && apt-get install -y \
         curl \


### PR DESCRIPTION
It seems like fpm is failing to install with latest Ubuntu 18.04 build 

https://dev.azure.com/dnceng/internal/_build/results?buildId=1956544&view=logs&j=b89d4bba-6f7d-5ea7-2ed5-f1e3b98a02e5&t=17c4997e-89ae-513c-de3e-350154a48db1
```
ERROR:  Error installing fpm:
	The last version of public_suffix (< 6.0, >= 2.0.2) to support your Ruby & RubyGems was 4.0.7. Try installing it with `gem install public_suffix -v 4.0.7` and then running the current command again
	public_suffix requires Ruby version >= 2.6. The current ruby version is 2.5.0.
```

while I don't like fixing the version, it fixes the build issue for now. 
Interestingly, Debian builds are still OK so this is some caveat of Ubuntu 18. 