### PR TITLE
Add ubuntu-22.04-cross-arm image

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,16 +98,16 @@ The [manifest.json](./manifest.json) contains metadata used by the build infrast
 
 ### Image Dependency
 
-A precondition for building an image is to ensure that the base image specified in the [FROM]((https://docs.docker.com/engine/reference/builder/#from)) statement of the Dockerfile is available either locally or can be pulled from a Docker registry.  Some of the Dockerfiles depend on images produced from other Dockerfiles (e.g. [src/ubuntu/16.04/debpkg](./src/ubuntu/16.04/debpkg)).  In these cases, the `FROM` reference should not include the `<date-time>-<dockerfile-commit-sha>` portion of the tags.  This is referred to as a stable tag as it does not change from build to build.  This pattern is used so that the Dockerfiles do not need constant updating as new versions of the base images are built.  To support this scenario, the manifest entry for the base image must be defined to produce the stable tag.
+A precondition for building an image is to ensure that the base image specified in the [FROM]((https://docs.docker.com/engine/reference/builder/#from)) statement of the Dockerfile is available either locally or can be pulled from a Docker registry.  Some of the Dockerfiles depend on images produced from other Dockerfiles (e.g. [src/ubuntu/22.04/debpkg](./src/ubuntu/22.04/debpkg)).  In these cases, the `FROM` reference should not include the `<date-time>-<dockerfile-commit-sha>` portion of the tags.  This is referred to as a stable tag as it does not change from build to build.  This pattern is used so that the Dockerfiles do not need constant updating as new versions of the base images are built.  To support this scenario, the manifest entry for the base image must be defined to produce the stable tag.
 
 ```json
 "platforms": [
     {
-        "dockerfile": "ubuntu/16.04",
+        "dockerfile": "ubuntu/22.04",
         "os": "linux",
         "tags": {
-            "ubuntu-16.04-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-            "ubuntu-16.04": {
+            "ubuntu-22.04-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+            "ubuntu-22.04": {
                 "isLocal": true
             }
         }

--- a/src/ubuntu/18.04/cross/arm/16.04/Dockerfile
+++ b/src/ubuntu/18.04/cross/arm/16.04/Dockerfile
@@ -1,3 +1,0 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-crossdeps
-
-ADD rootfs.arm.tar crossrootfs

--- a/src/ubuntu/18.04/cross/arm/16.04/hooks/post-build
+++ b/src/ubuntu/18.04/cross/arm/16.04/hooks/post-build
@@ -1,1 +1,0 @@
-../../../../../build-scripts/build-rootfs-cleanup.sh

--- a/src/ubuntu/18.04/cross/arm/16.04/hooks/pre-build
+++ b/src/ubuntu/18.04/cross/arm/16.04/hooks/pre-build
@@ -1,5 +1,0 @@
-#!/usr/bin/env sh
-
-SCRIPT=$(readlink -f "$0")
-SCRIPTPATH=$(dirname "$SCRIPT")
-$SCRIPTPATH/../../../../../build-scripts/build-rootfs.sh ubuntu-18.04 xenial

--- a/src/ubuntu/18.04/cross/arm/hooks/post-build
+++ b/src/ubuntu/18.04/cross/arm/hooks/post-build
@@ -1,5 +1,1 @@
-#!/usr/bin/env sh
-
-SCRIPT=$(readlink -f "$0")
-SCRIPTPATH=$(dirname "$SCRIPT")
-$SCRIPTPATH/../../../../build-scripts/build-rootfs-cleanup.sh
+../../../../build-scripts/build-rootfs-cleanup.sh

--- a/src/ubuntu/18.04/cross/arm64/16.04/Dockerfile
+++ b/src/ubuntu/18.04/cross/arm64/16.04/Dockerfile
@@ -1,9 +1,0 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-crossdeps
-
-# Install binutils-aarch64-linux-gnu
-RUN apt-get update \
-    && apt-get install -y \
-        binutils-aarch64-linux-gnu \
-    && rm -rf /var/lib/apt/lists/*
-
-ADD rootfs.arm64.tar crossrootfs

--- a/src/ubuntu/18.04/cross/arm64/16.04/hooks/post-build
+++ b/src/ubuntu/18.04/cross/arm64/16.04/hooks/post-build
@@ -1,1 +1,0 @@
-../../../../../build-scripts/build-rootfs-cleanup.sh

--- a/src/ubuntu/18.04/cross/arm64/16.04/hooks/pre-build
+++ b/src/ubuntu/18.04/cross/arm64/16.04/hooks/pre-build
@@ -1,5 +1,0 @@
-#!/usr/bin/env sh
-
-SCRIPT=$(readlink -f "$0")
-SCRIPTPATH=$(dirname "$SCRIPT")
-$SCRIPTPATH/../../../../../build-scripts/build-rootfs.sh ubuntu-18.04 xenial arm64 lldb3.9

--- a/src/ubuntu/22.04/cross/arm-alpine/hooks/pre-build
+++ b/src/ubuntu/22.04/cross/arm-alpine/hooks/pre-build
@@ -2,4 +2,4 @@
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
-$SCRIPTPATH/../../../../build-scripts/build-rootfs.sh ubuntu-22.04 alpine arm lldb14
+$SCRIPTPATH/../../../../build-scripts/build-rootfs.sh ubuntu-22.04 alpine arm

--- a/src/ubuntu/22.04/cross/arm/Dockerfile
+++ b/src/ubuntu/22.04/cross/arm/Dockerfile
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps
+
+ADD rootfs.arm.tar crossrootfs

--- a/src/ubuntu/22.04/cross/arm/hooks/post-build
+++ b/src/ubuntu/22.04/cross/arm/hooks/post-build
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+SCRIPT=$(readlink -f "$0")
+SCRIPTPATH=$(dirname "$SCRIPT")
+$SCRIPTPATH/../../../../build-scripts/build-rootfs-cleanup.sh

--- a/src/ubuntu/22.04/cross/arm/hooks/post-build
+++ b/src/ubuntu/22.04/cross/arm/hooks/post-build
@@ -1,5 +1,1 @@
-#!/usr/bin/env sh
-
-SCRIPT=$(readlink -f "$0")
-SCRIPTPATH=$(dirname "$SCRIPT")
-$SCRIPTPATH/../../../../build-scripts/build-rootfs-cleanup.sh
+../../../../build-scripts/build-rootfs-cleanup.sh

--- a/src/ubuntu/22.04/cross/arm/hooks/pre-build
+++ b/src/ubuntu/22.04/cross/arm/hooks/pre-build
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+SCRIPT=$(readlink -f "$0")
+SCRIPTPATH=$(dirname "$SCRIPT")
+$SCRIPTPATH/../../../../build-scripts/build-rootfs.sh ubuntu-22.04 jammy arm lldb14

--- a/src/ubuntu/manifest.json
+++ b/src/ubuntu/manifest.json
@@ -589,6 +589,18 @@
         {
           "platforms": [
             {
+              "dockerfile": "src/ubuntu/22.04/cross/arm",
+              "os": "linux",
+              "osVersion": "jammy",
+              "tags": {
+                "ubuntu-22.04-cross-arm-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
               "dockerfile": "src/ubuntu/22.04/cross/arm-alpine",
               "os": "linux",
               "osVersion": "jammy",

--- a/src/ubuntu/manifest.json
+++ b/src/ubuntu/manifest.json
@@ -103,18 +103,6 @@
         {
           "platforms": [
             {
-              "dockerfile": "src/ubuntu/18.04/cross/arm/16.04",
-              "os": "linux",
-              "osVersion": "bionic",
-              "tags": {
-                "ubuntu-18.04-cross-arm-16.04-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
-              }
-            }
-          ]
-        },
-        {
-          "platforms": [
-            {
               "dockerfile": "src/ubuntu/18.04/cross/arm",
               "os": "linux",
               "osVersion": "bionic",
@@ -144,18 +132,6 @@
               "osVersion": "bionic",
               "tags": {
                 "ubuntu-18.04-cross-arm64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
-              }
-            }
-          ]
-        },
-        {
-          "platforms": [
-            {
-              "dockerfile": "src/ubuntu/18.04/cross/arm64/16.04",
-              "os": "linux",
-              "osVersion": "bionic",
-              "tags": {
-                "ubuntu-18.04-cross-arm64-16.04-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
               }
             }
           ]


### PR DESCRIPTION
Moved `ubuntu-18.04-cross-arm-16.04` to `ubuntu-22.04-cross-arm`, since we already have `ubuntu-18.04-cross-arm` (xenial variant under bionic is a strange combination and it is not used by anyone). `22.04-cross-arm64` and `18.04-cross-arm64` are already present, so I have simply deleted the unused variant `18.04-cross-arm64-16.04`.

Also removed the unused argumetn `lldb14` from alpine-arm; we only use lldbX argument for Debian or Ubuntu in rootfs, so this is unused and confusing for the reader.