### PR TITLE
Fix codename in riscv64 pre-build hook

### DIFF
--- a/src/ubuntu/22.04/cross/riscv64/hooks/pre-build
+++ b/src/ubuntu/22.04/cross/riscv64/hooks/pre-build
@@ -2,4 +2,4 @@
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
-$SCRIPTPATH/../../../../build-scripts/build-rootfs.sh ubuntu-22.04 jammy riscv64
+$SCRIPTPATH/../../../../build-scripts/build-rootfs.sh ubuntu-22.04 sid riscv64


### PR DESCRIPTION
We have started to recognize `jammy` codename in arcade. Before https://github.com/dotnet/arcade/pull/10520, we were just ignoring the codename.