### PR TITLE
Add msquic to OpenSUSE

### DIFF
--- a/src/opensuse/15.2/helix/amd64/Dockerfile
+++ b/src/opensuse/15.2/helix/amd64/Dockerfile
@@ -35,9 +35,13 @@ RUN zypper ref && \
 
 ENV LANG=en_US.utf8
 
-RUN wget https://github.com/microsoft/msquic/releases/download/v2.1.1/libmsquic-2.1.1-1.x86_64.rpm && \
-    rpm -i libmsquic-2.1.1-1.x86_64.rpm && \
-    rm libmsquic-2.1.1-1.x86_64.rpm
+# Install MsQuic from official GitHub releases
+RUN wget https://packages.microsoft.com/keys/microsoft.asc && \
+    echo 2cfd20a306b2fa5e25522d78f2ef50a1f429d35fd30bd983e2ebffc2b80944fa microsoft.asc | sha256sum --check - && \
+    rpm --import microsoft.asc && \
+    rm microsoft.asc && \
+    zypper install -y https://github.com/microsoft/msquic/releases/download/v2.1.1/libmsquic-2.1.1-1.x86_64.rpm && \
+    zypper clean -a
 
 RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     python -m pip install --upgrade pip==20.2 && \

--- a/src/opensuse/15.2/helix/amd64/Dockerfile
+++ b/src/opensuse/15.2/helix/amd64/Dockerfile
@@ -28,8 +28,8 @@ RUN zypper ref && \
         python3-devel \
         python3-pip \
         sudo \
-        wget \
-        unzip && \
+        unzip \
+        wget && \
         \
         zypper clean -a
 

--- a/src/opensuse/15.2/helix/amd64/Dockerfile
+++ b/src/opensuse/15.2/helix/amd64/Dockerfile
@@ -28,11 +28,16 @@ RUN zypper ref && \
         python3-devel \
         python3-pip \
         sudo \
+        wget \
         unzip && \
         \
         zypper clean -a
 
 ENV LANG=en_US.utf8
+
+RUN wget https://github.com/microsoft/msquic/releases/download/v2.1.1/libmsquic-2.1.1-1.x86_64.rpm && \
+    rpm -i libmsquic-2.1.1-1.x86_64.rpm && \
+    rm libmsquic-2.1.1-1.x86_64.rpm
 
 RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     python -m pip install --upgrade pip==20.2 && \


### PR DESCRIPTION
This PR installs MsQuic 2.1.1 from official rpm from github (I did not find a way to add packages.microsoft.com feed to zypper). Tests run, except that IPv6 is apparently disabled on the image. That is going to be mitigated by https://github.com/dotnet/runtime/pull/75341.