### PR TITLE
Add additional packages for centos-stream9-helix

### DIFF
--- a/src/centos/stream9/helix/amd64/Dockerfile
+++ b/src/centos/stream9/helix/amd64/Dockerfile
@@ -6,10 +6,22 @@ RUN dnf install --setopt tsflags=nodocs --refresh -y \
     && \
     dnf config-manager --set-enabled crb \
     && \
-    dnf install --setopt tsflags=nodocs -y \
+    dnf install --setopt tsflags=nodocs -y --allowerasing \
+        autoconf \
+        automake \
+        curl \
+        file \
         gcc \
+        gcc-c++ \
+        gdb \
+        git-core \
+        iputils \
         libicu \
+        libtool \
+        make \
         openssl \
+        openssl-devel \
+        perl \
         python3 \
         python3-devel \
         sudo \


### PR DESCRIPTION
I tried using this dotnet/runtime and got a large set of missing-dependency issues:
https://dev.azure.com/dnceng/public/_build/results?buildId=1977064&view=results

Adding some (not all) packages based on the Debian 11 helix file.

I may have to do a few more iterations to get this container to a state where helix is fully happy with it.