### PR TITLE
update alpine helix images to use quic 2.1.1

### DIFF
--- a/src/alpine/3.15/helix/amd64/Dockerfile
+++ b/src/alpine/3.15/helix/amd64/Dockerfile
@@ -15,6 +15,18 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
     pip install ./helix_scripts-*-py3-none-any.whl
 
+# build MsQuic as we don't have packages
+RUN cd /tmp && \
+    mkdir pwsh && \
+    cd pwsh && \
+    curl -L https://github.com/PowerShell/PowerShell/releases/download/v7.2.5/powershell-7.2.5-linux-alpine-x64.tar.gz | tar xfz - && \
+    cd .. && \
+    git clone --depth 1 --single-branch --branch release/7.0 --recursive https://github.com/dotnet/msquic && \
+    cd msquic/src/msquic  &&  PATH=~/.dotnet/tools:$PATH /tmp/pwsh/pwsh scripts/build.ps1 -Config Release -UseSystemOpenSSLCrypto -DisableTools -DisableTest -DisablePerf && \
+    cp artifacts/bin/linux/x64_Release_openssl/libmsquic.so.2 artifacts/bin/linux/x64_Release_openssl/libmsquic.lttng.so.2.1.0 /usr/lib && \
+    cd /tmp && \
+    rm -r pwsh msquic
+
 # Needed for corefx tests to pass
 ENV LANG=en-US.UTF-8
 

--- a/src/alpine/3.16/helix/amd64/Dockerfile
+++ b/src/alpine/3.16/helix/amd64/Dockerfile
@@ -1,9 +1,44 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.14
+FROM alpine-3.16
 RUN apk update && apk add --no-cache \
-    cargo \
-    iputils \
-    libffi-dev \
-    rust
+        autoconf \
+        automake \
+        bash \
+        build-base \
+        cargo \
+        clang \
+        clang-dev \
+        cmake \
+        coreutils \
+        curl \
+        gcc \
+        gettext-dev \
+        git \
+        icu-dev \
+        iputils \
+        jq \
+        krb5-dev \
+        libffi-dev \
+        libtool \
+        libunwind-dev \
+        linux-headers \
+        lld \
+        lldb-dev \
+        llvm \
+        lttng-ust-dev \
+        make \
+        numactl-dev \
+        openssl \
+        openssl-dev \
+        paxctl \
+        py3-lldb \
+        python3-dev \
+        rust \
+        shadow \
+        sudo \
+        tzdata \
+        util-linux-dev \
+        which \
+        zlib-dev
 
 # Install Helix Dependencies
 
@@ -22,7 +57,7 @@ RUN cd /tmp && \
     curl -L https://github.com/PowerShell/PowerShell/releases/download/v7.2.5/powershell-7.2.5-linux-alpine-x64.tar.gz | tar xfz - && \
     cd .. && \
     git clone --depth 1 --single-branch --branch release/7.0 --recursive https://github.com/dotnet/msquic && \
-    cd msquic/src/msquic  &&  PATH=~/.dotnet/tools:$PATH /tmp/pwsh/pwsh scripts/build.ps1 -Config Release -Config Release -UseSystemOpenSSLCrypto -DisableTools -DisableTest -DisablePerf && \
+    cd msquic/src/msquic  &&  PATH=~/.dotnet/tools:$PATH /tmp/pwsh/pwsh scripts/build.ps1 -Config Release -UseSystemOpenSSLCrypto -DisableTools -DisableTest -DisablePerf && \
     cp artifacts/bin/linux/x64_Release_openssl/libmsquic.so.2 artifacts/bin/linux/x64_Release_openssl/libmsquic.lttng.so.2.1.0 /usr/lib && \
     cd /tmp && \
     rm -r pwsh msquic

--- a/src/alpine/manifest.json
+++ b/src/alpine/manifest.json
@@ -203,6 +203,18 @@
               }
             }
           ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/alpine/3.16/helix/amd64",
+              "os": "linux",
+              "osVersion": "alpine3.16",
+              "tags": {
+                "alpine-3.16-helix-amd64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
+              }
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
3.13 goes out of support in November so I did not bother. Instead, I added 3.16 that will expire 2024-05-23

arm64 does not have Power Shell binaries for Alpine so that will need separate effort. 