### PR TITLE
Rename build-rootfs to run-arcade-build-rootfs

### DIFF
--- a/src/raspbian/10/helix/arm32v6/hooks/pre-build
+++ b/src/raspbian/10/helix/arm32v6/hooks/pre-build
@@ -2,4 +2,4 @@
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
-$SCRIPTPATH/../../../../../ubuntu/build-scripts/build-rootfs.sh raspbian-10 raspbian armv6 "" "" true
+$SCRIPTPATH/../../../../../ubuntu/build-scripts/run-arcade-build-rootfs.sh raspbian-10 raspbian armv6 "" "" true

--- a/src/ubuntu/18.04/cross/arm-alpine/hooks/pre-build
+++ b/src/ubuntu/18.04/cross/arm-alpine/hooks/pre-build
@@ -2,4 +2,4 @@
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
-$SCRIPTPATH/../../../../build-scripts/build-rootfs.sh ubuntu-18.04 alpine arm lldb3.9
+$SCRIPTPATH/../../../../build-scripts/run-arcade-build-rootfs.sh ubuntu-18.04 alpine arm lldb3.9

--- a/src/ubuntu/18.04/cross/arm/hooks/pre-build
+++ b/src/ubuntu/18.04/cross/arm/hooks/pre-build
@@ -2,4 +2,4 @@
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
-$SCRIPTPATH/../../../../build-scripts/build-rootfs.sh ubuntu-18.04 bionic arm lldb3.9 "" "" llvm9
+$SCRIPTPATH/../../../../build-scripts/run-arcade-build-rootfs.sh ubuntu-18.04 bionic arm lldb3.9 "" "" llvm9

--- a/src/ubuntu/18.04/cross/arm64-alpine/hooks/pre-build
+++ b/src/ubuntu/18.04/cross/arm64-alpine/hooks/pre-build
@@ -2,4 +2,4 @@
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
-$SCRIPTPATH/../../../../build-scripts/build-rootfs.sh ubuntu-18.04 alpine arm64 lldb3.9
+$SCRIPTPATH/../../../../build-scripts/run-arcade-build-rootfs.sh ubuntu-18.04 alpine arm64 lldb3.9

--- a/src/ubuntu/18.04/cross/arm64/hooks/pre-build
+++ b/src/ubuntu/18.04/cross/arm64/hooks/pre-build
@@ -2,4 +2,4 @@
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
-$SCRIPTPATH/../../../../build-scripts/build-rootfs.sh ubuntu-18.04 bionic arm64 lldb3.9 "" "" llvm9
+$SCRIPTPATH/../../../../build-scripts/run-arcade-build-rootfs.sh ubuntu-18.04 bionic arm64 lldb3.9 "" "" llvm9

--- a/src/ubuntu/18.04/cross/armel-tizen/hooks/pre-build
+++ b/src/ubuntu/18.04/cross/armel-tizen/hooks/pre-build
@@ -2,4 +2,4 @@
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
-$SCRIPTPATH/../../../../build-scripts/build-rootfs.sh ubuntu-18.04 tizen armel lldb3.9 /rootfs/armel/usr/bin
+$SCRIPTPATH/../../../../build-scripts/run-arcade-build-rootfs.sh ubuntu-18.04 tizen armel lldb3.9 /rootfs/armel/usr/bin

--- a/src/ubuntu/18.04/cross/freebsd-arm64/13/hooks/pre-build
+++ b/src/ubuntu/18.04/cross/freebsd-arm64/13/hooks/pre-build
@@ -2,4 +2,4 @@
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
-$SCRIPTPATH/../../../../../build-scripts/build-rootfs.sh ubuntu-18.04 freebsd13 arm64
+$SCRIPTPATH/../../../../../build-scripts/run-arcade-build-rootfs.sh ubuntu-18.04 freebsd13 arm64

--- a/src/ubuntu/18.04/cross/freebsd/12/hooks/pre-build
+++ b/src/ubuntu/18.04/cross/freebsd/12/hooks/pre-build
@@ -2,4 +2,4 @@
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
-$SCRIPTPATH/../../../../../build-scripts/build-rootfs.sh ubuntu-18.04 freebsd12 x64
+$SCRIPTPATH/../../../../../build-scripts/run-arcade-build-rootfs.sh ubuntu-18.04 freebsd12 x64

--- a/src/ubuntu/18.04/cross/hooks/pre-build
+++ b/src/ubuntu/18.04/cross/hooks/pre-build
@@ -2,4 +2,4 @@
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
-$SCRIPTPATH/../../../build-scripts/build-rootfs.sh ubuntu-18.04 bionic
+$SCRIPTPATH/../../../build-scripts/run-arcade-build-rootfs.sh ubuntu-18.04 bionic

--- a/src/ubuntu/18.04/cross/illumos/hooks/pre-build
+++ b/src/ubuntu/18.04/cross/illumos/hooks/pre-build
@@ -2,4 +2,4 @@
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
-$SCRIPTPATH/../../../../build-scripts/build-rootfs.sh ubuntu-18.04 illumos x64
+$SCRIPTPATH/../../../../build-scripts/run-arcade-build-rootfs.sh ubuntu-18.04 illumos x64

--- a/src/ubuntu/18.04/cross/ppc64le/hooks/pre-build
+++ b/src/ubuntu/18.04/cross/ppc64le/hooks/pre-build
@@ -2,4 +2,4 @@
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
-$SCRIPTPATH/../../../../build-scripts/build-rootfs.sh ubuntu-18.04 bionic ppc64le nolldb
+$SCRIPTPATH/../../../../build-scripts/run-arcade-build-rootfs.sh ubuntu-18.04 bionic ppc64le nolldb

--- a/src/ubuntu/18.04/cross/s390x/hooks/pre-build
+++ b/src/ubuntu/18.04/cross/s390x/hooks/pre-build
@@ -2,4 +2,4 @@
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
-$SCRIPTPATH/../../../../build-scripts/build-rootfs.sh ubuntu-18.04 bionic s390x nolldb
+$SCRIPTPATH/../../../../build-scripts/run-arcade-build-rootfs.sh ubuntu-18.04 bionic s390x nolldb

--- a/src/ubuntu/18.04/cross/x86-linux/hooks/pre-build
+++ b/src/ubuntu/18.04/cross/x86-linux/hooks/pre-build
@@ -2,4 +2,4 @@
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
-$SCRIPTPATH/../../../../build-scripts/build-rootfs.sh ubuntu-18.04 linux x86 lldb3.9
+$SCRIPTPATH/../../../../build-scripts/run-arcade-build-rootfs.sh ubuntu-18.04 linux x86 lldb3.9

--- a/src/ubuntu/18.04/mlnet/cross/arm/hooks/pre-build
+++ b/src/ubuntu/18.04/mlnet/cross/arm/hooks/pre-build
@@ -2,4 +2,4 @@
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
-$SCRIPTPATH/../../../../../build-scripts/build-rootfs.sh ubuntu-18.04 bionic arm lldb3.9
+$SCRIPTPATH/../../../../../build-scripts/run-arcade-build-rootfs.sh ubuntu-18.04 bionic arm lldb3.9

--- a/src/ubuntu/18.04/mlnet/cross/arm64/hooks/pre-build
+++ b/src/ubuntu/18.04/mlnet/cross/arm64/hooks/pre-build
@@ -2,4 +2,4 @@
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
-$SCRIPTPATH/../../../../../build-scripts/build-rootfs.sh ubuntu-18.04 bionic arm64 lldb3.9
+$SCRIPTPATH/../../../../../build-scripts/run-arcade-build-rootfs.sh ubuntu-18.04 bionic arm64 lldb3.9

--- a/src/ubuntu/20.04/cross/armv6/10/hooks/pre-build
+++ b/src/ubuntu/20.04/cross/armv6/10/hooks/pre-build
@@ -2,4 +2,4 @@
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
-$SCRIPTPATH/../../../../../build-scripts/build-rootfs.sh ubuntu-20.04 raspbian armv6
+$SCRIPTPATH/../../../../../build-scripts/run-arcade-build-rootfs.sh ubuntu-20.04 raspbian armv6

--- a/src/ubuntu/22.04/cross/arm-alpine/hooks/pre-build
+++ b/src/ubuntu/22.04/cross/arm-alpine/hooks/pre-build
@@ -2,4 +2,4 @@
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
-$SCRIPTPATH/../../../../build-scripts/build-rootfs.sh ubuntu-22.04 alpine arm
+$SCRIPTPATH/../../../../build-scripts/run-arcade-build-rootfs.sh ubuntu-22.04 alpine arm

--- a/src/ubuntu/22.04/cross/arm/hooks/pre-build
+++ b/src/ubuntu/22.04/cross/arm/hooks/pre-build
@@ -2,4 +2,4 @@
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
-$SCRIPTPATH/../../../../build-scripts/build-rootfs.sh ubuntu-22.04 jammy arm lldb14
+$SCRIPTPATH/../../../../build-scripts/run-arcade-build-rootfs.sh ubuntu-22.04 jammy arm lldb14

--- a/src/ubuntu/22.04/cross/arm64-alpine/hooks/pre-build
+++ b/src/ubuntu/22.04/cross/arm64-alpine/hooks/pre-build
@@ -2,4 +2,4 @@
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
-$SCRIPTPATH/../../../../build-scripts/build-rootfs.sh ubuntu-22.04 alpine arm64
+$SCRIPTPATH/../../../../build-scripts/run-arcade-build-rootfs.sh ubuntu-22.04 alpine arm64

--- a/src/ubuntu/22.04/cross/arm64/hooks/pre-build
+++ b/src/ubuntu/22.04/cross/arm64/hooks/pre-build
@@ -2,4 +2,4 @@
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
-$SCRIPTPATH/../../../../build-scripts/build-rootfs.sh ubuntu-22.04 jammy arm64 lldb14
+$SCRIPTPATH/../../../../build-scripts/run-arcade-build-rootfs.sh ubuntu-22.04 jammy arm64 lldb14

--- a/src/ubuntu/22.04/cross/haiku/hooks/pre-build
+++ b/src/ubuntu/22.04/cross/haiku/hooks/pre-build
@@ -2,4 +2,4 @@
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
-$SCRIPTPATH/../../../../build-scripts/build-rootfs.sh ubuntu-22.04 haiku x64 "" /rootfs/x64/boot/system/bin
+$SCRIPTPATH/../../../../build-scripts/run-arcade-build-rootfs.sh ubuntu-22.04 haiku x64 "" /rootfs/x64/boot/system/bin

--- a/src/ubuntu/22.04/cross/riscv64/Dockerfile
+++ b/src/ubuntu/22.04/cross/riscv64/Dockerfile
@@ -1,3 +1,5 @@
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps
 
+RUN echo "a dummy change!"
+
 ADD rootfs.riscv64.tar crossrootfs

--- a/src/ubuntu/22.04/cross/riscv64/Dockerfile
+++ b/src/ubuntu/22.04/cross/riscv64/Dockerfile
@@ -1,5 +1,3 @@
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps
 
-RUN echo "a dummy change!"
-
 ADD rootfs.riscv64.tar crossrootfs

--- a/src/ubuntu/22.04/cross/riscv64/hooks/pre-build
+++ b/src/ubuntu/22.04/cross/riscv64/hooks/pre-build
@@ -2,4 +2,4 @@
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
-$SCRIPTPATH/../../../../build-scripts/build-rootfs.sh ubuntu-22.04 sid riscv64
+$SCRIPTPATH/../../../../build-scripts/run-arcade-build-rootfs.sh ubuntu-22.04 sid riscv64

--- a/src/ubuntu/22.04/crossdeps/Dockerfile
+++ b/src/ubuntu/22.04/crossdeps/Dockerfile
@@ -48,3 +48,5 @@ RUN wget -O- https://apt.llvm.org/llvm.sh | bash -s -- 15 \
         llvm \
         python3-lldb \
     && rm -rf /var/lib/apt/lists/*
+
+RUN echo "a dummy change!"

--- a/src/ubuntu/22.04/crossdeps/Dockerfile
+++ b/src/ubuntu/22.04/crossdeps/Dockerfile
@@ -48,5 +48,3 @@ RUN wget -O- https://apt.llvm.org/llvm.sh | bash -s -- 15 \
         llvm \
         python3-lldb \
     && rm -rf /var/lib/apt/lists/*
-
-RUN echo "a dummy change!"

--- a/src/ubuntu/build-scripts/run-arcade-build-rootfs.sh
+++ b/src/ubuntu/build-scripts/run-arcade-build-rootfs.sh
@@ -52,7 +52,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-echo "Running build-rootfs.sh"
+echo "Running dotnet/arcade's build-rootfs.sh"
 docker exec -e ROOTFS_DIR=/rootfs/$arch $buildRootFSContainer \
         /scripts/eng/common/cross/build-rootfs.sh $arch $crossToolset $lldb $llvm --skipunmount
 


### PR DESCRIPTION
When working with cross build, I found it a bit confusing that `build-rootfs.sh` in this repo is basically a wrapper script which invokes the script with same name from dotnet/arcade repository. The main confusion is the difference in their (positional) arguments.

The purpose of this PR is to disambiguate the names by renaming the script in this repo to <del>`invoke-arcade-rootfs.sh R`</del> `run-arcade-build-rootfs.sh`. <del>If this name sounds strange, I am open for suggestions. :)</del>