### PR TITLE
Only use floating tag suffix for staging

### DIFF
--- a/eng/pipelines/variables/common.yml
+++ b/eng/pipelines/variables/common.yml
@@ -13,15 +13,12 @@ variables:
   value: false
 - name: publicGitRepoUri
   value: https://github.com/dotnet/dotnet-buildtools-prereqs-docker
-- ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/production') }}:
+- ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
   - name: floatingTagSuffix
-    value: latest
-- ${{ elseif eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
-  - name: floatingTagSuffix
-    value: staging
+    value: -staging
 - ${{ else }}:
   - name: floatingTagSuffix
-    value: $(Build.SourceBranchName)
+    value: ""
 - name: manifestVariables
   value: --var UniqueId=$(sourceBuildId) --var FloatingTagSuffix=$(floatingTagSuffix)
 - ${{ if or(eq(variables['Build.SourceBranch'], 'refs/heads/production'), eq(variables['System.PullRequest.TargetBranch'], 'refs/heads/production')) }}:

--- a/eng/pipelines/variables/common.yml
+++ b/eng/pipelines/variables/common.yml
@@ -13,12 +13,15 @@ variables:
   value: false
 - name: publicGitRepoUri
   value: https://github.com/dotnet/dotnet-buildtools-prereqs-docker
-- ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+- ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/production') }}:
+  - name: floatingTagSuffix
+    value: ""
+- ${{ elseif eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
   - name: floatingTagSuffix
     value: -staging
 - ${{ else }}:
   - name: floatingTagSuffix
-    value: ""
+    value: $(Build.SourceBranchName)
 - name: manifestVariables
   value: --var UniqueId=$(sourceBuildId) --var FloatingTagSuffix=$(floatingTagSuffix)
 - ${{ if or(eq(variables['Build.SourceBranch'], 'refs/heads/production'), eq(variables['System.PullRequest.TargetBranch'], 'refs/heads/production')) }}:

--- a/src/alpine/manifest.json
+++ b/src/alpine/manifest.json
@@ -11,7 +11,7 @@
               "osVersion": "alpine3.13",
               "tags": {
                 "alpine-3.13-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "alpine-3.13-$(FloatingTagSuffix)": {},
+                "alpine-3.13$(FloatingTagSuffix)": {},
                 "alpine-3.13": {
                   "isLocal": true
                 }
@@ -27,7 +27,7 @@
               "osVersion": "alpine3.13",
               "tags": {
                 "alpine-3.13-helix-amd64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "alpine-3.13-helix-amd64-$(FloatingTagSuffix)": {}
+                "alpine-3.13-helix-amd64$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -41,7 +41,7 @@
               "osVersion": "alpine3.13",
               "tags": {
                 "alpine-3.13-helix-arm32v7-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "alpine-3.13-helix-arm32v7-$(FloatingTagSuffix)": {}
+                "alpine-3.13-helix-arm32v7$(FloatingTagSuffix)": {}
               },
               "variant": "v7"
             }
@@ -56,7 +56,7 @@
               "osVersion": "alpine3.13",
               "tags": {
                 "alpine-3.13-helix-arm64v8-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "alpine-3.13-helix-arm64v8-$(FloatingTagSuffix)": {}
+                "alpine-3.13-helix-arm64v8$(FloatingTagSuffix)": {}
               },
               "variant": "v8"
             }
@@ -70,7 +70,7 @@
               "osVersion": "alpine3.13",
               "tags": {
                 "alpine-3.13-WithNode-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "alpine-3.13-WithNode-$(FloatingTagSuffix)": {}
+                "alpine-3.13-WithNode$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -83,7 +83,7 @@
               "osVersion": "alpine3.14",
               "tags": {
                 "alpine-3.14-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "alpine-3.14-$(FloatingTagSuffix)": {},
+                "alpine-3.14$(FloatingTagSuffix)": {},
                 "alpine-3.14": {
                   "isLocal": true
                 }
@@ -99,7 +99,7 @@
               "osVersion": "alpine3.14",
               "tags": {
                 "alpine-3.14-helix-amd64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "alpine-3.14-helix-amd64-$(FloatingTagSuffix)": {}
+                "alpine-3.14-helix-amd64$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -113,7 +113,7 @@
               "osVersion": "alpine3.14",
               "tags": {
                 "alpine-3.14-helix-arm32v7-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "alpine-3.14-helix-arm32v7-$(FloatingTagSuffix)": {}
+                "alpine-3.14-helix-arm32v7$(FloatingTagSuffix)": {}
               },
               "variant": "v7"
             }
@@ -128,7 +128,7 @@
               "osVersion": "alpine3.14",
               "tags": {
                 "alpine-3.14-helix-arm64v8-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "alpine-3.14-helix-arm64v8-$(FloatingTagSuffix)": {}
+                "alpine-3.14-helix-arm64v8$(FloatingTagSuffix)": {}
               },
               "variant": "v8"
             }
@@ -142,7 +142,7 @@
               "osVersion": "alpine3.14",
               "tags": {
                 "alpine-3.14-WithNode-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "alpine-3.14-WithNode-$(FloatingTagSuffix)": {}
+                "alpine-3.14-WithNode$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -155,7 +155,7 @@
               "osVersion": "alpine3.15",
               "tags": {
                 "alpine-3.15-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "alpine-3.15-$(FloatingTagSuffix)": {},
+                "alpine-3.15$(FloatingTagSuffix)": {},
                 "alpine-3.15": {
                   "isLocal": true
                 }
@@ -171,7 +171,7 @@
               "osVersion": "alpine3.15",
               "tags": {
                 "alpine-3.15-helix-amd64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "alpine-3.15-helix-amd64-$(FloatingTagSuffix)": {}
+                "alpine-3.15-helix-amd64$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -185,7 +185,7 @@
               "osVersion": "alpine3.15",
               "tags": {
                 "alpine-3.15-helix-arm32v7-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "alpine-3.15-helix-arm32v7-$(FloatingTagSuffix)": {}
+                "alpine-3.15-helix-arm32v7$(FloatingTagSuffix)": {}
               },
               "variant": "v7"
             }
@@ -200,7 +200,7 @@
               "osVersion": "alpine3.15",
               "tags": {
                 "alpine-3.15-helix-arm64v8-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "alpine-3.15-helix-arm64v8-$(FloatingTagSuffix)": {}
+                "alpine-3.15-helix-arm64v8$(FloatingTagSuffix)": {}
               },
               "variant": "v8"
             }
@@ -214,7 +214,7 @@
               "osVersion": "alpine3.15",
               "tags": {
                 "alpine-3.15-WithNode-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "alpine-3.15-WithNode-$(FloatingTagSuffix)": {}
+                "alpine-3.15-WithNode$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -227,7 +227,7 @@
               "osVersion": "alpine3.16",
               "tags": {
                 "alpine-3.16-helix-amd64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "alpine-3.16-helix-amd64-$(FloatingTagSuffix)": {}
+                "alpine-3.16-helix-amd64$(FloatingTagSuffix)": {}
               }
             }
           ]

--- a/src/cbl-mariner/manifest.json
+++ b/src/cbl-mariner/manifest.json
@@ -11,7 +11,7 @@
               "osVersion": "cbl-mariner1.0",
               "tags": {
                 "cbl-mariner-1.0-helix-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "cbl-mariner-1.0-helix-$(FloatingTagSuffix)": {}
+                "cbl-mariner-1.0-helix$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -24,7 +24,7 @@
               "osVersion": "cbl-mariner2.0",
               "tags": {
                 "cbl-mariner-2.0-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "cbl-mariner-2.0-$(FloatingTagSuffix)": {}
+                "cbl-mariner-2.0$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -37,7 +37,7 @@
               "osVersion": "cbl-mariner2.0",
               "tags": {
                 "cbl-mariner-2.0-fpm-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "cbl-mariner-2.0-fpm-$(FloatingTagSuffix)": {}
+                "cbl-mariner-2.0-fpm$(FloatingTagSuffix)": {}
               }
             }
           ]

--- a/src/centos/manifest.json
+++ b/src/centos/manifest.json
@@ -11,7 +11,7 @@
               "osVersion": "centos7",
               "tags": {
                 "centos-7-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "centos-7-$(FloatingTagSuffix)": {},
+                "centos-7$(FloatingTagSuffix)": {},
                 "centos-7": {
                   "isLocal": true
                 }
@@ -27,7 +27,7 @@
               "osVersion": "centos7",
               "tags": {
                 "centos-7-mlnet-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "centos-7-mlnet-$(FloatingTagSuffix)": {},
+                "centos-7-mlnet$(FloatingTagSuffix)": {},
                 "centos-7-mlnet": {
                   "isLocal": true
                 }
@@ -43,7 +43,7 @@
               "osVersion": "centos7",
               "tags": {
                 "centos-7-mlnet-helix-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "centos-7-mlnet-helix-$(FloatingTagSuffix)": {}
+                "centos-7-mlnet-helix$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -56,7 +56,7 @@
               "osVersion": "centos7",
               "tags": {
                 "centos-7-rpmpkg-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "centos-7-rpmpkg-$(FloatingTagSuffix)": {}
+                "centos-7-rpmpkg$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -69,7 +69,7 @@
               "osVersion": "centos7",
               "tags": {
                 "centos-7-source-build-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "centos-7-source-build-$(FloatingTagSuffix)": {}
+                "centos-7-source-build$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -82,7 +82,7 @@
               "osVersion": "centos-stream8",
               "tags": {
                 "centos-stream8-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "centos-stream8-$(FloatingTagSuffix)": {}
+                "centos-stream8$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -95,7 +95,7 @@
               "osVersion": "centos-stream9",
               "tags": {
                 "centos-stream9-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "centos-stream9-$(FloatingTagSuffix)": {}
+                "centos-stream9$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -108,7 +108,7 @@
               "osVersion": "centos-stream9",
               "tags": {
                 "centos-stream9-helix-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "centos-stream9-helix-$(FloatingTagSuffix)": {}
+                "centos-stream9-helix$(FloatingTagSuffix)": {}
               }
             }
           ]

--- a/src/debian/manifest.json
+++ b/src/debian/manifest.json
@@ -11,7 +11,7 @@
               "osVersion": "stretch",
               "tags": {
                 "debian-stretch-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "debian-stretch-$(FloatingTagSuffix)": {},
+                "debian-stretch$(FloatingTagSuffix)": {},
                 "debian-stretch": {
                   "isLocal": true
                 }
@@ -28,7 +28,7 @@
               "osVersion": "stretch",
               "tags": {
                 "debian-9-arm32v7-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "debian-9-arm32v7-$(FloatingTagSuffix)": {}
+                "debian-9-arm32v7$(FloatingTagSuffix)": {}
               },
               "variant": "v7"
             }
@@ -43,7 +43,7 @@
               "osVersion": "stretch",
               "tags": {
                 "debian-9-arm64v8-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "debian-9-arm64v8-$(FloatingTagSuffix)": {}
+                "debian-9-arm64v8$(FloatingTagSuffix)": {}
               },
               "variant": "v8"
             }
@@ -58,7 +58,7 @@
               "osVersion": "stretch",
               "tags": {
                 "debian-9-helix-arm32v7-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "debian-9-helix-arm32v7-$(FloatingTagSuffix)": {}
+                "debian-9-helix-arm32v7$(FloatingTagSuffix)": {}
               },
               "variant": "v7"
             }
@@ -73,7 +73,7 @@
               "osVersion": "stretch",
               "tags": {
                 "debian-9-helix-arm64v8-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "debian-9-helix-arm64v8-$(FloatingTagSuffix)": {}
+                "debian-9-helix-arm64v8$(FloatingTagSuffix)": {}
               },
               "variant": "v8"
             }
@@ -90,7 +90,7 @@
               "osVersion": "buster",
               "tags": {
                 "debian-buster-slim-docker-testrunner-amd64-$(UniqueId)": {},
-                "debian-buster-slim-docker-testrunner-amd64-$(FloatingTagSuffix)": {}
+                "debian-buster-slim-docker-testrunner-amd64$(FloatingTagSuffix)": {}
               }
             },
             {
@@ -100,7 +100,7 @@
               "osVersion": "buster",
               "tags": {
                 "debian-buster-slim-docker-testrunner-arm64v8-$(UniqueId)": {},
-                "debian-buster-slim-docker-testrunner-arm64v8-$(FloatingTagSuffix)": {}
+                "debian-buster-slim-docker-testrunner-arm64v8$(FloatingTagSuffix)": {}
               },
               "variant": "v8"
             }
@@ -115,7 +115,7 @@
               "osVersion": "buster",
               "tags": {
                 "debian-10-helix-amd64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "debian-10-helix-amd64-$(FloatingTagSuffix)": {}
+                "debian-10-helix-amd64$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -129,7 +129,7 @@
               "osVersion": "buster",
               "tags": {
                 "debian-10-helix-arm32v7-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "debian-10-helix-arm32v7-$(FloatingTagSuffix)": {}
+                "debian-10-helix-arm32v7$(FloatingTagSuffix)": {}
               },
               "variant": "v7"
             }
@@ -144,7 +144,7 @@
               "osVersion": "buster",
               "tags": {
                 "debian-10-helix-arm64v8-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "debian-10-helix-arm64v8-$(FloatingTagSuffix)": {}
+                "debian-10-helix-arm64v8$(FloatingTagSuffix)": {}
               },
               "variant": "v8"
             }
@@ -159,7 +159,7 @@
               "osVersion": "bullseye",
               "tags": {
                 "debian-11-amd64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "debian-11-amd64-$(FloatingTagSuffix)": {}
+                "debian-11-amd64$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -173,7 +173,7 @@
               "osVersion": "bullseye",
               "tags": {
                 "debian-11-gcc12-amd64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "debian-11-gcc12-amd64-$(FloatingTagSuffix)": {}
+                "debian-11-gcc12-amd64$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -187,7 +187,7 @@
               "osVersion": "bullseye",
               "tags": {
                 "debian-11-helix-amd64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "debian-11-helix-amd64-$(FloatingTagSuffix)": {}
+                "debian-11-helix-amd64$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -201,7 +201,7 @@
               "osVersion": "bullseye",
               "tags": {
                 "debian-11-helix-arm32v7-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "debian-11-helix-arm32v7-$(FloatingTagSuffix)": {}
+                "debian-11-helix-arm32v7$(FloatingTagSuffix)": {}
               },
               "variant": "v7"
             }
@@ -216,7 +216,7 @@
               "osVersion": "bullseye",
               "tags": {
                 "debian-11-helix-arm64v8-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "debian-11-helix-arm64v8-$(FloatingTagSuffix)": {}
+                "debian-11-helix-arm64v8$(FloatingTagSuffix)": {}
               },
               "variant": "v8"
             }
@@ -231,7 +231,7 @@
               "osVersion": "bullseye",
               "tags": {
                 "debian-11-opt-arm64v8-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "debian-11-opt-arm64v8-$(FloatingTagSuffix)": {}
+                "debian-11-opt-arm64v8$(FloatingTagSuffix)": {}
               },
               "variant": "v8"
             }
@@ -246,7 +246,7 @@
               "osVersion": "debian",
               "tags": {
                 "debian-iot-arm32v7-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "debian-iot-arm32v7-$(FloatingTagSuffix)": {}
+                "debian-iot-arm32v7$(FloatingTagSuffix)": {}
               },
               "variant": "v7"
             }
@@ -261,7 +261,7 @@
               "osVersion": "bullseye",
               "tags": {
                 "debian-11-arm64v8-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "debian-11-arm64v8-$(FloatingTagSuffix)": {}
+                "debian-11-arm64v8$(FloatingTagSuffix)": {}
               },
               "variant": "v8"
             }

--- a/src/fedora/manifest.json
+++ b/src/fedora/manifest.json
@@ -10,7 +10,7 @@
             "osVersion": "fedora34",
             "tags": {
               "fedora-34-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-              "fedora-34-$(FloatingTagSuffix)": {},
+              "fedora-34$(FloatingTagSuffix)": {},
               "fedora-34": {
                 "isLocal": true
               }
@@ -25,7 +25,7 @@
               "osVersion": "fedora34",
               "tags": {
                 "fedora-34-helix-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "fedora-34-helix-$(FloatingTagSuffix)": {}
+                "fedora-34-helix$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -37,7 +37,7 @@
             "osVersion": "fedora36",
             "tags": {
               "fedora-36-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-              "fedora-36-$(FloatingTagSuffix)": {},
+              "fedora-36$(FloatingTagSuffix)": {},
               "fedora-36": {
                 "isLocal": true
               }
@@ -52,7 +52,7 @@
               "osVersion": "fedora36",
               "tags": {
                 "fedora-36-helix-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "fedora-36-helix-$(FloatingTagSuffix)": {}
+                "fedora-36-helix$(FloatingTagSuffix)": {}
               }
             }
           ]

--- a/src/nanoserver/manifest.json
+++ b/src/nanoserver/manifest.json
@@ -11,7 +11,7 @@
               "osVersion": "nanoserver-1809",
               "tags": {
                 "nanoserver-1809-helix-amd64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "nanoserver-1809-helix-amd64-$(FloatingTagSuffix)": {}
+                "nanoserver-1809-helix-amd64$(FloatingTagSuffix)": {}
               }
             }
           ]

--- a/src/opensuse/manifest.json
+++ b/src/opensuse/manifest.json
@@ -12,7 +12,7 @@
               "osVersion": "leap15.2",
               "tags": {
                 "opensuse-15.2-helix-amd64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "opensuse-15.2-helix-amd64-$(FloatingTagSuffix)": {}
+                "opensuse-15.2-helix-amd64$(FloatingTagSuffix)": {}
               }
             }
           ]

--- a/src/raspbian/manifest.json
+++ b/src/raspbian/manifest.json
@@ -12,7 +12,7 @@
               "osVersion": "buster",
               "tags": {
                 "raspbian-10-crossdeps-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "raspbian-10-crossdeps-$(FloatingTagSuffix)": {},
+                "raspbian-10-crossdeps$(FloatingTagSuffix)": {},
                 "raspbian-10-crossdeps": {
                   "isLocal": true
                 }
@@ -31,7 +31,7 @@
               "osVersion": "buster",
               "tags": {
                 "raspbian-10-helix-arm32v6-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "raspbian-10-helix-arm32v6-$(FloatingTagSuffix)": {}
+                "raspbian-10-helix-arm32v6$(FloatingTagSuffix)": {}
               },
               "variant": "v6"
             }

--- a/src/ubuntu/manifest.json
+++ b/src/ubuntu/manifest.json
@@ -11,7 +11,7 @@
               "osVersion": "bionic",
               "tags": {
                 "ubuntu-18.04-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-18.04-$(FloatingTagSuffix)": {},
+                "ubuntu-18.04$(FloatingTagSuffix)": {},
                 "ubuntu-18.04": {
                   "isLocal": true
                 }
@@ -28,7 +28,7 @@
               "osVersion": "bionic",
               "tags": {
                 "ubuntu-18.04-arm32v7-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-18.04-arm32v7-$(FloatingTagSuffix)": {}
+                "ubuntu-18.04-arm32v7$(FloatingTagSuffix)": {}
               },
               "variant": "v7"
             }
@@ -43,7 +43,7 @@
               "osVersion": "bionic",
               "tags": {
                 "ubuntu-18.04-arm64v8-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-18.04-arm64v8-$(FloatingTagSuffix)": {}
+                "ubuntu-18.04-arm64v8$(FloatingTagSuffix)": {}
               },
               "variant": "v8"
             }
@@ -57,7 +57,7 @@
               "osVersion": "bionic",
               "tags": {
                 "ubuntu-18.04-coredeps-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-18.04-coredeps-$(FloatingTagSuffix)": {},
+                "ubuntu-18.04-coredeps$(FloatingTagSuffix)": {},
                 "ubuntu-18.04-coredeps": {
                   "isLocal": true
                 }
@@ -73,7 +73,7 @@
               "osVersion": "bionic",
               "tags": {
                 "ubuntu-18.04-android-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-18.04-android-$(FloatingTagSuffix)": {}
+                "ubuntu-18.04-android$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -86,7 +86,7 @@
               "osVersion": "bionic",
               "tags": {
                 "ubuntu-18.04-crossdeps-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-18.04-crossdeps-$(FloatingTagSuffix)": {},
+                "ubuntu-18.04-crossdeps$(FloatingTagSuffix)": {},
                 "ubuntu-18.04-crossdeps": {
                   "isLocal": true
                 }
@@ -102,7 +102,7 @@
               "osVersion": "bionic",
               "tags": {
                 "ubuntu-18.04-cross-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-18.04-cross-$(FloatingTagSuffix)": {}
+                "ubuntu-18.04-cross$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -115,7 +115,7 @@
               "osVersion": "bionic",
               "tags": {
                 "ubuntu-18.04-cross-arm-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-18.04-cross-arm-$(FloatingTagSuffix)": {}
+                "ubuntu-18.04-cross-arm$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -128,7 +128,7 @@
               "osVersion": "bionic",
               "tags": {
                 "ubuntu-18.04-cross-arm-alpine-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-18.04-cross-arm-alpine-$(FloatingTagSuffix)": {}
+                "ubuntu-18.04-cross-arm-alpine$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -141,7 +141,7 @@
               "osVersion": "bionic",
               "tags": {
                 "ubuntu-18.04-cross-arm64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-18.04-cross-arm64-$(FloatingTagSuffix)": {}
+                "ubuntu-18.04-cross-arm64$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -154,7 +154,7 @@
               "osVersion": "bionic",
               "tags": {
                 "ubuntu-18.04-cross-arm64-alpine-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-18.04-cross-arm64-alpine-$(FloatingTagSuffix)": {}
+                "ubuntu-18.04-cross-arm64-alpine$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -167,7 +167,7 @@
               "osVersion": "bionic",
               "tags": {
                 "ubuntu-18.04-cross-armel-tizen-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-18.04-cross-armel-tizen-$(FloatingTagSuffix)": {}
+                "ubuntu-18.04-cross-armel-tizen$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -180,7 +180,7 @@
               "osVersion": "bionic",
               "tags": {
                 "ubuntu-18.04-cross-freebsd-12-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-18.04-cross-freebsd-12-$(FloatingTagSuffix)": {}
+                "ubuntu-18.04-cross-freebsd-12$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -193,7 +193,7 @@
               "osVersion": "bionic",
               "tags": {
                 "ubuntu-18.04-cross-arm64-freebsd-13-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-18.04-cross-arm64-freebsd-13-$(FloatingTagSuffix)": {}
+                "ubuntu-18.04-cross-arm64-freebsd-13$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -206,7 +206,7 @@
               "osVersion": "bionic",
               "tags": {
                 "ubuntu-18.04-cross-illumos-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-18.04-cross-illumos-$(FloatingTagSuffix)": {}
+                "ubuntu-18.04-cross-illumos$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -219,7 +219,7 @@
               "osVersion": "bionic",
               "tags": {
                 "ubuntu-18.04-cross-ppc64le-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-18.04-cross-ppc64le-$(FloatingTagSuffix)": {}
+                "ubuntu-18.04-cross-ppc64le$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -232,7 +232,7 @@
               "osVersion": "bionic",
               "tags": {
                 "ubuntu-18.04-cross-s390x-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-18.04-cross-s390x-$(FloatingTagSuffix)": {}
+                "ubuntu-18.04-cross-s390x$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -245,7 +245,7 @@
               "osVersion": "bionic",
               "tags": {
                 "ubuntu-18.04-cross-x86-linux-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-18.04-cross-x86-linux-$(FloatingTagSuffix)": {}
+                "ubuntu-18.04-cross-x86-linux$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -258,7 +258,7 @@
               "osVersion": "bionic",
               "tags": {
                 "ubuntu-18.04-debpkg-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-18.04-debpkg-$(FloatingTagSuffix)": {}
+                "ubuntu-18.04-debpkg$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -272,7 +272,7 @@
               "osVersion": "bionic",
               "tags": {
                 "ubuntu-18.04-helix-amd64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-18.04-helix-amd64-$(FloatingTagSuffix)": {},
+                "ubuntu-18.04-helix-amd64$(FloatingTagSuffix)": {},
                 "ubuntu-18.04-helix-amd64": {
                   "isLocal": true
                 }
@@ -289,7 +289,7 @@
               "osVersion": "bionic",
               "tags": {
                 "ubuntu-18.04-helix-arm32v7-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-18.04-helix-arm32v7-$(FloatingTagSuffix)": {}
+                "ubuntu-18.04-helix-arm32v7$(FloatingTagSuffix)": {}
               },
               "variant": "v7"
             }
@@ -304,7 +304,7 @@
               "osVersion": "bionic",
               "tags": {
                 "ubuntu-18.04-helix-arm64v8-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-18.04-helix-arm64v8-$(FloatingTagSuffix)": {}
+                "ubuntu-18.04-helix-arm64v8$(FloatingTagSuffix)": {}
               },
               "variant": "v8"
             }
@@ -319,7 +319,7 @@
               "osVersion": "bionic",
               "tags": {
                 "ubuntu-18.04-helix-webassembly-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-18.04-helix-webassembly-$(FloatingTagSuffix)": {}
+                "ubuntu-18.04-helix-webassembly$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -333,7 +333,7 @@
               "osVersion": "bionic",
               "tags": {
                 "ubuntu-18.04-helix-sqlserver-amd64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-18.04-helix-sqlserver-amd64-$(FloatingTagSuffix)": {}
+                "ubuntu-18.04-helix-sqlserver-amd64$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -346,7 +346,7 @@
               "osVersion": "bionic",
               "tags": {
                 "ubuntu-18.04-mlnet-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-18.04-mlnet-$(FloatingTagSuffix)": {},
+                "ubuntu-18.04-mlnet$(FloatingTagSuffix)": {},
                 "ubuntu-18.04-mlnet": {
                   "isLocal": true
                 }
@@ -362,7 +362,7 @@
               "osVersion": "bionic",
               "tags": {
                 "ubuntu-18.04-mlnet-cross-arm-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-18.04-mlnet-cross-arm-$(FloatingTagSuffix)": {}
+                "ubuntu-18.04-mlnet-cross-arm$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -375,7 +375,7 @@
               "osVersion": "bionic",
               "tags": {
                 "ubuntu-18.04-mlnet-cross-arm64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-18.04-mlnet-cross-arm64-$(FloatingTagSuffix)": {}
+                "ubuntu-18.04-mlnet-cross-arm64$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -388,7 +388,7 @@
               "osVersion": "bionic",
               "tags": {
                 "ubuntu-18.04-mlnet-helix-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-18.04-mlnet-helix-$(FloatingTagSuffix)": {}
+                "ubuntu-18.04-mlnet-helix$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -402,7 +402,7 @@
               "osVersion": "bionic",
               "tags": {
                 "ubuntu-18.04-mono-amd64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-18.04-mono-amd64-$(FloatingTagSuffix)": {}
+                "ubuntu-18.04-mono-amd64$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -416,7 +416,7 @@
               "osVersion": "bionic",
               "tags": {
                 "ubuntu-18.04-mono-arm32v7-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-18.04-mono-arm32v7-$(FloatingTagSuffix)": {}
+                "ubuntu-18.04-mono-arm32v7$(FloatingTagSuffix)": {}
               },
               "variant": "v7"
             }
@@ -431,7 +431,7 @@
               "osVersion": "bionic",
               "tags": {
                 "ubuntu-18.04-mono-arm64v8-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-18.04-mono-arm64v8-$(FloatingTagSuffix)": {}
+                "ubuntu-18.04-mono-arm64v8$(FloatingTagSuffix)": {}
               },
               "variant": "v8"
             }
@@ -445,7 +445,7 @@
               "osVersion": "bionic",
               "tags": {
                 "ubuntu-18.04-webassembly-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-18.04-webassembly-$(FloatingTagSuffix)": {}
+                "ubuntu-18.04-webassembly$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -458,7 +458,7 @@
               "osVersion": "focal",
               "tags": {
                 "ubuntu-20.04-coredeps-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-20.04-coredeps-$(FloatingTagSuffix)": {},
+                "ubuntu-20.04-coredeps$(FloatingTagSuffix)": {},
                 "ubuntu-20.04-coredeps": {
                   "isLocal": true
                 }
@@ -474,7 +474,7 @@
               "osVersion": "focal",
               "tags": {
                 "ubuntu-20.04-crossdeps-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-20.04-crossdeps-$(FloatingTagSuffix)": {},
+                "ubuntu-20.04-crossdeps$(FloatingTagSuffix)": {},
                 "ubuntu-20.04-crossdeps": {
                   "isLocal": true
                 }
@@ -490,7 +490,7 @@
               "osVersion": "focal",
               "tags": {
                 "ubuntu-20.04-cross-armv6-raspbian-10-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-20.04-cross-armv6-raspbian-10-$(FloatingTagSuffix)": {}
+                "ubuntu-20.04-cross-armv6-raspbian-10$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -504,7 +504,7 @@
               "osVersion": "focal",
               "tags": {
                 "ubuntu-20.04-crossdac-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-20.04-crossdac-$(FloatingTagSuffix)": {}
+                "ubuntu-20.04-crossdac$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -518,7 +518,7 @@
               "osVersion": "focal",
               "tags": {
                 "ubuntu-20.04-helix-amd64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-20.04-helix-amd64-$(FloatingTagSuffix)": {},
+                "ubuntu-20.04-helix-amd64$(FloatingTagSuffix)": {},
                 "ubuntu-20.04-helix-amd64": {
                   "isLocal": true
                 }
@@ -535,7 +535,7 @@
               "osVersion": "focal",
               "tags": {
                 "ubuntu-20.04-helix-wasm-amd64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-20.04-helix-wasm-amd64-$(FloatingTagSuffix)": {}
+                "ubuntu-20.04-helix-wasm-amd64$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -548,7 +548,7 @@
               "osVersion": "focal",
               "tags": {
                 "ubuntu-20.04-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-20.04-$(FloatingTagSuffix)": {},
+                "ubuntu-20.04$(FloatingTagSuffix)": {},
                 "ubuntu-20.04": {
                   "isLocal": true
                 }
@@ -564,7 +564,7 @@
               "osVersion": "jammy",
               "tags": {
                 "ubuntu-22.04-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-22.04-$(FloatingTagSuffix)": {},
+                "ubuntu-22.04$(FloatingTagSuffix)": {},
                 "ubuntu-22.04": {
                   "isLocal": true
                 }
@@ -580,7 +580,7 @@
               "osVersion": "jammy",
               "tags": {
                 "ubuntu-22.04-coredeps-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-22.04-coredeps-$(FloatingTagSuffix)": {},
+                "ubuntu-22.04-coredeps$(FloatingTagSuffix)": {},
                 "ubuntu-22.04-coredeps": {
                   "isLocal": true
                 }
@@ -596,7 +596,7 @@
               "osVersion": "jammy",
               "tags": {
                 "ubuntu-22.04-crossdeps-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-22.04-crossdeps-$(FloatingTagSuffix)": {},
+                "ubuntu-22.04-crossdeps$(FloatingTagSuffix)": {},
                 "ubuntu-22.04-crossdeps": {
                   "isLocal": true
                 }
@@ -612,7 +612,7 @@
               "osVersion": "jammy",
               "tags": {
                 "ubuntu-22.04-cross-arm-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-22.04-cross-arm-$(FloatingTagSuffix)": {}
+                "ubuntu-22.04-cross-arm$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -625,7 +625,7 @@
               "osVersion": "jammy",
               "tags": {
                 "ubuntu-22.04-cross-arm-alpine-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-22.04-cross-arm-alpine-$(FloatingTagSuffix)": {}
+                "ubuntu-22.04-cross-arm-alpine$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -638,7 +638,7 @@
               "osVersion": "jammy",
               "tags": {
                 "ubuntu-22.04-cross-arm64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-22.04-cross-arm64-$(FloatingTagSuffix)": {}
+                "ubuntu-22.04-cross-arm64$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -651,7 +651,7 @@
               "osVersion": "jammy",
               "tags": {
                 "ubuntu-22.04-cross-arm64-alpine-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-22.04-cross-arm64-alpine-$(FloatingTagSuffix)": {}
+                "ubuntu-22.04-cross-arm64-alpine$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -664,7 +664,7 @@
               "osVersion": "jammy",
               "tags": {
                 "ubuntu-22.04-cross-riscv64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-22.04-cross-riscv64-$(FloatingTagSuffix)": {}
+                "ubuntu-22.04-cross-riscv64$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -677,7 +677,7 @@
               "osVersion": "jammy",
               "tags": {
                 "ubuntu-22.04-cross-haiku-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-22.04-cross-haiku-$(FloatingTagSuffix)": {}
+                "ubuntu-22.04-cross-haiku$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -691,7 +691,7 @@
               "osVersion": "jammy",
               "tags": {
                 "ubuntu-22.04-helix-amd64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-22.04-helix-amd64-$(FloatingTagSuffix)": {}
+                "ubuntu-22.04-helix-amd64$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -705,7 +705,7 @@
               "osVersion": "jammy",
               "tags": {
                 "ubuntu-22.04-helix-arm64v8-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-22.04-helix-arm64v8-$(FloatingTagSuffix)": {}
+                "ubuntu-22.04-helix-arm64v8$(FloatingTagSuffix)": {}
               },
               "variant": "v8"
             }
@@ -719,7 +719,7 @@
               "osVersion": "jammy",
               "tags": {
                 "ubuntu-22.04-debpkg-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-22.04-debpkg-$(FloatingTagSuffix)": {}
+                "ubuntu-22.04-debpkg$(FloatingTagSuffix)": {}
               }
             }
           ]
@@ -732,7 +732,7 @@
               "osVersion": "jammy",
               "tags": {
                 "ubuntu-22.04-mlnet-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-22.04-mlnet-$(FloatingTagSuffix)": {},
+                "ubuntu-22.04-mlnet$(FloatingTagSuffix)": {},
                 "ubuntu-22.04-mlnet": {
                   "isLocal": true
                 }
@@ -748,7 +748,7 @@
               "osVersion": "jammy",
               "tags": {
                 "ubuntu-22.04-mlnet-helix-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-22.04-mlnet-helix-$(FloatingTagSuffix)": {}
+                "ubuntu-22.04-mlnet-helix$(FloatingTagSuffix)": {}
               }
             }
           ]

--- a/src/windowsservercore/manifest.json
+++ b/src/windowsservercore/manifest.json
@@ -11,7 +11,7 @@
               "osVersion": "windowsservercore-ltsc2019",
               "tags": {
                 "windowsservercore-ltsc2019-helix-amd64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "windowsservercore-ltsc2019-helix-amd64-$(FloatingTagSuffix)": {},
+                "windowsservercore-ltsc2019-helix-amd64$(FloatingTagSuffix)": {},
                 "windowsservercore-ltsc2019-helix-amd64": {
                   "isLocal": true
                 }
@@ -23,7 +23,7 @@
               "osVersion": "windowsservercore-ltsc2019",
               "tags": {
                 "windowsservercore-ltsc2019-webassembly-amd64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "windowsservercore-ltsc2019-webassembly-amd64-$(FloatingTagSuffix)": {}
+                "windowsservercore-ltsc2019-webassembly-amd64$(FloatingTagSuffix)": {}
               }
             },
             {
@@ -32,7 +32,7 @@
               "osVersion": "windowsservercore-ltsc2022",
               "tags": {
                 "windowsservercore-ltsc2022-helix-amd64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "windowsservercore-ltsc2022-helix-amd64-$(FloatingTagSuffix)": {},
+                "windowsservercore-ltsc2022-helix-amd64$(FloatingTagSuffix)": {},
                 "windowsservercore-ltsc2022-helix-amd64": {
                   "isLocal": true
                 }
@@ -44,7 +44,7 @@
               "osVersion": "windowsservercore-ltsc2022",
               "tags": {
                 "windowsservercore-ltsc2022-helix-webassembly-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "windowsservercore-ltsc2022-helix-webassembly-$(FloatingTagSuffix)": {}
+                "windowsservercore-ltsc2022-helix-webassembly$(FloatingTagSuffix)": {}
               }
             }
           ]


### PR DESCRIPTION
Updates the floating tag pattern to only use a suffix for staging tags. So this removes the use of a `-latest` suffix for the production tags.

For example, this means `mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.13-helix-arm64v8-latest` would now be `mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.13-helix-arm64v8`. But `mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.13-helix-arm64v8-staging` remains unchanged.