### PR TITLE
Change all of the tags that are "isLocal" to use the -local suffix

### DIFF
--- a/src/alpine/3.13/WithNode/amd64/Dockerfile
+++ b/src/alpine/3.13/WithNode/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.13
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.13-local
 
 RUN apk update && \
     apk add --no-cache \

--- a/src/alpine/3.13/helix/amd64/Dockerfile
+++ b/src/alpine/3.13/helix/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.13
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.13-local
 RUN apk update && apk add --no-cache \
     cargo \
     iputils \

--- a/src/alpine/3.14/WithNode/amd64/Dockerfile
+++ b/src/alpine/3.14/WithNode/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.14
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.14-local
 
 RUN apk update && \
     apk add --no-cache \

--- a/src/alpine/3.14/helix/amd64/Dockerfile
+++ b/src/alpine/3.14/helix/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.14
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.14-local
 RUN apk update && apk add --no-cache \
     cargo \
     iputils \

--- a/src/alpine/3.15/WithNode/amd64/Dockerfile
+++ b/src/alpine/3.15/WithNode/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.15
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.15-local
 
 RUN apk update && \
     apk add --no-cache \

--- a/src/alpine/3.15/helix/amd64/Dockerfile
+++ b/src/alpine/3.15/helix/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.15
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.15-local
 RUN apk update && apk add --no-cache \
     cargo \
     iputils \

--- a/src/alpine/manifest.json
+++ b/src/alpine/manifest.json
@@ -12,7 +12,7 @@
               "tags": {
                 "alpine-3.13-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
                 "alpine-3.13$(FloatingTagSuffix)": {},
-                "alpine-3.13": {
+                "alpine-3.13-local": {
                   "isLocal": true
                 }
               }
@@ -84,7 +84,7 @@
               "tags": {
                 "alpine-3.14-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
                 "alpine-3.14$(FloatingTagSuffix)": {},
-                "alpine-3.14": {
+                "alpine-3.14-local": {
                   "isLocal": true
                 }
               }
@@ -156,7 +156,7 @@
               "tags": {
                 "alpine-3.15-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
                 "alpine-3.15$(FloatingTagSuffix)": {},
-                "alpine-3.15": {
+                "alpine-3.15-local": {
                   "isLocal": true
                 }
               }

--- a/src/centos/7/mlnet/Dockerfile
+++ b/src/centos/7/mlnet/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-local
 
 RUN yum install -y \
         perl-Data-Dumper

--- a/src/centos/7/mlnet/helix/Dockerfile
+++ b/src/centos/7/mlnet/helix/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-mlnet
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-mlnet-local
 
 RUN yum install -y \
         dnf

--- a/src/centos/7/rpmpkg/Dockerfile
+++ b/src/centos/7/rpmpkg/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-local
 
 # Install the rpm packaging toolchain required to build rpms
 RUN yum clean all \

--- a/src/centos/manifest.json
+++ b/src/centos/manifest.json
@@ -12,7 +12,7 @@
               "tags": {
                 "centos-7-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
                 "centos-7$(FloatingTagSuffix)": {},
-                "centos-7": {
+                "centos-7-local": {
                   "isLocal": true
                 }
               }
@@ -28,7 +28,7 @@
               "tags": {
                 "centos-7-mlnet-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
                 "centos-7-mlnet$(FloatingTagSuffix)": {},
-                "centos-7-mlnet": {
+                "centos-7-mlnet-local": {
                   "isLocal": true
                 }
               }

--- a/src/debian/manifest.json
+++ b/src/debian/manifest.json
@@ -12,7 +12,7 @@
               "tags": {
                 "debian-stretch-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
                 "debian-stretch$(FloatingTagSuffix)": {},
-                "debian-stretch": {
+                "debian-stretch-local": {
                   "isLocal": true
                 }
               }

--- a/src/fedora/34/helix/amd64/Dockerfile
+++ b/src/fedora/34/helix/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-34
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-34-local
 
 # Install Helix Dependencies
 

--- a/src/fedora/36/helix/amd64/Dockerfile
+++ b/src/fedora/36/helix/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-36
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-36-local
 
 # Install Helix Dependencies
 

--- a/src/fedora/manifest.json
+++ b/src/fedora/manifest.json
@@ -11,7 +11,7 @@
             "tags": {
               "fedora-34-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
               "fedora-34$(FloatingTagSuffix)": {},
-              "fedora-34": {
+              "fedora-34-local": {
                 "isLocal": true
               }
             }
@@ -38,7 +38,7 @@
             "tags": {
               "fedora-36-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
               "fedora-36$(FloatingTagSuffix)": {},
-              "fedora-36": {
+              "fedora-36-local": {
                 "isLocal": true
               }
             }

--- a/src/raspbian/10/helix/arm32v6/Dockerfile
+++ b/src/raspbian/10/helix/arm32v6/Dockerfile
@@ -1,5 +1,5 @@
 # dummy F R O M to establish a dependency
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:raspbian-10-crossdeps
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:raspbian-10-crossdeps-local
 
 FROM scratch
 

--- a/src/raspbian/manifest.json
+++ b/src/raspbian/manifest.json
@@ -13,7 +13,7 @@
               "tags": {
                 "raspbian-10-crossdeps-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
                 "raspbian-10-crossdeps$(FloatingTagSuffix)": {},
-                "raspbian-10-crossdeps": {
+                "raspbian-10-crossdeps-local": {
                   "isLocal": true
                 }
               },

--- a/src/ubuntu/18.04/android/Dockerfile
+++ b/src/ubuntu/18.04/android/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-coredeps
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-coredeps-local
 
 # Dependencies for Android build
 RUN apt-get update \

--- a/src/ubuntu/18.04/cross/Dockerfile
+++ b/src/ubuntu/18.04/cross/Dockerfile
@@ -1,3 +1,3 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-crossdeps
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-crossdeps-local
 
 ADD rootfs.arm.tar crossrootfs

--- a/src/ubuntu/18.04/cross/arm-alpine/Dockerfile
+++ b/src/ubuntu/18.04/cross/arm-alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-crossdeps
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-crossdeps-local
 
 # Install bison. This is required to build musl-cross-make
 RUN apt-get update \

--- a/src/ubuntu/18.04/cross/arm/Dockerfile
+++ b/src/ubuntu/18.04/cross/arm/Dockerfile
@@ -1,3 +1,3 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-crossdeps
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-crossdeps-local
 
 ADD rootfs.arm.tar crossrootfs

--- a/src/ubuntu/18.04/cross/arm64-alpine/Dockerfile
+++ b/src/ubuntu/18.04/cross/arm64-alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-crossdeps
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-crossdeps-local
 
 # Install binutils-aarch64-linux-gnu
 #

--- a/src/ubuntu/18.04/cross/arm64/Dockerfile
+++ b/src/ubuntu/18.04/cross/arm64/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-crossdeps
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-crossdeps-local
 
 # Install binutils-aarch64-linux-gnu
 RUN apt-get update \

--- a/src/ubuntu/18.04/cross/armel-tizen/Dockerfile
+++ b/src/ubuntu/18.04/cross/armel-tizen/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-crossdeps
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-crossdeps-local
 
 # Install binutils-arm-linux-gnueabi
 RUN apt-get update \

--- a/src/ubuntu/18.04/cross/freebsd-arm64/13/Dockerfile
+++ b/src/ubuntu/18.04/cross/freebsd-arm64/13/Dockerfile
@@ -1,3 +1,3 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-crossdeps
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-crossdeps-local
 
 ADD rootfs.arm64.tar crossrootfs

--- a/src/ubuntu/18.04/cross/freebsd/12/Dockerfile
+++ b/src/ubuntu/18.04/cross/freebsd/12/Dockerfile
@@ -1,3 +1,3 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-crossdeps
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-crossdeps-local
 
 ADD rootfs.x64.tar crossrootfs

--- a/src/ubuntu/18.04/cross/illumos/Dockerfile
+++ b/src/ubuntu/18.04/cross/illumos/Dockerfile
@@ -1,3 +1,3 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-crossdeps
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-crossdeps-local
 
 ADD rootfs.x64.tar crossrootfs

--- a/src/ubuntu/18.04/cross/ppc64le/Dockerfile
+++ b/src/ubuntu/18.04/cross/ppc64le/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-crossdeps
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-crossdeps-local
 
 # Install binutils-powerpc64le-linux-gnu
 RUN apt-get update \

--- a/src/ubuntu/18.04/cross/s390x/Dockerfile
+++ b/src/ubuntu/18.04/cross/s390x/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-crossdeps
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-crossdeps-local
 
 # Install binutils-s390x-linux-gnu
 RUN apt-get update \

--- a/src/ubuntu/18.04/cross/x86-linux/Dockerfile
+++ b/src/ubuntu/18.04/cross/x86-linux/Dockerfile
@@ -1,3 +1,3 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-crossdeps
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-crossdeps-local
 
 ADD rootfs.x86.tar crossrootfs

--- a/src/ubuntu/18.04/crossdeps/Dockerfile
+++ b/src/ubuntu/18.04/crossdeps/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-coredeps
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-coredeps-local
 
 # Install the base toolchain we need to build anything (clang, cmake, make and the like).
 RUN apt-get update \

--- a/src/ubuntu/18.04/debpkg/Dockerfile
+++ b/src/ubuntu/18.04/debpkg/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-local
 
 # Install the deb packaging toolchain we need to build debs
 RUN apt-get update \

--- a/src/ubuntu/18.04/helix/sqlserver/amd64/Dockerfile
+++ b/src/ubuntu/18.04/helix/sqlserver/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-amd64
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-amd64-local
 
 USER root
 

--- a/src/ubuntu/18.04/helix/webassembly/Dockerfile
+++ b/src/ubuntu/18.04/helix/webassembly/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-amd64
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-amd64-local
 
 # Need some additional packages
 

--- a/src/ubuntu/18.04/mlnet/Dockerfile
+++ b/src/ubuntu/18.04/mlnet/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-local
 
 # Install openmp support with Clang
 RUN apt-get update \

--- a/src/ubuntu/18.04/mlnet/cross/arm/Dockerfile
+++ b/src/ubuntu/18.04/mlnet/cross/arm/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-crossdeps
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-crossdeps-local
 
 ADD rootfs.arm.tar crossrootfs
 

--- a/src/ubuntu/18.04/mlnet/cross/arm64/Dockerfile
+++ b/src/ubuntu/18.04/mlnet/cross/arm64/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-crossdeps
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-crossdeps-local
 
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys DE19EB17684BA42D
 

--- a/src/ubuntu/18.04/mlnet/helix/Dockerfile
+++ b/src/ubuntu/18.04/mlnet/helix/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-mlnet
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-mlnet-local
 
 # Install Helix Dependencies
 ENV DEBIAN_FRONTEND=noninteractive

--- a/src/ubuntu/18.04/webassembly/Dockerfile
+++ b/src/ubuntu/18.04/webassembly/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-coredeps
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-coredeps-local
 
 # Dependencies for WebAssembly build
 RUN apt-get update \

--- a/src/ubuntu/20.04/cross/armv6/10/Dockerfile
+++ b/src/ubuntu/20.04/cross/armv6/10/Dockerfile
@@ -1,3 +1,3 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-crossdeps
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-crossdeps-local-local
 
 ADD rootfs.armv6.tar crossrootfs

--- a/src/ubuntu/20.04/crossdeps/Dockerfile
+++ b/src/ubuntu/20.04/crossdeps/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-coredeps
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-coredeps-local
 
 # Install the base toolchain we need to build anything (clang, cmake, make and the like).
 RUN apt-get update \

--- a/src/ubuntu/20.04/helix/wasm/amd64/Dockerfile
+++ b/src/ubuntu/20.04/helix/wasm/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-helix-amd64
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-helix-amd64-local
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/src/ubuntu/22.04/cross/arm-alpine/Dockerfile
+++ b/src/ubuntu/22.04/cross/arm-alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps-local
 
 RUN cd /tmp \
     && wget https://ftp.gnu.org/gnu/binutils/binutils-2.39.tar.gz \

--- a/src/ubuntu/22.04/cross/arm/Dockerfile
+++ b/src/ubuntu/22.04/cross/arm/Dockerfile
@@ -1,3 +1,3 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps-local
 
 ADD rootfs.arm.tar crossrootfs

--- a/src/ubuntu/22.04/cross/arm64-alpine/Dockerfile
+++ b/src/ubuntu/22.04/cross/arm64-alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps-local
 
 RUN cd /tmp \
     && wget https://ftp.gnu.org/gnu/binutils/binutils-2.39.tar.gz \

--- a/src/ubuntu/22.04/cross/arm64/Dockerfile
+++ b/src/ubuntu/22.04/cross/arm64/Dockerfile
@@ -1,3 +1,3 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps-local
 
 ADD rootfs.arm64.tar crossrootfs

--- a/src/ubuntu/22.04/cross/haiku/Dockerfile
+++ b/src/ubuntu/22.04/cross/haiku/Dockerfile
@@ -1,3 +1,3 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps-local
 
 ADD rootfs.x64.tar crossrootfs

--- a/src/ubuntu/22.04/cross/riscv64/Dockerfile
+++ b/src/ubuntu/22.04/cross/riscv64/Dockerfile
@@ -1,3 +1,3 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps-local
 
 ADD rootfs.riscv64.tar crossrootfs

--- a/src/ubuntu/22.04/crossdeps/Dockerfile
+++ b/src/ubuntu/22.04/crossdeps/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-coredeps
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-coredeps-local
 
 # Install the base toolchain we need to build anything (clang, cmake, make and the like).
 RUN apt-get update \

--- a/src/ubuntu/22.04/debpkg/Dockerfile
+++ b/src/ubuntu/22.04/debpkg/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-local
 
 # Install the deb packaging toolchain we need to build debs
 RUN apt-get update \

--- a/src/ubuntu/22.04/mlnet/Dockerfile
+++ b/src/ubuntu/22.04/mlnet/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-local
 
 # Install openmp support
 RUN apt-get update \

--- a/src/ubuntu/22.04/mlnet/helix/Dockerfile
+++ b/src/ubuntu/22.04/mlnet/helix/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-mlnet
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-mlnet-local
 
 # Install Helix Dependencies
 RUN apt-get update \

--- a/src/ubuntu/build-scripts/run-arcade-build-rootfs.sh
+++ b/src/ubuntu/build-scripts/run-arcade-build-rootfs.sh
@@ -13,7 +13,7 @@ rootfsBinDirArg=${5:-}
 bypassArchDirArg=${6:-}
 llvm=${7:-}
 
-dockerCrossDepsTag="${DOCKER_REPO:-mcr.microsoft.com/dotnet-buildtools/prereqs}:${os}-crossdeps"
+dockerCrossDepsTag="${DOCKER_REPO:-mcr.microsoft.com/dotnet-buildtools/prereqs}:${os}-crossdeps-local"
 
 # If argument three was set, use that as the arch, otherwise use default arch : 'arm'
 arch=${archArg:-'arm'}

--- a/src/ubuntu/manifest.json
+++ b/src/ubuntu/manifest.json
@@ -12,7 +12,7 @@
               "tags": {
                 "ubuntu-18.04-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
                 "ubuntu-18.04$(FloatingTagSuffix)": {},
-                "ubuntu-18.04": {
+                "ubuntu-18.04-local": {
                   "isLocal": true
                 }
               }
@@ -58,7 +58,7 @@
               "tags": {
                 "ubuntu-18.04-coredeps-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
                 "ubuntu-18.04-coredeps$(FloatingTagSuffix)": {},
-                "ubuntu-18.04-coredeps": {
+                "ubuntu-18.04-coredeps-local": {
                   "isLocal": true
                 }
               }
@@ -87,7 +87,7 @@
               "tags": {
                 "ubuntu-18.04-crossdeps-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
                 "ubuntu-18.04-crossdeps$(FloatingTagSuffix)": {},
-                "ubuntu-18.04-crossdeps": {
+                "ubuntu-18.04-crossdeps-local": {
                   "isLocal": true
                 }
               }
@@ -273,7 +273,7 @@
               "tags": {
                 "ubuntu-18.04-helix-amd64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
                 "ubuntu-18.04-helix-amd64$(FloatingTagSuffix)": {},
-                "ubuntu-18.04-helix-amd64": {
+                "ubuntu-18.04-helix-amd64-local": {
                   "isLocal": true
                 }
               }
@@ -347,7 +347,7 @@
               "tags": {
                 "ubuntu-18.04-mlnet-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
                 "ubuntu-18.04-mlnet$(FloatingTagSuffix)": {},
-                "ubuntu-18.04-mlnet": {
+                "ubuntu-18.04-mlnet-local": {
                   "isLocal": true
                 }
               }
@@ -459,7 +459,7 @@
               "tags": {
                 "ubuntu-20.04-coredeps-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
                 "ubuntu-20.04-coredeps$(FloatingTagSuffix)": {},
-                "ubuntu-20.04-coredeps": {
+                "ubuntu-20.04-coredeps-local": {
                   "isLocal": true
                 }
               }
@@ -475,7 +475,7 @@
               "tags": {
                 "ubuntu-20.04-crossdeps-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
                 "ubuntu-20.04-crossdeps$(FloatingTagSuffix)": {},
-                "ubuntu-20.04-crossdeps": {
+                "ubuntu-20.04-crossdeps-local": {
                   "isLocal": true
                 }
               }
@@ -519,7 +519,7 @@
               "tags": {
                 "ubuntu-20.04-helix-amd64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
                 "ubuntu-20.04-helix-amd64$(FloatingTagSuffix)": {},
-                "ubuntu-20.04-helix-amd64": {
+                "ubuntu-20.04-helix-amd64-local": {
                   "isLocal": true
                 }
               }
@@ -549,7 +549,7 @@
               "tags": {
                 "ubuntu-20.04-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
                 "ubuntu-20.04$(FloatingTagSuffix)": {},
-                "ubuntu-20.04": {
+                "ubuntu-20.04-local": {
                   "isLocal": true
                 }
               }
@@ -565,7 +565,7 @@
               "tags": {
                 "ubuntu-22.04-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
                 "ubuntu-22.04$(FloatingTagSuffix)": {},
-                "ubuntu-22.04": {
+                "ubuntu-22.04-local": {
                   "isLocal": true
                 }
               }
@@ -581,7 +581,7 @@
               "tags": {
                 "ubuntu-22.04-coredeps-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
                 "ubuntu-22.04-coredeps$(FloatingTagSuffix)": {},
-                "ubuntu-22.04-coredeps": {
+                "ubuntu-22.04-coredeps-local": {
                   "isLocal": true
                 }
               }
@@ -597,7 +597,7 @@
               "tags": {
                 "ubuntu-22.04-crossdeps-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
                 "ubuntu-22.04-crossdeps$(FloatingTagSuffix)": {},
-                "ubuntu-22.04-crossdeps": {
+                "ubuntu-22.04-crossdeps-local": {
                   "isLocal": true
                 }
               }
@@ -733,7 +733,7 @@
               "tags": {
                 "ubuntu-22.04-mlnet-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
                 "ubuntu-22.04-mlnet$(FloatingTagSuffix)": {},
-                "ubuntu-22.04-mlnet": {
+                "ubuntu-22.04-mlnet-local": {
                   "isLocal": true
                 }
               }

--- a/src/windowsservercore/ltsc2022/helix/webassembly/Dockerfile
+++ b/src/windowsservercore/ltsc2022/helix/webassembly/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:windowsservercore-ltsc2022-helix-amd64
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:windowsservercore-ltsc2022-helix-amd64-local
 
 # Install 7zip
 ENV ZIP7_VERSION=1900

--- a/src/windowsservercore/manifest.json
+++ b/src/windowsservercore/manifest.json
@@ -12,7 +12,7 @@
               "tags": {
                 "windowsservercore-ltsc2019-helix-amd64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
                 "windowsservercore-ltsc2019-helix-amd64$(FloatingTagSuffix)": {},
-                "windowsservercore-ltsc2019-helix-amd64": {
+                "windowsservercore-ltsc2019-helix-amd64-local": {
                   "isLocal": true
                 }
               }
@@ -33,7 +33,7 @@
               "tags": {
                 "windowsservercore-ltsc2022-helix-amd64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
                 "windowsservercore-ltsc2022-helix-amd64$(FloatingTagSuffix)": {},
-                "windowsservercore-ltsc2022-helix-amd64": {
+                "windowsservercore-ltsc2022-helix-amd64-local": {
                   "isLocal": true
                 }
               }


### PR DESCRIPTION
We wanted to be able to make images published by production to use a suffix-less tag, but that caused a conflict with the local tags for some dockerfiles, since they are already suffix-less. This change add -local to those local tags, and updates all of the dockerfiles that were using the local images.