### PR TITLE
Remove repo specifier from arm dockerfiles and registry from fedora

### DIFF
--- a/src/alpine/3.13/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.13/helix/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/alpine:3.13
+FROM alpine:3.13
 
 RUN apk update && \
     apk add --no-cache \

--- a/src/alpine/3.13/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.13/helix/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/alpine:3.13
+FROM alpine:3.13
 
 RUN apk update && \
     apk add --no-cache \

--- a/src/alpine/3.14/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.14/helix/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/alpine:3.14
+FROM alpine:3.14
 
 RUN apk update && \
     apk add --no-cache \

--- a/src/alpine/3.14/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.14/helix/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/alpine:3.14
+FROM alpine:3.14
 
 RUN apk update && \
     apk add --no-cache \

--- a/src/alpine/3.15/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.15/helix/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/alpine:3.15
+FROM alpine:3.15
 
 RUN apk update && \
     apk add --no-cache \

--- a/src/alpine/3.15/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.15/helix/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/alpine:3.15
+FROM alpine:3.15
 
 RUN apk update && \
     apk add --no-cache \

--- a/src/debian/10/docker-testrunner/arm64v8/Dockerfile
+++ b/src/debian/10/docker-testrunner/arm64v8/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile used to create a testrunner image that can perform Docker operations.
 # Usage:  docker run --rm -v /var/run/docker.sock:/var/run/docker.sock testrunner pwsh -File xyz.ps1
 
-FROM arm64v8/debian:buster-slim
+FROM debian:buster-slim
 
 # Install Docker
 RUN apt-get update \

--- a/src/debian/10/helix/arm32v7/Dockerfile
+++ b/src/debian/10/helix/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/debian:buster
+FROM debian:buster
 
 # Workaround: https://github.com/pypa/wheel/issues/367
 ENV _PYTHON_HOST_PLATFORM=linux_armv7l

--- a/src/debian/10/helix/arm64v8/Dockerfile
+++ b/src/debian/10/helix/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/debian:buster
+FROM debian:buster
 
 # Install Helix Dependencies
 

--- a/src/debian/11/arm64v8/Dockerfile
+++ b/src/debian/11/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/debian:11
+FROM debian:11
 
 # Dependencies for generic .NET Core builds and the base toolchain we need to
 # build anything (clang, cmake, make and the like)

--- a/src/debian/11/helix/arm32v7/Dockerfile
+++ b/src/debian/11/helix/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/debian:bullseye
+FROM debian:bullseye
 
 # Workaround: https://github.com/pypa/wheel/issues/367
 ENV _PYTHON_HOST_PLATFORM=linux_armv7l

--- a/src/debian/11/helix/arm64v8/Dockerfile
+++ b/src/debian/11/helix/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/debian:bullseye
+FROM debian:bullseye
 
 # Install Helix Dependencies
 

--- a/src/debian/11/opt/arm64v8/Dockerfile
+++ b/src/debian/11/opt/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/debian:bullseye
+FROM debian:bullseye
 
 # Dependencies for generic .NET Core optimization runs
 RUN apt-get update \

--- a/src/debian/9/arm32v7/Dockerfile
+++ b/src/debian/9/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/debian:9
+FROM debian:9
 
 # Dependencies for generic .NET Core builds
 RUN apt-get update \

--- a/src/debian/9/arm64v8/Dockerfile
+++ b/src/debian/9/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/debian:9
+FROM debian:9
 
 # Dependencies for generic .NET Core builds and the base toolchain we need to
 # build anything (clang, cmake, make and the like)

--- a/src/debian/9/helix/arm32v7/Dockerfile
+++ b/src/debian/9/helix/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/debian:9
+FROM debian:9
 
 # Install Helix Dependencies
 

--- a/src/debian/9/helix/arm64v8/Dockerfile
+++ b/src/debian/9/helix/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/debian:9
+FROM debian:9
 
 # Install Helix Dependencies
 

--- a/src/debian/iot/arm32v7/Dockerfile
+++ b/src/debian/iot/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/debian:latest
+FROM debian:latest
 
 # Dependencies for downloading and running the installation script of libgpiod
 RUN apt-get update \

--- a/src/fedora/34/amd64/Dockerfile
+++ b/src/fedora/34/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:34
+FROM fedora:34
 
 # Install the base toolchain we need to build anything (clang, cmake, make and the like)
 # this does not include libraries that we need to compile different projects, we'd like

--- a/src/fedora/36/amd64/Dockerfile
+++ b/src/fedora/36/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:36
+FROM fedora:36
 
 # Install the base toolchain we need to build anything (clang, cmake, make and the like)
 # this does not include libraries that we need to compile different projects, we'd like

--- a/src/raspbian/10/crossdeps/Dockerfile
+++ b/src/raspbian/10/crossdeps/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/ubuntu:18.04
+FROM ubuntu:18.04
 
 # Install the base toolchain we need to build anything (clang, cmake, make and the like).
 RUN apt-get update \

--- a/src/ubuntu/18.04/arm32v7/Dockerfile
+++ b/src/ubuntu/18.04/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/ubuntu:18.04
+FROM ubuntu:18.04
 
 # fpm install may fail without adding public_suffix explicitly. May be remove in the future.
 # https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/675

--- a/src/ubuntu/18.04/arm64v8/Dockerfile
+++ b/src/ubuntu/18.04/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/ubuntu:18.04
+FROM ubuntu:18.04
 
 # fpm install may fail without adding public_suffix explicitly. May be remove in the future.
 # https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/675

--- a/src/ubuntu/18.04/helix/arm32v7/Dockerfile
+++ b/src/ubuntu/18.04/helix/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/ubuntu:18.04
+FROM ubuntu:18.04
 
 # Install Helix Dependencies
 

--- a/src/ubuntu/18.04/helix/arm64v8/Dockerfile
+++ b/src/ubuntu/18.04/helix/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/ubuntu:18.04
+FROM ubuntu:18.04
 
 # Install Helix Dependencies
 

--- a/src/ubuntu/18.04/mono/arm32v7/Dockerfile
+++ b/src/ubuntu/18.04/mono/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/ubuntu:18.04
+FROM ubuntu:18.04
 
 # Install Mono build dependencies
 ENV DEBIAN_FRONTEND=noninteractive

--- a/src/ubuntu/18.04/mono/arm64v8/Dockerfile
+++ b/src/ubuntu/18.04/mono/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/ubuntu:18.04
+FROM ubuntu:18.04
 
 # Install Mono build dependencies
 ENV DEBIAN_FRONTEND=noninteractive

--- a/src/ubuntu/22.04/helix/arm64v8/Dockerfile
+++ b/src/ubuntu/22.04/helix/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/ubuntu:22.04
+FROM ubuntu:22.04
 
 # Install Helix Dependencies
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
This change makes the following changes:

1) For all arm32/arm64, we remove the arm32v7 or arm64v8 repo specifier. We included this originally because docker didn't have a way to specify a platform and would figure that information out by looking at the machine the build was happening on. We can now specify this information via parameters to docker and we already do, so this information is redundant.

2) Remove the fedoraproject registry from fedora docker images. These images are mirrored to docker.io, and we eventually want to actually get them from an override registry, so we are removing the fedoraproject registry to do so.