### PR TITLE
General-purpose pipeline capable of building any path in the repo

### DIFF
--- a/eng/pipelines/dotnet-buildtools-prereqs-all.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-all.yml
@@ -1,0 +1,22 @@
+trigger: none
+pr: none
+
+resources:
+  repositories:
+  - repository: InternalVersionsRepo
+    type: github
+    endpoint: dotnet
+    name: dotnet/versions
+
+variables:
+- template: variables/common.yml
+
+stages:
+- template: ../common/templates/stages/dotnet/build-test-publish-repo.yml
+  parameters:
+    internalProjectName: ${{ variables.internalProjectName }}
+    publicProjectName: ${{ variables.publicProjectName }}
+    linuxAmdBuildJobTimeout: 210
+    linuxArmBuildJobTimeout: 300
+    customBuildInitSteps:
+    - template: /eng/pipelines/steps/install-cross-build-prereqs.yml


### PR DESCRIPTION
We want the ability to add a subscription to the dotnet-buildtools-prereqs-docker repo in https://github.com/dotnet/docker-tools/blob/main/eng/check-base-image-subscriptions.json so that Dockerfiles can be automatically rebuilt if an external base image is updated. In order to do that, we need a pipeline that can be referenced, so the tooling knows which pipeline should be executed. All the internal pipelines for this repo are hardcoded to be for specific operating systems. We need a single pipeline which can be used to arbitrarily build Dockerfiles in any path within the repo.

These changes create such a general-purpose pipeline. It will allow the tooling to explicitly provide the `--path` args to be able to target the specific paths which need to be rebuilt.