### PR TITLE
update msquic to 2.1.2 on arm32

### DIFF
--- a/src/debian/10/helix/arm32v7/Dockerfile
+++ b/src/debian/10/helix/arm32v7/Dockerfile
@@ -48,9 +48,9 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
 
 # Add MsQuic
 # There is problem with posting, use direct link instead. (signed binaries)
-RUN curl -LO https://github.com/microsoft/msquic/releases/download/v2.1.1/libmsquic_2.1.1_armv7l.deb && \
-    dpkg --force-architecture -i libmsquic_2.1.1_armv7l.deb && \
-    rm libmsquic_2.1.1_armv7l.deb
+RUN curl -LO https://github.com/microsoft/msquic/releases/download/v2.1.2/libmsquic_2.1.2_armhf.deb && \
+    dpkg -i libmsquic_2.*.deb && \
+    rm libmsquic_2.*.deb
 
 # Create helixbot user and give rights to sudo without password
 # additionally, preinstall the virtualenv packages used for VSTS reporting to save time

--- a/src/debian/11/helix/arm32v7/Dockerfile
+++ b/src/debian/11/helix/arm32v7/Dockerfile
@@ -37,9 +37,9 @@ RUN apt-get update && \
 
 # Add MsQuic
 # There is problem with posting, use direct link instead. (signed binaries)
-RUN curl -LO https://github.com/microsoft/msquic/releases/download/v2.1.1/libmsquic_2.1.1_armv7l.deb && \
-    dpkg --force-architecture -i libmsquic_2.1.1_armv7l.deb && \
-    rm libmsquic_2.1.1_armv7l.deb
+RUN curl -LO https://github.com/microsoft/msquic/releases/download/v2.1.2/libmsquic_2.1.2_armhf.deb && \
+    dpkg -i libmsquic_2.*.deb && \
+    rm libmsquic_2.*.deb
 
 ENV LANG=en_US.utf8
 


### PR DESCRIPTION
this is minor release for arm32 and windows. No need to update other images. 