### PR TITLE
Add secondary helixbot user to all helix ARM images; 

### DIFF
--- a/src/alpine/3.13/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.13/helix/arm32v7/Dockerfile
@@ -55,9 +55,12 @@ ENV LANG=en-US.UTF-8
 
 # create helixbot user and give rights to sudo without password
 # Alpine does not support long options
+# (we use two users here to ensure volume mounting works with two possible UIDs of the host UID)
 RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1001 helixbot && \
+    /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot2 && \
     chmod 755 /root && \
-    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot && \
+    echo "helixbot2 ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot2
 
 USER helixbot
 

--- a/src/alpine/3.13/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.13/helix/arm64v8/Dockerfile
@@ -53,9 +53,12 @@ ENV LANG=en-US.UTF-8
 
 # create helixbot user and give rights to sudo without password
 # Alpine does not support long options
+# (we use two users here to ensure volume mounting works with two possible UIDs of the host UID)
 RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1001 helixbot && \
+    /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot2 && \
     chmod 755 /root && \
-    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot && \
+    echo "helixbot2 ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot2
 
 USER helixbot
 

--- a/src/alpine/3.14/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.14/helix/arm32v7/Dockerfile
@@ -56,9 +56,12 @@ ENV LANG=en-US.UTF-8
 
 # create helixbot user and give rights to sudo without password
 # Alpine does not support long options
+# (we use two users here to ensure volume mounting works with two possible UIDs of the host UID)
 RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1001 helixbot && \
+    /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot2 && \
     chmod 755 /root && \
-    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot && \
+    echo "helixbot2 ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot2
 
 USER helixbot
 

--- a/src/alpine/3.14/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.14/helix/arm64v8/Dockerfile
@@ -53,9 +53,12 @@ ENV LANG=en-US.UTF-8
 
 # create helixbot user and give rights to sudo without password
 # Alpine does not support long options
+# (we use two users here to ensure volume mounting works with two possible UIDs of the host UID)
 RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1001 helixbot && \
+    /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot2 && \
     chmod 755 /root && \
-    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot && \ 
+    echo "helixbot2 ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot2
 
 USER helixbot
 

--- a/src/alpine/3.15/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.15/helix/arm32v7/Dockerfile
@@ -55,10 +55,13 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
 ENV LANG=en-US.UTF-8
 
 # create helixbot user and give rights to sudo without password
+# (we use two users here to ensure volume mounting works with two possible UIDs of the host UID)
 # Alpine does not support long options
 RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1001 helixbot && \
+    /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot2 && \
     chmod 755 /root && \
-    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot && \
+    echo "helixbot2 ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot2
 
 USER helixbot
 

--- a/src/alpine/3.15/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.15/helix/arm64v8/Dockerfile
@@ -52,10 +52,13 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
 ENV LANG=en-US.UTF-8
 
 # create helixbot user and give rights to sudo without password
+# (we use two users here to ensure volume mounting works with two possible UIDs of the host UID)
 # Alpine does not support long options
 RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1001 helixbot && \
+    /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot2 && \
     chmod 755 /root && \
-    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot && \
+    echo "helixbot2 ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot2
 
 USER helixbot
 

--- a/src/debian/10/helix/arm32v7/Dockerfile
+++ b/src/debian/10/helix/arm32v7/Dockerfile
@@ -53,10 +53,13 @@ RUN curl -LO https://github.com/microsoft/msquic/releases/download/v2.1.2/libmsq
     rm libmsquic_2.*.deb
 
 # Create helixbot user and give rights to sudo without password
+# (we use two users here to ensure volume mounting works with two possible UIDs of the host UID)
 # additionally, preinstall the virtualenv packages used for VSTS reporting to save time
 RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1001 --shell /bin/bash --ingroup adm helixbot && \
+    /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm helixbot2 && \
     chmod 755 /root && \
-    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers && \
+    echo "helixbot2 ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
 
 USER helixbot
 

--- a/src/debian/10/helix/arm64v8/Dockerfile
+++ b/src/debian/10/helix/arm64v8/Dockerfile
@@ -55,10 +55,13 @@ RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
     rm -rf /var/lib/apt/lists/* microsoft.asc
 
 # Create helixbot user and give rights to sudo without password
+# (we use two users here to ensure volume mounting works with two possible UIDs of the host UID)
 # additionally, preinstall the virtualenv packages used for VSTS reporting to save time
 RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1001 --shell /bin/bash --ingroup adm helixbot && \
+    /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm helixbot2 && \
     chmod 755 /root && \
-    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers && \
+    echo "helixbot2 ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
 
 USER helixbot
 

--- a/src/debian/11/helix/arm32v7/Dockerfile
+++ b/src/debian/11/helix/arm32v7/Dockerfile
@@ -53,10 +53,13 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     pip install ./helix_scripts-*-py3-none-any.whl
 
 # Create helixbot user and give rights to sudo without password
+# (we use two users here to ensure volume mounting works with two possible UIDs of the host UID)
 # additionally, preinstall the virtualenv packages used for VSTS reporting to save time
 RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1001 --shell /bin/bash --ingroup adm helixbot && \
+    /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm helixbot2 && \
     chmod 755 /root && \
-    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers && \
+    echo "helixbot2 ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
 
 USER helixbot
 

--- a/src/debian/11/helix/arm64v8/Dockerfile
+++ b/src/debian/11/helix/arm64v8/Dockerfile
@@ -54,11 +54,14 @@ RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
     apt-get install -y libmsquic && \
     rm -rf /var/lib/apt/lists/*
 
-# Create helixbot user and give rights to sudo without password
+# Create helixbot users and give rights to sudo without password
+# (we use two users here to ensure volume mounting works with two possible UIDs of the host UID)
 # additionally, preinstall the virtualenv packages used for VSTS reporting to save time
 RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1001 --shell /bin/bash --ingroup adm helixbot && \
+    /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm helixbot2 && \
     chmod 755 /root && \
-    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers 
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers && \
+    echo "helixbot2 ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers 
 
 USER helixbot
 

--- a/src/raspbian/10/helix/arm32v6/Dockerfile
+++ b/src/raspbian/10/helix/arm32v6/Dockerfile
@@ -56,10 +56,13 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     pip install ./helix_scripts-*-py3-none-any.whl
 
 # Create helixbot user and give rights to sudo without password
+# (we use two users here to ensure volume mounting works with two possible UIDs of the host UID)
 # additionally, preinstall the virtualenv packages used for VSTS reporting to save time
 RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1001 --shell /bin/bash --ingroup adm helixbot && \
+    /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm helixbot2 && \
     chmod 755 /root && \
-    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers && \
+    echo "helixbot2 ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
 
 USER helixbot
 

--- a/src/ubuntu/18.04/helix/arm32v7/Dockerfile
+++ b/src/ubuntu/18.04/helix/arm32v7/Dockerfile
@@ -56,8 +56,10 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     pip install ./helix_scripts-*-py3-none-any.whl
 
 RUN adduser --disabled-password --gecos '' --uid 1001 --shell /bin/bash --ingroup adm helixbot && \
+    adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm helixbot2 && \
     chmod -R +x /root && \
-    echo 'helixbot ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+    echo 'helixbot ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
+    echo 'helixbot2 ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 USER helixbot
 

--- a/src/ubuntu/18.04/helix/arm64v8/Dockerfile
+++ b/src/ubuntu/18.04/helix/arm64v8/Dockerfile
@@ -56,9 +56,12 @@ RUN curl -LO https://github.com/microsoft/msquic/releases/download/v2.1.1/libmsq
     dpkg -i libmsquic_2.1.1_arm64.deb && \
     rm -f libmsquic_2.1.1_arm64.deb
 
+## (we use two users here to ensure volume mounting works with two possible UIDs of the host UID)
 RUN adduser --disabled-password --gecos '' --uid 1001 --shell /bin/bash --ingroup adm helixbot && \
+    adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm helixbot2 && \
     chmod -R +x /root && \
-    echo 'helixbot ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+    echo 'helixbot ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
+    echo 'helixbot2 ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 USER helixbot
 

--- a/src/ubuntu/22.04/helix/arm64v8/Dockerfile
+++ b/src/ubuntu/22.04/helix/arm64v8/Dockerfile
@@ -63,9 +63,12 @@ RUN cd /tmp && \
     cd /tmp && \
     rm -r pwsh msquic
 
+# (we use two users here to ensure volume mounting works with two possible UIDs of the host UID)
 RUN adduser --disabled-password --gecos '' --uid 1001 --shell /bin/bash --ingroup adm helixbot && \
+    adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm helixbot2 && \
     chmod -R +x /root && \
-    echo 'helixbot ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+    echo 'helixbot ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
+    echo 'helixbot2 ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 USER helixbot
 


### PR DESCRIPTION
Helix Linux docker scenarios assume a non-root user that has the same UID and configuration inside the docker container, so test work items can do whatever they want within the sandbox of the work item.  

With the advent of Azure ARM machines, we now have different kinds of docker-using Helix clients with two different expected UIDs for Azure versus on-premises machines.  Images with both UID 1000 and 1001 will be able to run in either environment. 

