### PR TITLE
Update libssl-dev to 1.1 on Ubuntu 18.04

### DIFF
--- a/src/ubuntu/18.04/amd64/Dockerfile
+++ b/src/ubuntu/18.04/amd64/Dockerfile
@@ -76,7 +76,7 @@ RUN apt-get update \
         libkrb5-dev \
         liblttng-ust-dev \
         libnuma-dev \
-        libssl1.0-dev \
+        libssl-dev \
         libtool \
         libunwind8 \
         libunwind8-dev \


### PR DESCRIPTION
The ubuntu 18.04 container was installing libssl-dev 1.0, which is very out of date, and was breaking msquic from moving forward. This change updates that version to an unversioned install (which is 1.1.1, the version required by msquic).