### PR TITLE
Use all pipeline for production

### DIFF
--- a/eng/pipelines/dotnet-buildtools-prereqs-all-pr.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-all-pr.yml
@@ -1,26 +1,25 @@
 trigger: none
-pr:
+pr: 
   branches:
     include:
-    - main
-  paths:
-    include:
-    - src/debian/*
+    - production
 
 resources:
   repositories:
-  - repository: PublicVersionsRepo
+  - repository: InternalVersionsRepo
     type: github
-    endpoint: public
+    endpoint: dotnet
     name: dotnet/versions
 
 variables:
 - template: variables/common.yml
-- name: imageBuilder.pathArgs
-  value: --path 'src/debian/*'
 
 stages:
 - template: ../common/templates/stages/dotnet/build-test-publish-repo.yml
   parameters:
     internalProjectName: ${{ variables.internalProjectName }}
     publicProjectName: ${{ variables.publicProjectName }}
+    linuxAmdBuildJobTimeout: 210
+    linuxArmBuildJobTimeout: 300
+    customBuildInitSteps:
+    - template: /eng/pipelines/steps/install-cross-build-prereqs.yml

--- a/eng/pipelines/dotnet-buildtools-prereqs-all.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-all.yml
@@ -1,4 +1,7 @@
-trigger: none
+trigger: 
+  branches:
+    include:
+    - production
 pr: none
 
 resources:

--- a/eng/pipelines/dotnet-buildtools-prereqs-alpine-pr.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-alpine-pr.yml
@@ -3,7 +3,6 @@ pr:
   branches:
     include:
     - main
-    - production
   paths:
     include:
     - src/alpine/*

--- a/eng/pipelines/dotnet-buildtools-prereqs-alpine.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-alpine.yml
@@ -2,7 +2,6 @@ trigger:
   branches:
     include:
     - main
-    - production
   paths:
     include:
     - src/alpine/*

--- a/eng/pipelines/dotnet-buildtools-prereqs-centos-pr.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-centos-pr.yml
@@ -3,7 +3,6 @@ pr:
   branches:
     include:
     - main
-    - production
   paths:
     include:
     - src/centos/*

--- a/eng/pipelines/dotnet-buildtools-prereqs-centos.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-centos.yml
@@ -2,7 +2,6 @@ trigger:
   branches:
     include:
     - main
-    - production
   paths:
     include:
     - src/centos/*

--- a/eng/pipelines/dotnet-buildtools-prereqs-debian.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-debian.yml
@@ -2,7 +2,6 @@ trigger:
   branches:
     include:
     - main
-    - production
   paths:
     include:
     - src/debian/*

--- a/eng/pipelines/dotnet-buildtools-prereqs-eng.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-eng.yml
@@ -3,7 +3,6 @@ pr:
   branches:
     include:
     - main
-    - production
   paths:
     exclude:
     - src/*

--- a/eng/pipelines/dotnet-buildtools-prereqs-fedora-pr.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-fedora-pr.yml
@@ -3,7 +3,6 @@ pr:
   branches:
     include:
     - main
-    - production
   paths:
     include:
     - src/fedora/*

--- a/eng/pipelines/dotnet-buildtools-prereqs-fedora.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-fedora.yml
@@ -2,7 +2,6 @@ trigger:
   branches:
     include:
     - main
-    - production
   paths:
     include:
     - src/fedora/*

--- a/eng/pipelines/dotnet-buildtools-prereqs-mariner-pr.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-mariner-pr.yml
@@ -3,7 +3,6 @@ pr:
   branches:
     include:
     - main
-    - production
   paths:
     include:
     - src/cbl-mariner/*

--- a/eng/pipelines/dotnet-buildtools-prereqs-mariner.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-mariner.yml
@@ -2,7 +2,6 @@ trigger:
   branches:
     include:
     - main
-    - production
   paths:
     include:
     - src/cbl-mariner/*

--- a/eng/pipelines/dotnet-buildtools-prereqs-nanoserver-pr.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-nanoserver-pr.yml
@@ -3,7 +3,6 @@ pr:
   branches:
     include:
     - main
-    - production
   paths:
     include:
     - src/nanoserver/*

--- a/eng/pipelines/dotnet-buildtools-prereqs-nanoserver.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-nanoserver.yml
@@ -2,7 +2,6 @@ trigger:
   branches:
     include:
     - main
-    - production
   paths:
     include:
     - src/nanoserver/*

--- a/eng/pipelines/dotnet-buildtools-prereqs-opensuse-pr.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-opensuse-pr.yml
@@ -3,7 +3,6 @@ pr:
   branches:
     include:
     - main
-    - production
   paths:
     include:
     - src/opensuse/*

--- a/eng/pipelines/dotnet-buildtools-prereqs-opensuse.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-opensuse.yml
@@ -2,7 +2,6 @@ trigger:
   branches:
     include:
     - main
-    - production
   paths:
     include:
     - src/opensuse/*

--- a/eng/pipelines/dotnet-buildtools-prereqs-raspbian-pr.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-raspbian-pr.yml
@@ -3,7 +3,6 @@ pr:
   branches:
     include:
     - main
-    - production
   paths:
     include:
     - src/raspbian/*

--- a/eng/pipelines/dotnet-buildtools-prereqs-raspbian.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-raspbian.yml
@@ -2,7 +2,6 @@ trigger:
   branches:
     include:
     - main
-    - production
   paths:
     include:
     - src/raspbian/*

--- a/eng/pipelines/dotnet-buildtools-prereqs-ubuntu-pr.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-ubuntu-pr.yml
@@ -3,7 +3,6 @@ pr:
   branches:
     include:
     - main
-    - production
   paths:
     include:
     - src/ubuntu/*

--- a/eng/pipelines/dotnet-buildtools-prereqs-ubuntu.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-ubuntu.yml
@@ -2,7 +2,6 @@ trigger:
   branches:
     include:
     - main
-    - production
   paths:
     include:
     - src/ubuntu/*

--- a/eng/pipelines/dotnet-buildtools-prereqs-windowsservercore-pr.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-windowsservercore-pr.yml
@@ -3,7 +3,6 @@ pr:
   branches:
     include:
     - main
-    - production
   paths:
     include:
     - src/windowsservercore/*

--- a/eng/pipelines/dotnet-buildtools-prereqs-windowsservercore.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-windowsservercore.yml
@@ -2,7 +2,6 @@ trigger:
   branches:
     include:
     - main
-    - production
   paths:
     include:
     - src/windowsservercore/*


### PR DESCRIPTION
For the production branch, we want to build everything, both on CI and PR. This change modifies the pipelines to run the "-all" pipeline for production instead of the split out pipelines.