### PR TITLE
Update pipeline timeouts

### DIFF
--- a/eng/pipelines/dotnet-buildtools-prereqs-all-pr.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-all-pr.yml
@@ -19,7 +19,7 @@ stages:
   parameters:
     internalProjectName: ${{ variables.internalProjectName }}
     publicProjectName: ${{ variables.publicProjectName }}
-    linuxAmdBuildJobTimeout: 210
+    linuxAmdBuildJobTimeout: 360
     linuxArmBuildJobTimeout: 300
     customBuildInitSteps:
     - template: /eng/pipelines/steps/install-cross-build-prereqs.yml

--- a/eng/pipelines/dotnet-buildtools-prereqs-all.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-all.yml
@@ -19,7 +19,7 @@ stages:
   parameters:
     internalProjectName: ${{ variables.internalProjectName }}
     publicProjectName: ${{ variables.publicProjectName }}
-    linuxAmdBuildJobTimeout: 210
+    linuxAmdBuildJobTimeout: 360
     linuxArmBuildJobTimeout: 300
     ${{ if eq(variables['System.TeamProject'], 'internal') }}:
       customCopyBaseImagesInitSteps:

--- a/eng/pipelines/dotnet-buildtools-prereqs-eng.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-eng.yml
@@ -25,7 +25,7 @@ stages:
   parameters:
     internalProjectName: ${{ variables.internalProjectName }}
     publicProjectName: ${{ variables.publicProjectName }}
-    linuxAmdBuildJobTimeout: 210
+    linuxAmdBuildJobTimeout: 360
     linuxArmBuildJobTimeout: 300
     customBuildInitSteps:
     - template: /eng/pipelines/steps/install-cross-build-prereqs.yml


### PR DESCRIPTION
The `dotnet-buildtools-prereqs-docker-all` pipeline is failing due to a timeout in an Ubuntu job. The timeout for the job is 210 minutes which differs from the timeout set in the `dotnet-buildtools-prereqs-ubuntu` pipeline, which is set to 360. Since the `dotnet-buildtools-prereqs-docker-all` pipeline is intended to handle all OS types, it should have the default set to the highest value amongst all of those OS types which, in this case, is the Ubuntu one. So I've updated the timeout to be 360 for all relevant pipelines that build the entire suite of Dockerfiles.