### PR TITLE
Use powershell 7.2.5 on Alpine 3.15 helix container

### DIFF
--- a/src/alpine/3.15/helix/amd64/Dockerfile
+++ b/src/alpine/3.15/helix/amd64/Dockerfile
@@ -19,8 +19,7 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
 RUN cd /tmp && \
     mkdir pwsh && \
     cd pwsh && \
-    powerShellVersionTag=$(curl --silent https://api.github.com/repos/PowerShell/PowerShell/releases/latest | jq -r .tag_name) && \
-    curl -L https://github.com/PowerShell/PowerShell/releases/download/$powerShellVersionTag/powershell-${powerShellVersionTag:1}-linux-alpine-x64.tar.gz | tar xfz - && \
+    curl -L https://github.com/PowerShell/PowerShell/releases/download/v7.2.5/powershell-7.2.5-linux-alpine-x64.tar.gz | tar xfz - && \
     cd .. && \
     git clone --depth 1 --single-branch --branch release/7.0 --recursive https://github.com/dotnet/msquic && \
     cd msquic/src/msquic  &&  PATH=~/.dotnet/tools:$PATH /tmp/pwsh/pwsh scripts/build.ps1 -Config Release -UseSystemOpenSSLCrypto -DisableTools -DisableTest -DisablePerf && \


### PR DESCRIPTION
We were using "whatever is most recent" but that currently has broken permissions on the executables. We shouldn't float versions of dependencies anyway, so this change downgrades to powershell 7.2.5, which matches other alpine containers.

Addresses https://github.com/dotnet/arcade/issues/11579