### PR TITLE
Pin cmake version on 18.04 cross containers to 3.24.1

### DIFF
--- a/src/ubuntu/18.04/crossdeps/Dockerfile
+++ b/src/ubuntu/18.04/crossdeps/Dockerfile
@@ -15,7 +15,8 @@ RUN apt-get update \
         binfmt-support \
         binutils-arm-linux-gnueabihf \
         build-essential \
-        cmake \
+        cmake=3.24.1-0kitware1ubuntu18.04.1 \
+        cmake-data=3.24.1-0kitware1ubuntu18.04.1 \
         cpio \
         debootstrap \
         gdb \


### PR DESCRIPTION
Runtime requires 3.24.1 on the freeBSD cross container, but the default/latest version provided by kitware was recently upgraded to 3.25.0, which broke runtime's FreeBSD legs here: https://github.com/dotnet/runtime/issues/78522.

This addresses https://github.com/dotnet/arcade/issues/11676.