### PR TITLE
Fix WSC manifest to have separate images

### DIFF
--- a/src/windowsservercore/manifest.json
+++ b/src/windowsservercore/manifest.json
@@ -16,7 +16,11 @@
                   "isLocal": true
                 }
               }
-            },
+            }
+          ]
+        },
+        {
+          "platforms": [
             {
               "dockerfile": "src/windowsservercore/ltsc2019/webassembly",
               "os": "windows",
@@ -25,7 +29,11 @@
                 "windowsservercore-ltsc2019-webassembly-amd64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
                 "windowsservercore-ltsc2019-webassembly-amd64$(FloatingTagSuffix)": {}
               }
-            },
+            }
+          ]
+        },
+        {
+          "platforms": [
             {
               "dockerfile": "src/windowsservercore/ltsc2022/helix/amd64",
               "os": "windows",
@@ -37,7 +45,11 @@
                   "isLocal": true
                 }
               }
-            },
+            }
+          ]
+        },
+        {
+          "platforms": [
             {
               "dockerfile": "src/windowsservercore/ltsc2022/helix/webassembly",
               "os": "windows",


### PR DESCRIPTION
The changes from https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/552 introduced an error with how the windowsservercore manifest is defined. It lumps all the Dockerfiles into a single image definition within the manifest. This treats the images as a single unit when there is no such need. They should be listed as separate images.

This configuration actually causes pseudo-duplicate entries in the image info file because these all these Dockerfiles are treated as a unit and since the tags are different with each build, the processing thinks it's a new entry in the image info for each build of the images. See https://github.com/dotnet/versions/pull/861