### PR TITLE
Fix cross root package sources for x86 ubuntu 18.04

### DIFF
--- a/src/ubuntu/18.04/cross/x86-linux/hooks/pre-build
+++ b/src/ubuntu/18.04/cross/x86-linux/hooks/pre-build
@@ -2,4 +2,4 @@
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
-$SCRIPTPATH/../../../../build-scripts/run-arcade-build-rootfs.sh ubuntu-18.04 linux x86 lldb3.9
+$SCRIPTPATH/../../../../build-scripts/run-arcade-build-rootfs.sh ubuntu-18.04 bionic x86 lldb3.9


### PR DESCRIPTION
The `linux` argument doesn't exist in the arcade build-rootfs.sh script, we should be passing the Ubuntu codename. It defaulted to xenial which caused outdated packages to be in the crossrootfs, see https://github.com/dotnet/runtime/pull/79013#issuecomment-1340957545