### PR TITLE
Set jsvu bin path

### DIFF
--- a/src/ubuntu/20.04/helix/wasm/amd64/Dockerfile
+++ b/src/ubuntu/20.04/helix/wasm/amd64/Dockerfile
@@ -24,5 +24,5 @@ USER helixbot
 
 # Install V8 & other engines in the non-root context
 RUN jsvu --os=linux64 --engines=v8
-ENV PATH="/home/helixbot/.jsvu:${PATH}"
+ENV PATH="/home/helixbot/.jsvu/bin:${PATH}"
 RUN v8 -e "console.log(version());quit();"

--- a/src/windowsservercore/ltsc2022/helix/webassembly/Dockerfile
+++ b/src/windowsservercore/ltsc2022/helix/webassembly/Dockerfile
@@ -44,5 +44,5 @@ RUN msiexec /i %TEMP%\nodejs.msi /quiet /passive /qn /norestart
 # install jsvu and engines
 RUN npm install jsvu -g
 RUN npm exec -c "jsvu --os=win64 --engines=v8"
-RUN setx PATH "%PATH%;%USERPROFILE%\.jsvu"
+RUN setx PATH "%PATH%;%USERPROFILE%\.jsvu\bin"
 RUN v8 -e "console.log(version());quit();"


### PR DESCRIPTION
The WASM Dockerfiles that install [jsvu](https://github.com/GoogleChromeLabs/jsvu) are failing with the build error:

```
Step 9/9 : RUN v8 -e "console.log(version());quit();"
 ---> Running in efa35e356d1a
/bin/sh: 1: v8: not found
```

This seems to be caused by a newer major version of jsvu. The previous version that had been last built was using 1.13.4. The latest version is now 2.0.0.

Looking at the installation instructions for jsvu, [it says to set the `PATH` variable to `.jsvu/bin`](https://github.com/GoogleChromeLabs/jsvu/blob/db210612b301169315aabe492dea72c63504bb45/README.md?plain=1#L19-L23) but the Dockerfile was just setting it to the `.jsvu` directory. Changing that allowed the build to pass.