### PR TITLE
Add arm64 cross-build images targeting Ubuntu 16.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ A precondition for building an image is to ensure that the base image specified 
 
 In certain cases, it is necessary to run custom logic before and after the Dockerfiles are built.  For example, to build the Dockerfiles that are used for cross-gen builds, the rootfs that gets copied into the Docker image needs to be built on the host OS.  To support these scenarios a `pre-build` or `post-build` bash or PowerShell script can be placed in a `hooks` folder next to the Dockerfile.  The scripts will get invoked by the build process.
 
+Note that multi-stage docker builds can be used to accomplish the same without build hooks, and are easier to iterate on locally because this takes advantage of docker image caching to avoid re-running steps when nothing has changed (whereas pre-build hooks run every time the dockerfile is built).
+
 **Warning:** It is generally recommended to avoid the need to use hooks whenever possible.
 
 ### Image-Builder

--- a/src/ubuntu/18.04/cross/arm64/hooks/pre-build
+++ b/src/ubuntu/18.04/cross/arm64/hooks/pre-build
@@ -2,4 +2,4 @@
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
-$SCRIPTPATH/../../../../build-scripts/run-arcade-build-rootfs.sh ubuntu-18.04 xenial arm64 lldb3.9 "" "" llvm8
+$SCRIPTPATH/../../../../build-scripts/run-arcade-build-rootfs.sh ubuntu-18.04 bionic arm64 lldb3.9 "" "" llvm9

--- a/src/ubuntu/18.04/cross/arm64/hooks/pre-build
+++ b/src/ubuntu/18.04/cross/arm64/hooks/pre-build
@@ -2,4 +2,4 @@
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
-$SCRIPTPATH/../../../../build-scripts/run-arcade-build-rootfs.sh ubuntu-18.04 bionic arm64 lldb3.9 "" "" llvm9
+$SCRIPTPATH/../../../../build-scripts/run-arcade-build-rootfs.sh ubuntu-18.04 xenial arm64 lldb3.9 "" "" llvm8

--- a/src/ubuntu/20.04/cross/arm64/Dockerfile
+++ b/src/ubuntu/20.04/cross/arm64/Dockerfile
@@ -24,7 +24,7 @@ RUN mkdir compiler-rt-build && \
     cd compiler-rt-build && \
     \
     TARGET_TRIPLE=aarch64-linux-gnu \
-    BUILD_CXX_FLAGS="-v --sysroot=$ROOTFS_DIR" && \
+    BUILD_FLAGS="-v --sysroot=$ROOTFS_DIR" && \
     \
     cmake ../compiler-rt-9.0.1.src \
         -DCOMPILER_RT_BUILD_PROFILE=ON \
@@ -41,8 +41,8 @@ RUN mkdir compiler-rt-build && \
         -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON \
         -DLLVM_CONFIG_PATH=/usr/bin/llvm-config-9 \
         \
-        -DCMAKE_C_FLAGS="${BUILD_CXX_FLAGS}" \
-        -DCMAKE_CXX_FLAGS="${BUILD_CXX_FLAGS}"
+        -DCMAKE_C_FLAGS="${BUILD_FLAGS}" \
+        -DCMAKE_CXX_FLAGS="${BUILD_FLAGS}"
 
 RUN cd compiler-rt-build && make
 

--- a/src/ubuntu/20.04/cross/arm64/Dockerfile
+++ b/src/ubuntu/20.04/cross/arm64/Dockerfile
@@ -24,26 +24,25 @@ RUN mkdir compiler-rt-build && \
     cd compiler-rt-build && \
     \
     TARGET_TRIPLE=aarch64-linux-gnu \
-    BUILD_C_FLAGS="-v --sysroot=$ROOTFS_DIR" && \
+    BUILD_CXX_FLAGS="-v --sysroot=$ROOTFS_DIR" && \
     \
     cmake ../compiler-rt-9.0.1.src \
-    -DCOMPILER_RT_BUILD_PROFILE=ON \
-    -DCOMPILER_RT_BUILD_BUILTINS=OFF \
-    -DCOMPILER_RT_BUILD_SANITIZERS=OFF \
-    -DCOMPILER_RT_BUILD_XRAY=OFF \
-    -DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
-    \
-    -DCMAKE_C_COMPILER=/usr/bin/clang-9 \
-    -DCMAKE_CXX_COMPILER=/usr/bin/clang++-9 \
-    -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld" \
-    -DCMAKE_C_COMPILER_TARGET="${TARGET_TRIPLE}" \
-    -DCMAKE_CXX_COMPILER_TARGET="${TARGET_TRIPLE}" \
-    -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON \
-    -DLLVM_CONFIG_PATH=/usr/bin/llvm-config-9 \
-    \
-    -DCMAKE_C_FLAGS="${BUILD_C_FLAGS}" \
-    -DCMAKE_CXX_FLAGS="${BUILD_C_FLAGS}" \
-    -DCMAKE_C_COMPILER_EXTERNAL_TOOLCHAIN="$ROOTFS_DIR/usr"
+        -DCOMPILER_RT_BUILD_PROFILE=ON \
+        -DCOMPILER_RT_BUILD_BUILTINS=OFF \
+        -DCOMPILER_RT_BUILD_SANITIZERS=OFF \
+        -DCOMPILER_RT_BUILD_XRAY=OFF \
+        -DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
+        \
+        -DCMAKE_C_COMPILER=/usr/bin/clang-9 \
+        -DCMAKE_CXX_COMPILER=/usr/bin/clang++-9 \
+        -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld" \
+        -DCMAKE_C_COMPILER_TARGET="${TARGET_TRIPLE}" \
+        -DCMAKE_CXX_COMPILER_TARGET="${TARGET_TRIPLE}" \
+        -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON \
+        -DLLVM_CONFIG_PATH=/usr/bin/llvm-config-9 \
+        \
+        -DCMAKE_C_FLAGS="${BUILD_CXX_FLAGS}" \
+        -DCMAKE_CXX_FLAGS="${BUILD_CXX_FLAGS}"
 
 RUN cd compiler-rt-build && make
 

--- a/src/ubuntu/20.04/cross/arm64/Dockerfile
+++ b/src/ubuntu/20.04/cross/arm64/Dockerfile
@@ -1,0 +1,57 @@
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-crossdeps-local AS binutils
+
+# Install binutils-aarch64-linux-gnu
+RUN apt-get update \
+    && apt-get install -y \
+        binutils-aarch64-linux-gnu \
+    && rm -rf /var/lib/apt/lists/*
+
+
+FROM binutils AS rootfsbuild
+ARG ROOTFS_DIR=/crossrootfs
+
+# Build rootfs
+RUN git config --global user.email builder@dotnet-buildtools-prereqs-docker && \
+    git clone --depth 1 --single-branch https://github.com/dotnet/arcade /scripts
+RUN /scripts/eng/common/cross/build-rootfs.sh arm64 xenial lldb3.9 --skipunmount
+RUN bash -c "rm -rf $ROOTFS_DIR/*/{var/cache/apt/archives/*,var/lib/apt/lists/*,usr/share/doc,usr/share/man}"
+
+# Build llvm-9 compiler-rt profile library for arm64, for PGO support
+RUN wget https://github.com/llvm/llvm-project/releases/download/llvmorg-9.0.1/compiler-rt-9.0.1.src.tar.xz
+RUN tar -xf compiler-rt-9.0.1.src.tar.xz && \
+    rm compiler-rt-9.0.1.src.tar.xz
+RUN mkdir compiler-rt-build && \
+    cd compiler-rt-build && \
+    \
+    TARGET_TRIPLE=aarch64-linux-gnu \
+    BUILD_C_FLAGS="-v --sysroot=$ROOTFS_DIR" && \
+    \
+    cmake ../compiler-rt-9.0.1.src \
+    -DCOMPILER_RT_BUILD_PROFILE=ON \
+    -DCOMPILER_RT_BUILD_BUILTINS=OFF \
+    -DCOMPILER_RT_BUILD_SANITIZERS=OFF \
+    -DCOMPILER_RT_BUILD_XRAY=OFF \
+    -DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
+    \
+    -DCMAKE_C_COMPILER=/usr/bin/clang-9 \
+    -DCMAKE_CXX_COMPILER=/usr/bin/clang++-9 \
+    -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld" \
+    -DCMAKE_C_COMPILER_TARGET="${TARGET_TRIPLE}" \
+    -DCMAKE_CXX_COMPILER_TARGET="${TARGET_TRIPLE}" \
+    -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON \
+    -DLLVM_CONFIG_PATH=/usr/bin/llvm-config-9 \
+    \
+    -DCMAKE_C_FLAGS="${BUILD_C_FLAGS}" \
+    -DCMAKE_CXX_FLAGS="${BUILD_C_FLAGS}" \
+    -DCMAKE_C_COMPILER_EXTERNAL_TOOLCHAIN="$ROOTFS_DIR/usr"
+
+RUN cd compiler-rt-build && make
+
+# Copy profile library to the rootfs
+RUN mkdir -p $ROOTFS_DIR/usr/lib/llvm-9/lib/clang/9.0.1/lib/linux/ && \
+    cp /compiler-rt-build/lib/linux/libclang_rt.profile-aarch64.a $ROOTFS_DIR/usr/lib/llvm-9/lib/clang/9.0.1/lib/linux/
+
+
+FROM binutils
+ARG ROOTFS_DIR=/crossrootfs
+COPY --from=rootfsbuild $ROOTFS_DIR $ROOTFS_DIR

--- a/src/ubuntu/manifest.json
+++ b/src/ubuntu/manifest.json
@@ -485,6 +485,19 @@
         {
           "platforms": [
             {
+              "dockerfile": "src/ubuntu/20.04/cross/arm64",
+              "os": "linux",
+              "osVersion": "focal",
+              "tags": {
+                "ubuntu-20.04-cross-arm64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "ubuntu-20.04-cross-arm64$(FloatingTagSuffix)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
               "dockerfile": "src/ubuntu/20.04/cross/armv6/10",
               "os": "linux",
               "osVersion": "focal",


### PR DESCRIPTION
@janvorli @MichaelSimons PTAL. I can't seem to add reviewers directly.

This is adding an Ubuntu 20.04 image with an arm64 Ubuntu 16.04 rootfs that we can use to build against a lower glibc version than we currently support. The plan is to use this image at least for the .NET 7 part of https://github.com/dotnet/runtime/issues/69361.

Locally, I've used these steps to build a container that can build coreclr with the `--pgoinstrument` argument. Without the profile library build, the build fails with
```
ld.lld: error: cannot open /rootfs/usr/lib/llvm-9/lib/clang/9.0.1/lib/linux/libclang_rt.profile-aarch64.a: No such file or directory
```
Building this library and copying it into the rootfs fixes this.

@janvorli I would appreciate if you could also review the logs here to make sure everything looks ok: https://dev.azure.com/dnceng-public/cbb18261-c48f-4abb-8651-8cdcb5474649/_apis/build/builds/137325/logs/467. I started with instructions at https://llvm.org/docs/HowToCrossCompileLLVM.html and https://llvm.org/docs/HowToCrossCompileBuiltinsOnArm.html, then had to play around with the arguments and use a mix of CMAKE variables and flags like `--sysroot` (`-DCMAKE_SYSROOT` was not working as I expected). The logs show that `/usr/lib/llvm-9/lib/clang/9.0.1/include` is still being used as an include path - I am not sure if this is a problem, so I'd appreciate your eyes on this.