### PR TITLE
Update the node and npm so that newer jsvu and v8 work

### DIFF
--- a/src/ubuntu/20.04/helix/wasm/amd64/Dockerfile
+++ b/src/ubuntu/20.04/helix/wasm/amd64/Dockerfile
@@ -22,9 +22,10 @@ RUN apt-get clean && \
 USER helixbot
 
 # update node, which is required for newer npm, jsvu and v8
+ENV NODE_VERSION 18.12.1
 RUN cd ~ && \
-    curl -LO https://nodejs.org/dist/v18.12.1/node-v18.12.1-linux-x64.tar.xz && \
-    tar xf node-v18.12.1-linux-x64.tar.xz
+    curl -LO https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz && \
+    tar xf node-v${NODE_VERSION}-linux-x64.tar.xz
 
 USER root
 

--- a/src/ubuntu/20.04/helix/wasm/amd64/Dockerfile
+++ b/src/ubuntu/20.04/helix/wasm/amd64/Dockerfile
@@ -18,6 +18,17 @@ RUN apt-get clean && \
      && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
 
+USER helixbot
+
+# update node, which is required for newer npm, jsvu and v8
+RUN cd ~ && \
+    curl -LO https://nodejs.org/dist/v18.12.1/node-v18.12.1-linux-x64.tar.xz && \
+    tar xf node-v18.12.1-linux-x64.tar.xz
+
+USER root
+
+ENV PATH=/home/helixbot/node-v18.12.1-linux-x64/bin:$PATH
+RUN npm install -g npm
 RUN npm install jsvu -g
 
 USER helixbot

--- a/src/ubuntu/20.04/helix/wasm/amd64/Dockerfile
+++ b/src/ubuntu/20.04/helix/wasm/amd64/Dockerfile
@@ -22,7 +22,7 @@ RUN npm install jsvu -g
 
 USER helixbot
 
-# Install V8 & other engines in the non-root context
+# Install latest V8 engine
 RUN jsvu --os=linux64 --engines=v8
 ENV PATH="/home/helixbot/.jsvu/bin:${PATH}"
 RUN v8 -e "console.log(version());quit();"

--- a/src/ubuntu/20.04/helix/wasm/amd64/Dockerfile
+++ b/src/ubuntu/20.04/helix/wasm/amd64/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get clean && \
     mv /etc/apt/sources.list1 /etc/apt/sources.list &&  apt-get update && \
     apt-get install -qq -y \
         libnode-dev \
+        curl \
         node-gyp \
         npm \
      && rm -rf /var/lib/apt/lists/* \

--- a/src/ubuntu/20.04/helix/wasm/amd64/Dockerfile
+++ b/src/ubuntu/20.04/helix/wasm/amd64/Dockerfile
@@ -29,7 +29,7 @@ RUN cd ~ && \
 
 USER root
 
-ENV PATH=/home/helixbot/node-v18.12.1-linux-x64/bin:$PATH
+ENV PATH=/home/helixbot/node-v${NODE_VERSION}-linux-x64/bin:$PATH
 RUN npm install -g npm
 RUN npm install jsvu -g
 

--- a/src/windowsservercore/ltsc2019/webassembly/Dockerfile
+++ b/src/windowsservercore/ltsc2019/webassembly/Dockerfile
@@ -76,7 +76,7 @@ RUN curl -SL --output %TEMP%\nodejs.msi https://nodejs.org/dist/v%NODE_VERSION%/
 # install jsvu and engines
 RUN npm install jsvu -g \
     && npm exec -c "jsvu --os=win64 --engines=v8,spidermonkey" \
-    && setx /M PATH "%PATH%;%USERPROFILE%\.jsvu"
+    && setx /M PATH "%PATH%;%USERPROFILE%\.jsvu\bin"
 
 # Install cmake
 ENV CMAKE_VERSION 3.20.3

--- a/src/windowsservercore/ltsc2022/helix/webassembly/Dockerfile
+++ b/src/windowsservercore/ltsc2022/helix/webassembly/Dockerfile
@@ -41,7 +41,7 @@ ENV NODE_VERSION 17.3.1
 RUN curl -SL --output %TEMP%\nodejs.msi https://nodejs.org/dist/v%NODE_VERSION%/node-v%NODE_VERSION%-x64.msi
 RUN msiexec /i %TEMP%\nodejs.msi /quiet /passive /qn /norestart
 
-# install jsvu and engines
+# install latest jsvu and v8 engine
 RUN npm install jsvu -g
 RUN npm exec -c "jsvu --os=win64 --engines=v8"
 RUN setx PATH "%PATH%;%USERPROFILE%\.jsvu\bin"


### PR DESCRIPTION
That should fix https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/755 and unblock builds. Next step will be to consider and move to newer Ubuntu 22.04.