### PR TITLE
Increase retry count for waiting to install cross build packages

### DIFF
--- a/src/ubuntu/build-scripts/install-cross-build-prereqs.sh
+++ b/src/ubuntu/build-scripts/install-cross-build-prereqs.sh
@@ -26,7 +26,7 @@ retryCount=0
 waitSecs=60
 until installPkgs; do
     retryCount=$((retryCount+1))
-    if [ $retryCount -lt 5 ]; then
+    if [ $retryCount -lt 10 ]; then
         echo "Failed to update apt-get, retrying in $waitSecs seconds..."
         sleep $waitSecs
     else


### PR DESCRIPTION
There are still issues with the changes from https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/759 that were intended to solve the issue of waiting for the lock to be released to allow packages to be installed on the build machine. There are cases where machines still have a lock. So I'm doubling the retry count to allow more time for the lock to be released.