### PR TITLE
Add OpenSSL 1.1 to Fedora 36 to support VMR Codespaces

### DIFF
--- a/src/fedora/36/amd64/Dockerfile
+++ b/src/fedora/36/amd64/Dockerfile
@@ -51,3 +51,9 @@ RUN dnf --setopt=install_weak_deps=False install -y \
         uuid-devel \
         zlib-devel \
     && dnf clean all
+
+# Dependencies for running the VMR tooling
+# LibGit2Sharp requires this when synchronizing the VMR in a Codespace
+RUN dnf --setopt=install_weak_deps=False install -y \
+        openssl1.1.x86_64 \
+    && dnf clean all

--- a/src/fedora/36/amd64/Dockerfile
+++ b/src/fedora/36/amd64/Dockerfile
@@ -55,5 +55,5 @@ RUN dnf --setopt=install_weak_deps=False install -y \
 # Dependencies for running the VMR tooling
 # LibGit2Sharp requires this when synchronizing the VMR in a Codespace
 RUN dnf --setopt=install_weak_deps=False install -y \
-        openssl1.1.x86_64 \
+        openssl1.1 \
     && dnf clean all


### PR DESCRIPTION
https://github.com/dotnet/arcade/issues/12101