### PR TITLE
Add support for Bookworm

### DIFF
--- a/src/debian/12/helix/amd64/Dockerfile
+++ b/src/debian/12/helix/amd64/Dockerfile
@@ -1,0 +1,62 @@
+FROM debian:bookworm
+
+# Install Helix Dependencies
+
+RUN apt-get update && \
+    apt-get install -y \
+        autoconf \
+        automake \
+        at \
+        build-essential \
+        curl \
+        gcc \
+        gdb \
+        git \
+        iputils-ping \
+        libcurl4 \
+        libffi-dev \
+        libgdiplus \
+        libicu-dev \
+        libssl-dev \
+        libtool \
+        libunwind8 \
+        locales \
+        locales-all \
+        python3-dev \
+        python3-pip \
+        software-properties-common \
+        sudo \
+        tzdata \
+        unzip \
+    && rm -rf /var/lib/apt/lists/* \
+    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+ENV LANG=en_US.utf8
+
+RUN ln -sf /usr/bin/python3 /usr/bin/python && \
+    curl https://bootstrap.pypa.io/get-pip.py -o ./get-pip.py --fail --silent --show-error && \
+    python ./get-pip.py && rm ./get-pip.py && \
+    python -m pip install --upgrade pip==20.2 && \
+    python -m pip install virtualenv==16.6.0 && \
+    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    pip install ./helix_scripts-*-py3-none-any.whl
+
+# Add MsQuic
+RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
+    echo 2cfd20a306b2fa5e25522d78f2ef50a1f429d35fd30bd983e2ebffc2b80944fa microsoft.asc| sha256sum --check - && \
+    apt-key add microsoft.asc && \
+    rm microsoft.asc && \
+    apt-add-repository https://packages.microsoft.com/debian/11/prod && \
+    apt-get update && \
+    apt-get install -y libmsquic && \
+    rm -rf /var/lib/apt/lists/*
+
+# Create helixbot user and give rights to sudo without password
+# additionally, preinstall the virtualenv packages used for VSTS reporting to save time
+RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm helixbot && \
+    chmod 755 /root && \
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
+
+USER helixbot
+
+RUN python -m virtualenv --no-site-packages /home/helixbot/.vsts-env

--- a/src/debian/12/helix/amd64/Dockerfile
+++ b/src/debian/12/helix/amd64/Dockerfile
@@ -41,16 +41,6 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
     pip install ./helix_scripts-*-py3-none-any.whl
 
-# Add MsQuic
-RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
-    echo 2cfd20a306b2fa5e25522d78f2ef50a1f429d35fd30bd983e2ebffc2b80944fa microsoft.asc| sha256sum --check - && \
-    apt-key add microsoft.asc && \
-    rm microsoft.asc && \
-    apt-add-repository https://packages.microsoft.com/debian/11/prod && \
-    apt-get update && \
-    apt-get install -y libmsquic && \
-    rm -rf /var/lib/apt/lists/*
-
 # Create helixbot user and give rights to sudo without password
 # additionally, preinstall the virtualenv packages used for VSTS reporting to save time
 RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm helixbot && \

--- a/src/debian/12/helix/arm64v8/Dockerfile
+++ b/src/debian/12/helix/arm64v8/Dockerfile
@@ -1,0 +1,68 @@
+FROM debian:bookworm
+
+# Install Helix Dependencies
+
+RUN apt-get update && \
+    apt-get install -y \
+        autoconf \
+        automake \
+        at \
+        build-essential \
+        cmake \
+        curl \
+        gcc \
+        gdb \
+        git \
+        iputils-ping \
+        libcurl4 \
+        libffi-dev \
+        libgdiplus \
+        libicu-dev \
+        libssl-dev \
+        libtool \
+        libunwind8 \
+        locales \
+        locales-all \
+        python3-dev \
+        python3-pip \
+        software-properties-common \
+        sudo \
+        tzdata \
+        unzip \
+    && rm -rf /var/lib/apt/lists/* \
+    \
+    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+ENV LANG=en_US.utf8
+
+RUN ln -sf /usr/bin/python3 /usr/bin/python && \
+    curl https://bootstrap.pypa.io/get-pip.py -o ./get-pip.py --fail --silent --show-error && \
+    python ./get-pip.py && rm ./get-pip.py && \
+    python -m pip install --upgrade pip==20.2 && \
+    python -m pip install virtualenv==16.6.0 && \
+    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    export CRYPTOGRAPHY_DONT_BUILD_RUST=1 && \
+    pip install ./helix_scripts-*-py3-none-any.whl
+
+# Add MsQuic
+RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
+    echo 2cfd20a306b2fa5e25522d78f2ef50a1f429d35fd30bd983e2ebffc2b80944fa microsoft.asc| sha256sum --check - && \
+    apt-key add microsoft.asc && \
+    rm microsoft.asc && \
+    apt-add-repository https://packages.microsoft.com/debian/11/prod && \
+    apt-get update && \
+    apt-get install -y libmsquic && \
+    rm -rf /var/lib/apt/lists/*
+
+# Create helixbot users and give rights to sudo without password
+# (we use two users here to ensure volume mounting works with two possible UIDs of the host UID)
+# additionally, preinstall the virtualenv packages used for VSTS reporting to save time
+RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1001 --shell /bin/bash --ingroup adm helixbot && \
+    /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm helixbot2 && \
+    chmod 755 /root && \
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers && \
+    echo "helixbot2 ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers 
+
+USER helixbot
+
+RUN python -m virtualenv --no-site-packages /home/helixbot/.vsts-env

--- a/src/debian/12/helix/arm64v8/Dockerfile
+++ b/src/debian/12/helix/arm64v8/Dockerfile
@@ -44,16 +44,6 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     export CRYPTOGRAPHY_DONT_BUILD_RUST=1 && \
     pip install ./helix_scripts-*-py3-none-any.whl
 
-# Add MsQuic
-RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
-    echo 2cfd20a306b2fa5e25522d78f2ef50a1f429d35fd30bd983e2ebffc2b80944fa microsoft.asc| sha256sum --check - && \
-    apt-key add microsoft.asc && \
-    rm microsoft.asc && \
-    apt-add-repository https://packages.microsoft.com/debian/11/prod && \
-    apt-get update && \
-    apt-get install -y libmsquic && \
-    rm -rf /var/lib/apt/lists/*
-
 # Create helixbot users and give rights to sudo without password
 # (we use two users here to ensure volume mounting works with two possible UIDs of the host UID)
 # additionally, preinstall the virtualenv packages used for VSTS reporting to save time

--- a/src/debian/manifest.json
+++ b/src/debian/manifest.json
@@ -175,6 +175,31 @@
               "variant": "v8"
             }
           ]
+        },
+        {
+          "platforms": [
+            {
+              "architecture": "amd64",
+              "dockerfile": "src/debian/12/helix/amd64",
+              "os": "linux",
+              "osVersion": "bookworm",
+              "tags": {
+                "debian-12-helix-amd64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "debian-12-helix-amd64$(FloatingTagSuffix)": {}
+              }
+            }
+          ]
+        },
+        {
+          "architecture": "arm64",
+          "dockerfile": "src/debian/11/helix/arm64v8",
+          "os": "linux",
+          "osVersion": "bullseye",
+          "tags": {
+            "debian-12-helix-arm64v8-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+            "debian-12-helix-arm64v8$(FloatingTagSuffix)": {}
+          },
+          "variant": "v8"
         }
       ]
     }


### PR DESCRIPTION
These Dockerfiles are (mostly) a copy of the Debian bullseye variants. I've made two changes:

- Updated `FROM` statement to `bookworm`
- Removed `msquic` which is apparently not compatible with OpenSSL 3 (which comes with Bookworm).

The last `RUN` statement fails with the following error. I'll need some help with that. I validated that the Debian 11 variant works and it does.

```bash
 => ERROR [5/5] RUN python -m virtualenv --no-site-packages /home/helixbo  0.6s
------
 > [5/5] RUN python -m virtualenv --no-site-packages /home/helixbot/.vsts-env:
#8 0.574 Traceback (most recent call last):
#8 0.574   File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
#8 0.574     return _run_code(code, main_globals, None,
#8 0.574   File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
#8 0.574     exec(code, run_globals)
#8 0.574   File "/usr/local/lib/python3.10/dist-packages/virtualenv.py", line 2580, in <module>
#8 0.575     main()
#8 0.575   File "/usr/local/lib/python3.10/dist-packages/virtualenv.py", line 821, in main
#8 0.575     create_environment(
#8 0.575   File "/usr/local/lib/python3.10/dist-packages/virtualenv.py", line 1106, in create_environment
#8 0.575     install_python(home_dir, lib_dir, inc_dir, bin_dir, site_packages=site_packages, clear=clear, symlink=symlink)
#8 0.575   File "/usr/local/lib/python3.10/dist-packages/virtualenv.py", line 1666, in install_python
#8 0.575     fix_local_scheme(home_dir, symlink)
#8 0.575   File "/usr/local/lib/python3.10/dist-packages/virtualenv.py", line 1752, in fix_local_scheme
#8 0.575     if sysconfig._get_default_scheme() == "posix_local":
#8 0.575 AttributeError: module 'sysconfig' has no attribute '_get_default_scheme'. Did you mean: 'get_default_scheme'?
#8 0.575 Using base prefix '/usr'
#8 0.575 New python executable in /home/helixbot/.vsts-env/bin/python
------
executor failed running [/bin/sh -c python -m virtualenv --no-site-packages /home/helixbot/.vsts-env]: exit code: 1
```