### PR TITLE
Add Helix image for Mariner 2.0

### DIFF
--- a/src/cbl-mariner/2.0/amd64/Dockerfile
+++ b/src/cbl-mariner/2.0/amd64/Dockerfile
@@ -27,14 +27,14 @@ RUN tdnf install -y \
         ncurses-devel \
         numactl-devel \
         openssl-devel \
-	pkgconf \
+        pkgconf \
         python3 \
         python3-devel \
         readline-devel \
-	sed \
+        sed \
         sudo \
         swig \
-	tar \
+        tar \
         wget \
         which \
         xz \

--- a/src/cbl-mariner/2.0/helix/amd64/Dockerfile
+++ b/src/cbl-mariner/2.0/helix/amd64/Dockerfile
@@ -1,0 +1,39 @@
+FROM cblmariner.azurecr.io/base/core:2.0
+
+# Install Helix Dependencies
+
+ENV LANG=en_US.utf8
+
+RUN tdnf install --setopt tsflags=nodocs --refresh -y \
+         ca-certificates-microsoft \
+         gcc \
+         icu \
+         iputils \
+         python3-pip \
+         shadow-utils \
+         tzdata \
+         which \
+    && tdnf clean all
+
+# Install MsQuic - hack until packages are pushes to mariner repository
+# When that is done, this should go to section above.
+# Mariner already has MS repos and signing keys.
+RUN rpm -i https://packages.microsoft.com/centos/7/prod/libmsquic-2.1.4-1.x86_64.rpm
+
+RUN ln -sf /usr/bin/python3 /usr/bin/python && \
+    python -m pip install --upgrade pip==21.1.2 && \
+    python -m pip install virtualenv==16.6.0 && \
+    python -m pip install --upgrade setuptools && \
+    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \ 
+    pip install ./helix_scripts-*-py3-none-any.whl && \
+    rm ./helix_scripts-*-py3-none-any.whl
+
+# create helixbot user and give rights to sudo without password
+RUN /usr/sbin/useradd -c '' --uid 1000 --shell /bin/bash --groups adm helixbot && \
+    chmod 755 /root && \
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers && \
+    mkdir /home/helixbot/ && chown -R helixbot /home/helixbot/
+
+USER helixbot
+
+RUN python -m virtualenv --no-site-packages /home/helixbot/.vsts-env

--- a/src/cbl-mariner/2.0/helix/amd64/Dockerfile
+++ b/src/cbl-mariner/2.0/helix/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM cblmariner.azurecr.io/base/core:2.0
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
 
 # Install Helix Dependencies
 

--- a/src/cbl-mariner/2.0/helix/amd64/Dockerfile
+++ b/src/cbl-mariner/2.0/helix/amd64/Dockerfile
@@ -31,7 +31,7 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
 # create helixbot user and give rights to sudo without password
 RUN /usr/sbin/useradd -c '' --uid 1000 --shell /bin/bash --groups adm helixbot && \
     chmod 755 /root && \
-    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers && \
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers && \
     mkdir /home/helixbot/ && chown -R helixbot /home/helixbot/
 
 USER helixbot

--- a/src/cbl-mariner/manifest.json
+++ b/src/cbl-mariner/manifest.json
@@ -23,8 +23,8 @@
               "os": "linux",
               "osVersion": "cbl-mariner2.0",
               "tags": {
-                "cbl-mariner-2.0-helix-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "cbl-mariner-2.0-helix$(FloatingTagSuffix)": {}
+                "cbl-mariner-2.0-helix-amd64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "cbl-mariner-2.0-helix-amd64$(FloatingTagSuffix)": {}
               }
             }
           ]

--- a/src/cbl-mariner/manifest.json
+++ b/src/cbl-mariner/manifest.json
@@ -19,6 +19,19 @@
         {
           "platforms": [
             {
+              "dockerfile": "src/cbl-mariner/2.0/helix/amd64",
+              "os": "linux",
+              "osVersion": "cbl-mariner2.0",
+              "tags": {
+                "cbl-mariner-2.0-helix-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "cbl-mariner-2.0-helix$(FloatingTagSuffix)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
               "dockerfile": "src/cbl-mariner/2.0/amd64",
               "os": "linux",
               "osVersion": "cbl-mariner2.0",


### PR DESCRIPTION
based on Mariner 1.0
Request for Mariner packages is tracked by https://github.com/microsoft/msquic/issues/3376

The build runs with warning
```
WARNING: Running pip as root will break packages and permissions. You should install packages reliably by using venv: https://pip.pypa.io/warnings/venv
WARNING: You are using pip version 21.1.2; however, version 22.3.1 is available.
You should consider upgrading via the '/usr/bin/python -m pip install --upgrade pip' command.
```

I'm wondering if we should install the python  craft _after_ we add `helixbot` user @MattGal. 
I would assume this is not only one distributions where we bend the recommendation. 


cc: @ManickaP 