### PR TITLE
Fix rootfs dir

### DIFF
--- a/src/ubuntu/20.04/cross/arm64/Dockerfile
+++ b/src/ubuntu/20.04/cross/arm64/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update \
 
 
 FROM binutils AS rootfsbuild
-ARG ROOTFS_DIR=/crossrootfs
+ARG ROOTFS_DIR=/crossrootfs/arm64
 
 # Build rootfs
 RUN git config --global user.email builder@dotnet-buildtools-prereqs-docker && \
@@ -52,5 +52,5 @@ RUN mkdir -p $ROOTFS_DIR/usr/lib/llvm-9/lib/clang/9.0.1/lib/linux/ && \
 
 
 FROM binutils
-ARG ROOTFS_DIR=/crossrootfs
+ARG ROOTFS_DIR=/crossrootfs/arm64
 COPY --from=rootfsbuild $ROOTFS_DIR $ROOTFS_DIR

--- a/src/ubuntu/20.04/crossdeps/Dockerfile
+++ b/src/ubuntu/20.04/crossdeps/Dockerfile
@@ -1,5 +1,7 @@
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-coredeps-local
 
+RUN echo triggering rebuild!
+
 # Install the base toolchain we need to build anything (clang, cmake, make and the like).
 RUN apt-get update \
     && apt-get install -y \

--- a/src/ubuntu/20.04/crossdeps/Dockerfile
+++ b/src/ubuntu/20.04/crossdeps/Dockerfile
@@ -1,7 +1,5 @@
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-coredeps-local
 
-RUN echo triggering rebuild!
-
 # Install the base toolchain we need to build anything (clang, cmake, make and the like).
 RUN apt-get update \
     && apt-get install -y \


### PR DESCRIPTION
This fixes the rootfs dir for the images added in https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/754, to be consistent with the existing images.

I looked for a way to extract this into a single variable in the Dockerfile. The only way I found was to use ENV, but that would persist the environment variable into the created image - and I want to avoid polluting the image's environment.