### PR TITLE
Disable image caching for production branch builds

### DIFF
--- a/eng/pipelines/variables/common.yml
+++ b/eng/pipelines/variables/common.yml
@@ -29,6 +29,8 @@ variables:
 - ${{ if or(eq(variables['Build.SourceBranch'], 'refs/heads/production'), eq(variables['System.PullRequest.TargetBranch'], 'refs/heads/production')) }}:
   - name: publicSourceBranch
     value: production
+  - name: noCache
+    value: true
 - ${{ else }}:
   - name: publicSourceBranch
     value: main


### PR DESCRIPTION
Ensures that we don't use image caching for production builds.

Fixes #768