### PR TITLE
Remove base image override for Alpine

### DIFF
--- a/eng/pipelines/dotnet-buildtools-prereqs-all.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-all.yml
@@ -26,7 +26,7 @@ stages:
       - template: ../../../pipelines/steps/set-base-image-override-options.yml
         parameters:
           variableName: customCopyBaseImagesArgs
-          dockerfileOs: (alpine|centos|debian|fedora|ubuntu)
+          dockerfileOs: (centos|debian|fedora|ubuntu)
           baseOverrideRegistry: $(overrideRegistry) # Comes from DotNet-Docker-Common variable group
     customBuildInitSteps:
     - template: /eng/pipelines/steps/install-cross-build-prereqs.yml
@@ -34,6 +34,6 @@ stages:
       - template: ../../../pipelines/steps/set-base-image-override-options.yml
         parameters:
           variableName: imageBuilderBuildArgs
-          dockerfileOs: (alpine|centos|debian|fedora|ubuntu)
+          dockerfileOs: (centos|debian|fedora|ubuntu)
           baseOverrideRegistry: $(overrideRegistry) # Comes from DotNet-Docker-Common variable group
     

--- a/eng/pipelines/dotnet-buildtools-prereqs-alpine.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-alpine.yml
@@ -24,16 +24,3 @@ stages:
   parameters:
     internalProjectName: ${{ variables.internalProjectName }}
     publicProjectName: ${{ variables.publicProjectName }}
-    ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-      customCopyBaseImagesInitSteps:
-      - template: ../../../pipelines/steps/set-base-image-override-options.yml
-        parameters:
-          variableName: customCopyBaseImagesArgs
-          dockerfileOs: alpine
-          baseOverrideRegistry: $(overrideRegistry) # Comes from DotNet-Docker-Common variable group
-      customBuildInitSteps:
-      - template: ../../../pipelines/steps/set-base-image-override-options.yml
-        parameters:
-          variableName: imageBuilderBuildArgs
-          dockerfileOs: alpine
-          baseOverrideRegistry: $(overrideRegistry) # Comes from DotNet-Docker-Common variable group


### PR DESCRIPTION
Unable to continue with base image overriding for Alpine since new Alpine tags are not being accepted. Falling back to what's specified in the Dockerfile instead. This unblocks the internal build for https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/788.