### PR TITLE
fix locale setting for Alpine 3.17

### DIFF
--- a/src/alpine/3.17/helix/amd64/Dockerfile
+++ b/src/alpine/3.17/helix/amd64/Dockerfile
@@ -43,7 +43,6 @@ RUN apk update && \
         zlib-dev
 
 # Install Helix Dependencies
-
 RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     curl https://bootstrap.pypa.io/get-pip.py -o ./get-pip.py --fail --silent --show-error && \
     python ./get-pip.py && rm ./get-pip.py && \
@@ -66,6 +65,7 @@ RUN cd /tmp && \
 
 # Needed for corefx tests to pass
 ENV LANG=en-US.UTF-8
+RUN echo export LANG=en-US.UTF-8  >> /etc/profile.d/locale.sh
 
 # create helixbot user and give rights to sudo without password
 # Alpine does not support long options


### PR DESCRIPTION
related to https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/788#issuecomment-1423473134
I did not run tests but at least when running bash `LANG` is correct.