### PR TITLE
fix helix Ubuntu 22 build on arm64

### DIFF
--- a/src/ubuntu/22.04/helix/arm64v8/Dockerfile
+++ b/src/ubuntu/22.04/helix/arm64v8/Dockerfile
@@ -58,8 +58,8 @@ RUN cd /tmp && \
     tar xf powershell-7.2.5-linux-arm64.tar.gz && \
     cd .. && \
     git clone --depth 1 --single-branch --branch main --recursive https://github.com/dotnet/msquic && \
-    cd msquic/src/msquic  &&  PATH=~/.dotnet/tools:$PATH /tmp/pwsh/pwsh scripts/build.ps1 -arch arm64 -Config Release -DisableTools -DisableTest -DisablePerf && \
-    cp artifacts/bin/linux/arm64_Release_openssl/libmsquic.so.2 artifacts/bin/linux/arm64_Release_openssl/libmsquic.lttng.so.2.2.0 /usr/lib/aarch64-linux-gnu && \
+    cd msquic/src/msquic  &&  PATH=~/.dotnet/tools:$PATH /tmp/pwsh/pwsh scripts/build.ps1 -arch arm64 -Config Release -DisableTools -DisableTest -DisablePerf -UseSystemOpenSSLCrypto && \
+    cp artifacts/bin/linux/arm64_Release_openssl3/libmsquic.so.2 artifacts/bin/linux/arm64_Release_openssl3/libmsquic.lttng.so.2.2.0 /usr/lib/aarch64-linux-gnu && \
     cd /tmp && \
     rm -r pwsh msquic
 


### PR DESCRIPTION
https://dev.azure.com/dnceng/internal/_build/results?buildId=2108754&view=logs&j=c977949b-2bac-537a-607c-ccfd6201d486&t=15285f4f-8cbb-599d-bbac-1b70b321dc8e

fix the build. The repo we pull msquic from has changed and the old script no longer works

Fixes https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/794