### PR TITLE
Fix logic to detect PR build for production branch

### DIFF
--- a/eng/pipelines/variables/common.yml
+++ b/eng/pipelines/variables/common.yml
@@ -26,7 +26,7 @@ variables:
     value: $(Build.SourceBranchName)
 - name: manifestVariables
   value: --var UniqueId=$(sourceBuildId) --var FloatingTagSuffix=$(floatingTagSuffix)
-- ${{ if or(eq(variables['Build.SourceBranch'], 'refs/heads/production'), eq(variables['System.PullRequest.TargetBranch'], 'refs/heads/production')) }}:
+- ${{ if or(eq(variables['Build.SourceBranch'], 'refs/heads/production'), eq(variables['System.PullRequest.TargetBranch'], 'production')) }}:
   - name: publicSourceBranch
     value: production
   - name: noCache


### PR DESCRIPTION
Any build that targets the production branch should run with caching disabled. This isn't currently happening for PR builds. This was intended to be fixed by https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/784 but the conditional logic there isn't correct. The value of `System.PullRequest.TargetBranch` for a PR build is actually `production` not `refs/heads/production`.