### PR TITLE
Add alpine 3.17 (non-helix) dockerfile

### DIFF
--- a/src/alpine/3.17/amd64/Dockerfile
+++ b/src/alpine/3.17/amd64/Dockerfile
@@ -1,0 +1,39 @@
+FROM alpine:3.17
+
+RUN apk update && \
+    apk add --no-cache \
+        autoconf \
+        automake \
+        bash \
+        build-base \
+        clang \
+        clang-dev \
+        cmake \
+        coreutils \
+        curl \
+        gcc \
+        gettext-dev \
+        git \
+        icu-dev \
+        jq \
+        krb5-dev \
+        libtool \
+        libunwind-dev \
+        linux-headers \
+        lld \
+        lldb-dev \
+        llvm \
+        lttng-ust-dev \
+        make \
+        numactl-dev \
+        openssl \
+        openssl-dev \
+        paxctl \
+        py3-lldb \
+        python3-dev \
+        shadow \
+        sudo \
+        tzdata \
+        util-linux-dev \
+        which \
+        zlib-dev

--- a/src/alpine/manifest.json
+++ b/src/alpine/manifest.json
@@ -235,6 +235,19 @@
         {
           "platforms": [
             {
+              "dockerfile": "src/alpine/3.17/amd64",
+              "os": "linux",
+              "osVersion": "alpine3.17",
+              "tags": {
+                "alpine-3.17-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "alpine-3.17$(FloatingTagSuffix)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
               "dockerfile": "src/alpine/3.17/helix/amd64",
               "os": "linux",
               "osVersion": "alpine3.17",


### PR DESCRIPTION
This came up in https://github.com/dotnet/installer/pull/14417. We are trying to add a CI leg for alpine, and alpine 3.17 most closely matches the 7.0.1xx lifecycle.

The Dockerfile itself is a copy of the 3.15 Dockerfile, with 3.15 replaced with 3.17.