### PR TITLE
fix locale setting for Alpine 3.16

### DIFF
--- a/src/alpine/3.16/helix/amd64/Dockerfile
+++ b/src/alpine/3.16/helix/amd64/Dockerfile
@@ -66,6 +66,7 @@ RUN cd /tmp && \
 
 # Needed for corefx tests to pass
 ENV LANG=en-US.UTF-8
+RUN echo export LANG=${LANG}  >> /etc/profile.d/locale.sh
 
 # create helixbot user and give rights to sudo without password
 # Alpine does not support long options

--- a/src/alpine/3.16/helix/amd64/Dockerfile
+++ b/src/alpine/3.16/helix/amd64/Dockerfile
@@ -28,6 +28,7 @@ RUN apk update && \
         llvm \
         lttng-ust-dev \
         make \
+        musl-locales \
         numactl-dev \
         openssl \
         openssl-dev \


### PR DESCRIPTION
Dupe of https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/792