### PR TITLE
improve Alpine 3.17 helix image

### DIFF
--- a/src/alpine/3.17/helix/amd64/Dockerfile
+++ b/src/alpine/3.17/helix/amd64/Dockerfile
@@ -1,46 +1,10 @@
-FROM alpine:3.17
-
-RUN apk update && \
-    apk add --no-cache \
-        autoconf \
-        automake \
-        bash \
-        build-base \
-        cargo \
-        clang \
-        clang-dev \
-        cmake \
-        coreutils \
-        curl \
-        gcc \
-        gettext-dev \
-        git \
-        icu-dev \
-        iputils \
-        jq \
-        krb5-dev \
-        libffi-dev \
-        libtool \
-        libunwind-dev \
-        linux-headers \
-        lld \
-        lldb-dev \
-        llvm \
-        lttng-ust-dev \
-        make \
-        numactl-dev \
-        openssl \
-        openssl-dev \
-        paxctl \
-        py3-lldb \
-        python3-dev \
-        rust \
-        shadow \
-        sudo \
-        tzdata \
-        util-linux-dev \
-        which \
-        zlib-dev
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.17-local
+RUN apk update && apk add --no-cache \
+    cargo \
+    iputils \
+    libffi-dev \
+    musl-locales \
+    rust
 
 # Install Helix Dependencies
 RUN ln -sf /usr/bin/python3 /usr/bin/python && \
@@ -65,7 +29,7 @@ RUN cd /tmp && \
 
 # Needed for corefx tests to pass
 ENV LANG=en-US.UTF-8
-RUN echo export LANG=en-US.UTF-8  >> /etc/profile.d/locale.sh
+RUN echo export LANG=${LANG}  >> /etc/profile.d/locale.sh
 
 # create helixbot user and give rights to sudo without password
 # Alpine does not support long options

--- a/src/alpine/manifest.json
+++ b/src/alpine/manifest.json
@@ -240,7 +240,10 @@
               "osVersion": "alpine3.17",
               "tags": {
                 "alpine-3.17-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "alpine-3.17$(FloatingTagSuffix)": {}
+                "alpine-3.17$(FloatingTagSuffix)": {},
+                "alpine-3.17-local": {
+                  "isLocal": true
+                }
               }
             }
           ]


### PR DESCRIPTION
This is follow-up on #792 and #797 

While  #792  improved runtime test runs, some were still failing - particularly parsing foreign numbers. 
It seems like `musl-locales` package adds the missing definition (and locale -a work now just like glibc) 

#797  added base 3.17 image. So I refactor this to use it as base instead of duplicating the package. 
While `helix` may not need all the dev tools this is the structure we used in previous releases. 
Investigation if we can string helix images would be probably separate effort. 


