### PR TITLE
add msquic to Centos7

### DIFF
--- a/src/centos/7/mlnet/helix/Dockerfile
+++ b/src/centos/7/mlnet/helix/Dockerfile
@@ -6,7 +6,7 @@ RUN yum install -y \
 # Install dependencies
 RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
     echo 2cfd20a306b2fa5e25522d78f2ef50a1f429d35fd30bd983e2ebffc2b80944fa microsoft.asc| sha256sum --check - && \
-    apt-key add microsoft.asc && \
+    rpm --import microsoft.asc && \
     rm microsoft.asc && \
     dnf install --setopt tsflags=nodocs --refresh -y \
         dnf-plugins-core \

--- a/src/centos/7/mlnet/helix/Dockerfile
+++ b/src/centos/7/mlnet/helix/Dockerfile
@@ -4,14 +4,22 @@ RUN yum install -y \
         dnf
 
 # Install dependencies
-RUN dnf install --setopt tsflags=nodocs --refresh -y \
+RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
+    echo 2cfd20a306b2fa5e25522d78f2ef50a1f429d35fd30bd983e2ebffc2b80944fa microsoft.asc| sha256sum --check - && \
+    apt-key add microsoft.asc && \
+    rm microsoft.asc && \
+    dnf install --setopt tsflags=nodocs --refresh -y \
         dnf-plugins-core \
         epel-release \
+    && \
+    dnf config-manager --add-repo https://packages.microsoft.com/centos/7/prod \
     && \
     dnf install --setopt tsflags=nodocs -y \
         gcc \
         libicu \
+        libmsquic \
         openssl \
+        openssl11-libs \
         python3 \
         python3-devel \
         sudo \


### PR DESCRIPTION
```
[root@285591f33eb2 /]# ldd /usr/lib64/libmsquic.so.2
	linux-vdso.so.1 =>  (0x00007ffdab3d5000)
	libcrypto.so.1.1 => /lib64/libcrypto.so.1.1 (0x00007fc541940000)
	libdl.so.2 => /lib64/libdl.so.2 (0x00007fc54173c000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007fc541520000)
	libc.so.6 => /lib64/libc.so.6 (0x00007fc541152000)
	libz.so.1 => /lib64/libz.so.1 (0x00007fc540f3c000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fc541e24000)
```

going back to https://github.com/dotnet/arcade/issues/10253#issuecomment-1215320634 @MattGal 
it seems like the needed `openssl11` comes from EPEL e.g. `dns install epel-release` is crucial. 

