### PR TITLE
add icu-data-full to Helix alpine images

### DIFF
--- a/src/alpine/3.16/helix/amd64/Dockerfile
+++ b/src/alpine/3.16/helix/amd64/Dockerfile
@@ -15,6 +15,7 @@ RUN apk update && \
         gcc \
         gettext-dev \
         git \
+        icu-data-full \
         icu-dev \
         iputils \
         jq \

--- a/src/alpine/3.17/helix/amd64/Dockerfile
+++ b/src/alpine/3.17/helix/amd64/Dockerfile
@@ -1,6 +1,7 @@
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.17-local
 RUN apk update && apk add --no-cache \
     cargo \
+    icu-data-full \
     iputils \
     libffi-dev \
     musl-locales \


### PR DESCRIPTION
With this, runtime tests should pass
```
  ===========================================================================================================
  ~/github/wfurt-runtime2/artifacts/bin/System.ComponentModel.Annotations.Tests/Debug/net8.0 ~/github/wfurt-runtime2/src/libraries/System.ComponentModel.Annotations/tests
    Discovering: System.ComponentModel.Annotations.Tests (method display = ClassAndMethod, method display options = None)
    Discovered:  System.ComponentModel.Annotations.Tests (found 389 of 395 test cases)
    Starting:    System.ComponentModel.Annotations.Tests (parallel test collections = on, max threads = 4)
    Finished:    System.ComponentModel.Annotations.Tests
  === TEST EXECUTION SUMMARY ===
     System.ComponentModel.Annotations.Tests  Total: 796, Errors: 0, Failed: 0, Skipped: 0, Time: 0.600s
  ~/github/wfurt-runtime2/src/libraries/System.ComponentModel.Annotations/tests
```

big thanks to @tarekgh who pointed me right direction.
https://git.alpinelinux.org/aports/tree/main/icu/icu-data-en.post-install?h=3.17-stable

It seems like Alpine strips non-english locales by default.  