### PR TITLE
Add icu-data-full to alpine 3.17 dockerfile

### DIFF
--- a/src/alpine/3.17/amd64/Dockerfile
+++ b/src/alpine/3.17/amd64/Dockerfile
@@ -14,6 +14,7 @@ RUN apk update && \
         gcc \
         gettext-dev \
         git \
+        icu-data-full \
         icu-dev \
         jq \
         krb5-dev \

--- a/src/alpine/3.17/helix/amd64/Dockerfile
+++ b/src/alpine/3.17/helix/amd64/Dockerfile
@@ -1,7 +1,6 @@
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.17-local
 RUN apk update && apk add --no-cache \
     cargo \
-    icu-data-full \
     iputils \
     libffi-dev \
     musl-locales \


### PR DESCRIPTION
We use this dockerfile to try and build .NET. Localization in .NET seems to require full ICU.

The error messages aren't clear, but look like this:

```
      Determining projects to restore...
      Restored /tarball/src/msbuild/artifacts/source-build/self/src/src/StringTools/StringTools.csproj (in 388 ms).
      Restored /tarball/src/msbuild/artifacts/source-build/self/src/src/Utilities/Microsoft.Build.Utilities.csproj (in 392 ms).
      Restored /tarball/src/msbuild/artifacts/source-build/self/src/src/Tasks/Microsoft.Build.Tasks.csproj (in 394 ms).
      Restored /tarball/src/msbuild/artifacts/source-build/self/src/src/MSBuild/MSBuild.csproj (in 400 ms).
      Restored /tarball/src/msbuild/artifacts/source-build/self/src/src/Package/Localization/Localization.csproj (in 402 ms).
      Restored /tarball/src/msbuild/artifacts/source-build/self/src/src/Build/Microsoft.Build.csproj (in 433 ms).
      Restored /tarball/src/msbuild/artifacts/source-build/self/src/src/Framework/Microsoft.Build.Framework.csproj (in 512 ms).
      Microsoft.Build.Framework -> /tarball/src/msbuild/artifacts/source-build/self/src/artifacts/bin/Microsoft.Build.Framework/Release/netstandard2.0/Microsoft.Build.Framework.dll
      StringTools -> /tarball/src/msbuild/artifacts/source-build/self/src/artifacts/bin/StringTools/Release/net7.0/Microsoft.NET.StringTools.dll
      StringTools -> /tarball/src/msbuild/artifacts/source-build/self/src/artifacts/bin/StringTools/Release/netstandard2.0/Microsoft.NET.StringTools.dll
      Microsoft.Build.Framework -> /tarball/src/msbuild/artifacts/source-build/self/src/artifacts/bin/Microsoft.Build.Framework/Release/net7.0/Microsoft.Build.Framework.dll
      Microsoft.Build.Utilities -> /tarball/src/msbuild/artifacts/source-build/self/src/artifacts/bin/Microsoft.Build.Utilities/Release/net7.0/Microsoft.Build.Utilities.Core.dll
      Microsoft.Build -> /tarball/src/msbuild/artifacts/source-build/self/src/artifacts/bin/Microsoft.Build/Release/net7.0/Microsoft.Build.dll
      Microsoft.Build.Utilities -> /tarball/src/msbuild/artifacts/source-build/self/src/artifacts/bin/Microsoft.Build.Utilities/Release/netstandard2.0/Microsoft.Build.Utilities.Core.dll
      Microsoft.Build -> /tarball/src/msbuild/artifacts/source-build/self/src/artifacts/bin/Microsoft.Build/Release/net472/Microsoft.Build.dll
      Microsoft.Build.Tasks -> /tarball/src/msbuild/artifacts/source-build/self/src/artifacts/bin/Microsoft.Build.Tasks/Release/netstandard2.0/Microsoft.Build.Tasks.Core.dll
      Microsoft.Build.Tasks -> /tarball/src/msbuild/artifacts/source-build/self/src/artifacts/bin/Microsoft.Build.Tasks/Release/net7.0/Microsoft.Build.Tasks.Core.dll
      MSBuild -> /tarball/src/msbuild/artifacts/source-build/self/src/artifacts/bin/MSBuild/Release/net7.0/MSBuild.dll
      Localization -> /tarball/src/msbuild/artifacts/source-build/self/src/artifacts/bin/Localization/Release/net7.0/Localization.dll
    /tarball/.dotnet/sdk/7.0.102/Sdks/NuGet.Build.Tasks.Pack/build/NuGet.Build.Tasks.Pack.targets(221,5): error : Could not find a part of the path '/tarball/src/msbuild/artifacts/source-build/self/src/artifacts/bin/Localization/Release/net7.0/cs'. [/tarball/src/msbuild/artifacts/source-build/self/src/src/Package/Localization/Localization.csproj]
##[error]/tarball/.dotnet/sdk/7.0.102/Sdks/NuGet.Build.Tasks.Pack/build/NuGet.Build.Tasks.Pack.targets(221,5): error : (NETCORE_ENGINEERING_TELEMETRY=Build) Could not find a part of the path '/tarball/src/msbuild/artifacts/source-build/self/src/artifacts/bin/Localization/Release/net7.0/cs'.
      Successfully created package '/tarball/src/msbuild/artifacts/source-build/self/src/artifacts/packages/Release/Shipping/Microsoft.NET.StringTools.17.4.1.nupkg'.
      Successfully created package '/tarball/src/msbuild/artifacts/source-build/self/src/artifacts/packages/Release/Shipping/Microsoft.Build.Framework.17.4.1.nupkg'.
      Successfully created package '/tarball/src/msbuild/artifacts/source-build/self/src/artifacts/packages/Release/Shipping/Microsoft.Build.Utilities.Core.17.4.1.nupkg'.
      Successfully created package '/tarball/src/msbuild/artifacts/source-build/self/src/artifacts/packages/Release/Shipping/Microsoft.Build.Runtime.17.4.1.nupkg'.
      Successfully created package '/tarball/src/msbuild/artifacts/source-build/self/src/artifacts/packages/Release/Shipping/Microsoft.Build.Tasks.Core.17.4.1.nupkg'.
      Successfully created package '/tarball/src/msbuild/artifacts/source-build/self/src/artifacts/packages/Release/Shipping/Microsoft.Build.17.4.1.nupkg'.
    
    Build FAILED.
    
    /tarball/.dotnet/sdk/7.0.102/Sdks/NuGet.Build.Tasks.Pack/build/NuGet.Build.Tasks.Pack.targets(221,5): error : Could not find a part of the path '/tarball/src/msbuild/artifacts/source-build/self/src/artifacts/bin/Localization/Release/net7.0/cs'. [/tarball/src/msbuild/artifacts/source-build/self/src/src/Package/Localization/Localization.csproj]
        0 Warning(s)
        1 Error(s)
```