### PR TITLE
refactor Alpine Helix image

### DIFF
--- a/src/alpine/3.17/helix/amd64/Dockerfile
+++ b/src/alpine/3.17/helix/amd64/Dockerfile
@@ -1,33 +1,52 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.17-local
+FROM alpine:3.17
+# Install .NET and test dependencies
 RUN apk update && apk add --no-cache \
-    cargo \
+    bash \
+    coreutils \
+    curl \
+    icu-data-full \
     iputils \
-    libffi-dev \
+    lttng-ust \
     musl-locales \
-    rust
+    openssl \
+    python3 \
+    sudo \
+    tzdata
 
 # Install Helix Dependencies
-RUN ln -sf /usr/bin/python3 /usr/bin/python && \
+RUN apk update && apk add --no-cache && \
+    apk add cargo linux-headers python3-dev openssl-dev && \
+    apk list --installed > /start2.txt && \
+    ln -sf /usr/bin/python3 /usr/bin/python && \
     curl https://bootstrap.pypa.io/get-pip.py -o ./get-pip.py --fail --silent --show-error && \
-    python ./get-pip.py && rm ./get-pip.py && \
-    python -m pip install --upgrade pip==22.2.2 && \
-    python -m pip install virtualenv==20.16.5 && \
+    python3 ./get-pip.py && rm ./get-pip.py && \
+    python3 -m pip install --upgrade pip==22.2.2 && \
+    python3 -m pip install virtualenv==20.16.5 && \
     pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    pip install ./helix_scripts-*-py3-none-any.whl
+    pip install ./helix_scripts-*-py3-none-any.whl && \
+    apk del cargo linux-headers python3-dev openssl-dev
 
-# build MsQuic as we don't have packages
-RUN cd /tmp && \
-    mkdir pwsh && \
-    cd pwsh && \
-    curl -L https://github.com/PowerShell/PowerShell/releases/download/v7.2.5/powershell-7.2.5-linux-alpine-x64.tar.gz | tar xfz - && \
-    cd .. && \
-    git clone --depth 1 --single-branch --branch main --recursive https://github.com/dotnet/msquic && \
-    cd msquic/src/msquic  &&  PATH=~/.dotnet/tools:$PATH /tmp/pwsh/pwsh scripts/build.ps1 -Config Release -UseSystemOpenSSLCrypto -DisableTools -DisableTest -DisablePerf && \
-    cp artifacts/bin/linux/x64_Release_openssl3/libmsquic.so.2 artifacts/bin/linux/x64_Release_openssl3/libmsquic.lttng.so.2.* /usr/lib && \
+# build MsQuic as we don't have Alpine packages (yet)
+RUN apk update && apk add --no-cache && \
+    apk add cmake g++ gcc git numactl-dev linux-headers lttng-ust-dev make musl-dev openssl-dev perl && \
     cd /tmp && \
-    rm -r pwsh msquic
+    git clone --depth 1 --single-branch --branch main --recursive https://github.com/dotnet/msquic && \
+    cd msquic/src/msquic && \
+    cmake -B build/linux/x64_openssl3 \
+       -DQUIC_OUTPUT_DIR=/tmp/msquic/src/msquic/artifacts/bin/linux/x64_Release_openssl3 \
+       -DCMAKE_BUILD_TYPE=Release \
+       -DQUIC_TLS=openssl3 \
+       -DQUIC_ENABLE_LOGGING=true \
+       -DQUIC_USE_SYSTEM_LIBCRYPTO=true \
+       -DQUIC_BUILD_TOOLS=off \
+       -DQUIC_BUILD_TEST=off \
+       -DQUIC_BUILD_PERF=off && \
+    cmake --build build/linux/x64_openssl3  --config Release && \
+    cp artifacts/bin/linux/x64_Release_openssl3/libmsquic.so.* artifacts/bin/linux/x64_Release_openssl3/libmsquic.lttng.so.* /usr/lib && \
+    rm -rf /tmp/msquic && \
+    apk del cmake g++ gcc git linux-headers lttng-ust-dev make musl-dev openssl-dev perl
 
-# Needed for corefx tests to pass
+# Needed for runtime tests to pass
 ENV LANG=en-US.UTF-8
 RUN echo export LANG=${LANG}  >> /etc/profile.d/locale.sh
 
@@ -39,4 +58,4 @@ RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
 
 USER helixbot
 
-RUN python -m virtualenv /home/helixbot/.vsts-env
+RUN python3 -m virtualenv /home/helixbot/.vsts-env

--- a/src/alpine/3.17/helix/amd64/Dockerfile
+++ b/src/alpine/3.17/helix/amd64/Dockerfile
@@ -16,7 +16,6 @@ RUN apk update && apk add --no-cache \
 # Install Helix Dependencies
 RUN apk update && apk add --no-cache && \
     apk add cargo linux-headers python3-dev openssl-dev && \
-    apk list --installed > /start2.txt && \
     ln -sf /usr/bin/python3 /usr/bin/python && \
     curl https://bootstrap.pypa.io/get-pip.py -o ./get-pip.py --fail --silent --show-error && \
     python3 ./get-pip.py && rm ./get-pip.py && \

--- a/src/alpine/3.17/helix/amd64/Dockerfile
+++ b/src/alpine/3.17/helix/amd64/Dockerfile
@@ -6,6 +6,7 @@ RUN apk update && apk add --no-cache \
     curl \
     icu-data-full \
     iputils \
+    lldb \
     lttng-ust \
     musl-locales \
     openssl \

--- a/src/alpine/3.17/helix/amd64/Dockerfile
+++ b/src/alpine/3.17/helix/amd64/Dockerfile
@@ -16,7 +16,11 @@ RUN apk update && apk add --no-cache \
 
 # Install Helix Dependencies
 RUN apk update && apk add --no-cache && \
-    apk add cargo linux-headers python3-dev openssl-dev && \
+    apk add \
+        cargo \
+        linux-headers \
+        python3-dev \
+        openssl-dev && \
     ln -sf /usr/bin/python3 /usr/bin/python && \
     curl https://bootstrap.pypa.io/get-pip.py -o ./get-pip.py --fail --silent --show-error && \
     python3 ./get-pip.py && rm ./get-pip.py && \
@@ -24,11 +28,26 @@ RUN apk update && apk add --no-cache && \
     python3 -m pip install virtualenv==20.16.5 && \
     pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
     pip install ./helix_scripts-*-py3-none-any.whl && \
-    apk del cargo linux-headers python3-dev openssl-dev
+    apk del \
+        cargo \
+        linux-headers \
+        python3-dev \
+        openssl-dev
 
 # build MsQuic as we don't have Alpine packages (yet)
 RUN apk update && apk add --no-cache && \
-    apk add cmake g++ gcc git numactl-dev linux-headers lttng-ust-dev make musl-dev openssl-dev perl && \
+    apk add \
+        cmake \
+        g++ \
+        gcc \
+        git \
+        numactl-dev \
+        linux-headers \
+        lttng-ust-dev \
+        make \
+        musl-dev \
+        openssl-dev \
+        perl && \
     cd /tmp && \
     git clone --depth 1 --single-branch --branch main --recursive https://github.com/dotnet/msquic && \
     cd msquic/src/msquic && \
@@ -44,7 +63,17 @@ RUN apk update && apk add --no-cache && \
     cmake --build build/linux/x64_openssl3  --config Release && \
     cp artifacts/bin/linux/x64_Release_openssl3/libmsquic.so.* artifacts/bin/linux/x64_Release_openssl3/libmsquic.lttng.so.* /usr/lib && \
     rm -rf /tmp/msquic && \
-    apk del cmake g++ gcc git linux-headers lttng-ust-dev make musl-dev openssl-dev perl
+    apk del \
+        cmake \
+        g++ \
+        gcc \
+        git \
+        linux-headers \
+        lttng-ust-dev \
+        make \
+        musl-dev \
+        openssl-dev \
+        perl
 
 # Needed for runtime tests to pass
 ENV LANG=en-US.UTF-8


### PR DESCRIPTION
contributes to #805
old image was ~ 2.1G 
```
mcr.microsoft.com/dotnet-buildtools/prereqs         alpine-3.17-helix-amd64-20230210201636-609d24f    67b176d4e97d   6 days ago       2.1GB
```

new one is ~ 511M and it _should_ be functionally same AFAIK. 
```
mcr.microsoft.com/dotnet-buildtools/prereqs         alpine-3.17-helix-amd64-20230217065202-7f13c75    355f491a1337   17 seconds ago   511MB
```

there few important changes:
- removed the -dev packages. They should not be needed to run tests. 
- `cargo` & `rust` pulls in `gcc`. It was needed for Helix but I don't think we need them for runtime.  
- removed dev tools from base. Instead each layer that needs needs to add (and remove) them 
- for Helix I added rust, cargo, python3-dev and few more to support building Helix support
- msquic build was refactored to don't need PowerShell.  It does not impact image size but it avoid PWSH download. 

we can save two more layers if we move `helixbot` creation to Helix prep and locale.sh to runtime deps. 
But they are really small so I'm not sure if it is worth it. 

I don't know if there is good way how to run Helix runtime tests on this. If this looks good enough, I can run draft PR on the -staging image and follow-up if needed.  

BTW it is easy to pull in bunch of random dependencies unintentionally. Perhaps PRs for Helix should have at least total size for sanity check. 

Here are the boring details 
```
furt@ubu18:~$ docker image history 355f491a1337
IMAGE          CREATED             CREATED BY                                      SIZE      COMMENT
355f491a1337   12 minutes ago      /bin/sh -c python3 -m virtualenv /home/helix…   25.1MB
183b4c3a60f3   12 minutes ago      /bin/sh -c #(nop)  USER helixbot                0B
4c151dc5296b   12 minutes ago      /bin/sh -c /usr/sbin/adduser -D -g '' -G adm…   4.7kB
97c212c288a4   12 minutes ago      /bin/sh -c echo export LANG=${LANG}  >> /etc…   85B
0ff3449aacc8   12 minutes ago      /bin/sh -c #(nop)  ENV LANG=en-US.UTF-8         0B
a63cc52005ed   12 minutes ago      /bin/sh -c apk update && apk add --no-cache …   9.02MB
9e880fe20eee   About an hour ago   /bin/sh -c apk update && apk add --no-cache …   377MB
402fc0364e2b   About an hour ago   /bin/sh -c apk update && apk add --no-cache …   93.3MB
b2aa39c304c2   6 days ago          /bin/sh -c #(nop)  CMD ["/bin/sh"]              0B
<missing>      6 days ago          /bin/sh -c #(nop) ADD file:40887ab7c06977737…   7.05MB
``` 


