### PR TITLE
update msquic for Ubuntu 22

### DIFF
--- a/src/ubuntu/22.04/helix/amd64/Dockerfile
+++ b/src/ubuntu/22.04/helix/amd64/Dockerfile
@@ -43,6 +43,33 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
     pip install ./helix_scripts-*-py3-none-any.whl
 
+# build MsQuic as we don't have binary package.
+# Ubuntu 22  does not have OpenSSL 1.1.1 package and Quic releases currently do not work with OpenSsl3
+# support for OpenSSL3 is early progress in msquic/main
+RUN apt-get update && \
+    apt-get install -qq -y libnuma-dev liblttng-ust-dev ruby-dev && \
+    gem install fpm && \
+    cd /tmp && \
+    git clone --depth 1 --single-branch --branch main --recursive https://github.com/dotnet/msquic && \
+    cd msquic/src/msquic && \
+    cmake -B build/linux/x64_openssl3 \
+        -DQUIC_OUTPUT_DIR=/tmp/msquic/src/msquic/artifacts/bin/linux/x64_Release_openssl3 \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DQUIC_TLS=openssl3 \
+        -DQUIC_ENABLE_LOGGING=true \
+        -DQUIC_USE_SYSTEM_LIBCRYPTO=true \
+        -DQUIC_BUILD_TOOLS=off \
+        -DQUIC_BUILD_TEST=off \
+        -DQUIC_BUILD_PERF=off && \
+     cmake --build build/linux/x64_openssl3  --config Release && \
+     ./scripts/make-packages.sh --tls openssl3 --config Release && \
+     dpkg -i artifacts/packages/linux/x64_Release_openssl3/libmsquic_*.deb && \
+     rm -rf /tmp/msquic && \
+     apt-get remove -y libnuma-dev liblttng-ust-dev ruby-dev && \
+     apt autoremove -y && \
+     rm -rf  /tmp/msquic && \
+     rm -rf /var/lib/apt/lists/*
+
 # create helixbot user and give rights to sudo without password
 RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm helixbot && \
     chmod 755 /root && \

--- a/src/ubuntu/22.04/helix/amd64/Dockerfile
+++ b/src/ubuntu/22.04/helix/amd64/Dockerfile
@@ -43,9 +43,9 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
     pip install ./helix_scripts-*-py3-none-any.whl
 
-# build MsQuic as we don't have binary package.
-# Ubuntu 22  does not have OpenSSL 1.1.1 package and Quic releases currently do not work with OpenSsl3
-# support for OpenSSL3 is early progress in msquic/main
+# Build MsQuic as we don't have binary package.
+# Ubuntu 22  does not have OpenSSL 1.1.1 package and MsQuic releases currently do not work with OpenSSL 3.
+# Support for OpenSSL 3 is early progress in msquic/main.
 RUN apt-get update && \
     apt-get install -qq -y libnuma-dev liblttng-ust-dev ruby-dev && \
     gem install fpm && \

--- a/src/ubuntu/22.04/helix/amd64/Dockerfile
+++ b/src/ubuntu/22.04/helix/amd64/Dockerfile
@@ -48,7 +48,6 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
 # Support for OpenSSL 3 is early progress in msquic/main.
 RUN apt-get update && \
     apt-get install -qq -y \
-        libnuma-dev \
         liblttng-ust-dev \
         ruby-dev && \
     gem install fpm && \
@@ -69,7 +68,6 @@ RUN apt-get update && \
      dpkg -i artifacts/packages/linux/x64_Release_openssl3/libmsquic_*.deb && \
      rm -rf /tmp/msquic && \
      apt-get remove -y \
-        libnuma-dev \
         liblttng-ust-dev \
         ruby-dev && \
      apt autoremove -y && \

--- a/src/ubuntu/22.04/helix/amd64/Dockerfile
+++ b/src/ubuntu/22.04/helix/amd64/Dockerfile
@@ -47,7 +47,10 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
 # Ubuntu 22  does not have OpenSSL 1.1.1 package and MsQuic releases currently do not work with OpenSSL 3.
 # Support for OpenSSL 3 is early progress in msquic/main.
 RUN apt-get update && \
-    apt-get install -qq -y libnuma-dev liblttng-ust-dev ruby-dev && \
+    apt-get install -qq -y \
+        libnuma-dev \
+        liblttng-ust-dev \
+        ruby-dev && \
     gem install fpm && \
     cd /tmp && \
     git clone --depth 1 --single-branch --branch main --recursive https://github.com/dotnet/msquic && \
@@ -65,9 +68,11 @@ RUN apt-get update && \
      ./scripts/make-packages.sh --tls openssl3 --config Release && \
      dpkg -i artifacts/packages/linux/x64_Release_openssl3/libmsquic_*.deb && \
      rm -rf /tmp/msquic && \
-     apt-get remove -y libnuma-dev liblttng-ust-dev ruby-dev && \
+     apt-get remove -y \
+        libnuma-dev \
+        liblttng-ust-dev \
+        ruby-dev && \
      apt autoremove -y && \
-     rm -rf  /tmp/msquic && \
      rm -rf /var/lib/apt/lists/*
 
 # create helixbot user and give rights to sudo without password

--- a/src/ubuntu/22.04/helix/arm64v8/Dockerfile
+++ b/src/ubuntu/22.04/helix/arm64v8/Dockerfile
@@ -52,7 +52,6 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
 # Support for OpenSSL 3 is early progress in msquic/main.
 RUN apt-get update && \
     apt-get install -qq -y \
-        libnuma-dev \
         liblttng-ust-dev \
         ruby-dev && \
     gem install fpm && \
@@ -72,8 +71,7 @@ RUN apt-get update && \
      ./scripts/make-packages.sh --tls openssl3 --config Release && \
      dpkg -i artifacts/packages/linux/arm64_Release_openssl3/libmsquic_*.deb && \
      rm -rf /tmp/msquic && \
-     apt-get remove -y
-        libnuma-dev \
+     apt-get remove -y \
         liblttng-ust-dev \
         ruby-dev && \
      apt autoremove -y && \

--- a/src/ubuntu/22.04/helix/arm64v8/Dockerfile
+++ b/src/ubuntu/22.04/helix/arm64v8/Dockerfile
@@ -47,11 +47,14 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     export CRYPTOGRAPHY_DONT_BUILD_RUST=1 && \
     pip install ./helix_scripts-*-py3-none-any.whl
 
-# build MsQuic as we don't have binary package.
-# Ubuntu 22  does not have OpenSSL 1.1.1 package and Quic releases currently do not work with OpenSsl3
-# support for OpenSSL3 is early progress in msquic/main
+#Build MsQuic as we don't have binary package.
+# Ubuntu 22  does not have OpenSSL 1.1.1 package and MsQuic releases currently do not work with OpenSSL 3.
+# Support for OpenSSL 3 is early progress in msquic/main.
 RUN apt-get update && \
-    apt-get install -qq -y libnuma-dev liblttng-ust-dev ruby-dev && \
+    apt-get install -qq -y \
+        libnuma-dev \
+        liblttng-ust-dev \
+        ruby-dev && \
     gem install fpm && \
     cd /tmp && \
     git clone --depth 1 --single-branch --branch main --recursive https://github.com/dotnet/msquic && \
@@ -69,9 +72,11 @@ RUN apt-get update && \
      ./scripts/make-packages.sh --tls openssl3 --config Release && \
      dpkg -i artifacts/packages/linux/arm64_Release_openssl3/libmsquic_*.deb && \
      rm -rf /tmp/msquic && \
-     apt-get remove -y libnuma-dev liblttng-ust-dev ruby-dev && \
+     apt-get remove -y
+        libnuma-dev \
+        liblttng-ust-dev \
+        ruby-dev && \
      apt autoremove -y && \
-     rm -rf  /tmp/msquic && \
      rm -rf /var/lib/apt/lists/*
 
 # (we use two users here to ensure volume mounting works with two possible UIDs of the host UID)

--- a/src/ubuntu/22.04/helix/arm64v8/Dockerfile
+++ b/src/ubuntu/22.04/helix/arm64v8/Dockerfile
@@ -50,18 +50,29 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
 # build MsQuic as we don't have binary package.
 # Ubuntu 22  does not have OpenSSL 1.1.1 package and Quic releases currently do not work with OpenSsl3
 # support for OpenSSL3 is early progress in msquic/main
-RUN cd /tmp && \
-    mkdir pwsh && \
-    cd pwsh && \
-    curl -LO https://github.com/PowerShell/PowerShell/releases/download/v7.2.5/powershell-7.2.5-linux-arm64.tar.gz && \
-    echo "709265A0B99232CD8AB6F8A02C01F3AEE94262B959E1A4B0FD871C8789C07396 powershell-7.2.5-linux-arm64.tar.gz" | sha256sum --check - && \
-    tar xf powershell-7.2.5-linux-arm64.tar.gz && \
-    cd .. && \
-    git clone --depth 1 --single-branch --branch main --recursive https://github.com/dotnet/msquic && \
-    cd msquic/src/msquic  &&  PATH=~/.dotnet/tools:$PATH /tmp/pwsh/pwsh scripts/build.ps1 -arch arm64 -Config Release -DisableTools -DisableTest -DisablePerf -UseSystemOpenSSLCrypto && \
-    cp artifacts/bin/linux/arm64_Release_openssl3/libmsquic.so.2 artifacts/bin/linux/arm64_Release_openssl3/libmsquic.lttng.so.2.2.0 /usr/lib/aarch64-linux-gnu && \
+RUN apt-get update && \
+    apt-get install -qq -y libnuma-dev liblttng-ust-dev ruby-dev && \
+    gem install fpm && \
     cd /tmp && \
-    rm -r pwsh msquic
+    git clone --depth 1 --single-branch --branch main --recursive https://github.com/dotnet/msquic && \
+    cd msquic/src/msquic && \
+    cmake -B build/linux/arm64_openssl3 \
+        -DQUIC_OUTPUT_DIR=/tmp/msquic/src/msquic/artifacts/bin/linux/arm64_Release_openssl3 \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DQUIC_TLS=openssl3 \
+        -DQUIC_ENABLE_LOGGING=true \
+        -DQUIC_USE_SYSTEM_LIBCRYPTO=true \
+        -DQUIC_BUILD_TOOLS=off \
+        -DQUIC_BUILD_TEST=off \
+        -DQUIC_BUILD_PERF=off && \
+     cmake --build build/linux/arm64_openssl3  --config Release && \
+     ./scripts/make-packages.sh --tls openssl3 --config Release && \
+     dpkg -i artifacts/packages/linux/arm64_Release_openssl3/libmsquic_*.deb && \
+     rm -rf /tmp/msquic && \
+     apt-get remove -y libnuma-dev liblttng-ust-dev ruby-dev && \
+     apt autoremove -y && \
+     rm -rf  /tmp/msquic && \
+     rm -rf /var/lib/apt/lists/*
 
 # (we use two users here to ensure volume mounting works with two possible UIDs of the host UID)
 RUN adduser --disabled-password --gecos '' --uid 1001 --shell /bin/bash --ingroup adm helixbot && \


### PR DESCRIPTION
This brings current msquic to both x64 & arm64. 
We use OpenSSL 3 using `UseSystemOpenSSLCrypto`

Aside from that there are two more changes:
- drop PowerShell and build directly using cmake
- build and install package instead of file copy. That will hopefully make it closer to final production.