### PR TITLE
add icu-libs to Alpine 3.17

### DIFF
--- a/src/alpine/3.17/helix/amd64/Dockerfile
+++ b/src/alpine/3.17/helix/amd64/Dockerfile
@@ -5,6 +5,7 @@ RUN apk update && apk add --no-cache \
     coreutils \
     curl \
     icu-data-full \
+    icu-libs \
     iputils \
     lldb \
     lttng-ust \


### PR DESCRIPTION
miss that one during refactor. It was probably pulled in as indirect dependency.