### PR TITLE
Set main to push non-staging tags

### DIFF
--- a/eng/pipelines/variables/common.yml
+++ b/eng/pipelines/variables/common.yml
@@ -20,7 +20,7 @@ variables:
     value: ""
 - ${{ elseif eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
   - name: floatingTagSuffix
-    value: -staging
+    value: ""
 - ${{ else }}:
   - name: floatingTagSuffix
     value: $(Build.SourceBranchName)

--- a/eng/pipelines/variables/common.yml
+++ b/eng/pipelines/variables/common.yml
@@ -16,6 +16,8 @@ variables:
 - name: publicGitRepoUri
   value: https://github.com/dotnet/dotnet-buildtools-prereqs-docker
 - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/production') }}:
+  # See https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/814 for why the value for this is blank.
+  # If/When we get back to flowing changes to production, we will want to change this back to -staging
   - name: floatingTagSuffix
     value: ""
 - ${{ elseif eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:


### PR DESCRIPTION
Since we will not be doing rollouts to production for a while, and we don't want to hold back product teams, make the main branch push the non-staging (aka production) tags.