### PR TITLE
Use same rootfs in Ubuntu 22 cross arm64 as 18

### DIFF
--- a/src/ubuntu/22.04/cross/arm64/Dockerfile
+++ b/src/ubuntu/22.04/cross/arm64/Dockerfile
@@ -1,3 +1,9 @@
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps-local
 
+# Install binutils-aarch64-linux-gnu
+RUN apt-get update \
+    && apt-get install -y \
+        binutils-aarch64-linux-gnu \
+    && rm -rf /var/lib/apt/lists/*
+
 ADD rootfs.arm64.tar crossrootfs

--- a/src/ubuntu/22.04/cross/arm64/hooks/pre-build
+++ b/src/ubuntu/22.04/cross/arm64/hooks/pre-build
@@ -2,4 +2,4 @@
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
-$SCRIPTPATH/../../../../build-scripts/run-arcade-build-rootfs.sh ubuntu-22.04 jammy arm64 lldb14
+$SCRIPTPATH/../../../../build-scripts/run-arcade-build-rootfs.sh ubuntu-22.04 xenial arm64 lldb3.9


### PR DESCRIPTION
We need to keep this to lowest for portability.