### PR TITLE
update Alpine 3.15 Helix images

### DIFF
--- a/src/alpine/3.15/helix/amd64/Dockerfile
+++ b/src/alpine/3.15/helix/amd64/Dockerfile
@@ -1,34 +1,86 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.15-local
+FROM alpine:3.15
+# Install .NET and test dependencies
 RUN apk update && apk add --no-cache \
-    cargo \
+    bash \
+    coreutils \
+    curl \
+    icu-data-full \
+    icu-libs \
     iputils \
-    libffi-dev \
-    rust
+    lldb \
+    lttng-ust \
+    musl-locales \
+    openssl \
+    python3 \
+    sudo \
+    tzdata
 
 # Install Helix Dependencies
-
-RUN ln -sf /usr/bin/python3 /usr/bin/python && \
+RUN apk update && apk add --no-cache && \
+    apk add \
+        cargo \
+        libffi-dev \
+        linux-headers \
+        python3-dev \
+        openssl-dev && \
+    ln -sf /usr/bin/python3 /usr/bin/python && \
     curl https://bootstrap.pypa.io/get-pip.py -o ./get-pip.py --fail --silent --show-error && \
-    python ./get-pip.py && rm ./get-pip.py && \
-    python -m pip install --upgrade pip==21.2.4 && \
-    python -m pip install virtualenv==16.6.0 && \
+    python3 ./get-pip.py && rm ./get-pip.py && \
+    python3 -m pip install --upgrade pip==22.2.2 && \
+    python3 -m pip install virtualenv==20.16.5 && \
     pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    pip install ./helix_scripts-*-py3-none-any.whl
+    pip install ./helix_scripts-*-py3-none-any.whl && \
+    apk del \
+        cargo \
+        libffi-dev \
+        linux-headers \
+        python3-dev \
+        openssl-dev
 
-# build MsQuic as we don't have packages
-RUN cd /tmp && \
-    mkdir pwsh && \
-    cd pwsh && \
-    curl -L https://github.com/PowerShell/PowerShell/releases/download/v7.2.5/powershell-7.2.5-linux-alpine-x64.tar.gz | tar xfz - && \
-    cd .. && \
-    git clone --depth 1 --single-branch --branch main --recursive https://github.com/dotnet/msquic && \
-    cd msquic/src/msquic  &&  PATH=~/.dotnet/tools:$PATH /tmp/pwsh/pwsh scripts/build.ps1 -Config Release -UseSystemOpenSSLCrypto -DisableTools -DisableTest -DisablePerf && \
-    cp artifacts/bin/linux/x64_Release_openssl/libmsquic.so.2 artifacts/bin/linux/x64_Release_openssl/libmsquic.lttng.so.2.* /usr/lib && \
+# build MsQuic as we don't have Alpine packages (yet)
+RUN apk update && apk add --no-cache && \
+    apk add \
+        cmake \
+        g++ \
+        gcc \
+        git \
+        numactl-dev \
+        linux-headers \
+        lttng-ust-dev \
+        make \
+        musl-dev \
+        openssl-dev \
+        perl && \
     cd /tmp && \
-    rm -r pwsh msquic
+    git clone --depth 1 --single-branch --branch main --recursive https://github.com/dotnet/msquic && \
+    cd msquic/src/msquic && \
+    cmake -B build/linux/x64_openssl \
+       -DQUIC_OUTPUT_DIR=/tmp/msquic/src/msquic/artifacts/bin/linux/x64_Release_openssl \
+       -DCMAKE_BUILD_TYPE=Release \
+       -DQUIC_TLS=openssl \
+       -DQUIC_ENABLE_LOGGING=true \
+       -DQUIC_USE_SYSTEM_LIBCRYPTO=true \
+       -DQUIC_BUILD_TOOLS=off \
+       -DQUIC_BUILD_TEST=off \
+       -DQUIC_BUILD_PERF=off && \
+    cmake --build build/linux/x64_openssl  --config Release && \
+    cp artifacts/bin/linux/x64_Release_openssl/libmsquic.so.* artifacts/bin/linux/x64_Release_openssl/libmsquic.lttng.so.* /usr/lib && \
+    rm -rf /tmp/msquic && \
+    apk del \
+        cmake \
+        g++ \
+        gcc \
+        git \
+        linux-headers \
+        lttng-ust-dev \
+        make \
+        musl-dev \
+        openssl-dev \
+        perl
 
-# Needed for corefx tests to pass
+# Needed for runtime tests to pass
 ENV LANG=en-US.UTF-8
+RUN echo export LANG=${LANG}  >> /etc/profile.d/locale.sh
 
 # create helixbot user and give rights to sudo without password
 # Alpine does not support long options
@@ -38,4 +90,4 @@ RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
 
 USER helixbot
 
-RUN python -m virtualenv --no-site-packages /home/helixbot/.vsts-env
+RUN python3 -m virtualenv /home/helixbot/.vsts-env

--- a/src/alpine/3.15/helix/amd64/Dockerfile
+++ b/src/alpine/3.15/helix/amd64/Dockerfile
@@ -4,7 +4,7 @@ RUN apk update && apk add --no-cache \
     bash \
     coreutils \
     curl \
-    icu-data-full \
+    icu-data \
     icu-libs \
     iputils \
     lldb \

--- a/src/alpine/3.15/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.15/helix/arm32v7/Dockerfile
@@ -86,7 +86,7 @@ RUN echo export LANG=${LANG}  >> /etc/profile.d/locale.sh
 
 # create helixbot user and give rights to sudo without password
 # Alpine does not support long options
-RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
+RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1001 helixbot && \
     /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot2 && \
     chmod 755 /root && \
     echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot && \

--- a/src/alpine/3.15/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.15/helix/arm32v7/Dockerfile
@@ -90,7 +90,7 @@ RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
     /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot2 && \
     chmod 755 /root && \
     echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot && \
-    echo "helixbot2 ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/helixbot2
+    echo "helixbot2 ALL=(ALL)      NOPASSWD: ALL" > /etc/sudoers.d/helixbot2
 
 USER helixbot
 

--- a/src/alpine/3.15/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.15/helix/arm32v7/Dockerfile
@@ -1,68 +1,97 @@
-FROM alpine:3.15
-
-RUN apk update && \
-    apk add --no-cache \
-        autoconf \
-        automake \
-        bash \
-        build-base \
-        cargo \
-        clang \
-        clang-dev \
-        cmake \
-        coreutils \
-        curl \
-        gcc \
-        gettext-dev \
-        git \
-        icu-dev \
-        iputils \
-        jq \
-        krb5-dev \
-        libtool \
-        libunwind-dev \
-        libffi-dev \
-        linux-headers \
-        llvm \
-        lttng-ust-dev \
-        make \
-        numactl-dev \
-        openssl \
-        openssl-dev \
-        paxctl \
-        py-cffi \
-        python3-dev \
-        sudo \
-        tzdata \
-        util-linux-dev \
-        wget \
-        zlib-dev
+FROM arm32v7/alpine:3.15
+# Install .NET and test dependencies
+RUN apk update && apk add --no-cache \
+    bash \
+    coreutils \
+    curl \
+    icu-data-full \
+    icu-libs \
+    iputils \
+    krb5-libs \
+    lldb \
+    lttng-ust \
+    musl-locales \
+    openssl \
+    python3 \
+    sudo \
+    tzdata
 
 # Install Helix Dependencies
-
-# Workaround: https://github.com/pypa/wheel/issues/367
-ENV _PYTHON_HOST_PLATFORM=linux_armv7l
-
-RUN ln -sf /usr/bin/python3 /usr/bin/python && \
+RUN apk update && apk add --no-cache && \
+    apk add \
+        cargo \
+        libffi-dev \
+        linux-headers \
+        python3-dev \
+        openssl-dev && \
+    ln -sf /usr/bin/python3 /usr/bin/python && \
     curl https://bootstrap.pypa.io/get-pip.py -o ./get-pip.py --fail --silent --show-error && \
-    python ./get-pip.py && rm ./get-pip.py && \
-    python -m pip install --upgrade pip==21.2.4 && \
-    python -m pip install virtualenv==16.6.0 && \
+    python3 ./get-pip.py && rm ./get-pip.py && \
+    python3 -m pip install --upgrade pip==22.2.2 && \
+    python3 -m pip install virtualenv==20.16.5 && \
     pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    pip install ./helix_scripts-*-py3-none-any.whl
+    pip install ./helix_scripts-*-py3-none-any.whl && \
+    apk del \
+        cargo \
+        libffi-dev \
+        linux-headers \
+        python3-dev \
+        openssl-dev
 
-# Needed for corefx tests to pass
+# build MsQuic as we don't have Alpine packages (yet)
+RUN apk update && apk add --no-cache && \
+    apk add \
+        cmake \
+        g++ \
+        gcc \
+        git \
+        numactl-dev \
+        linux-headers \
+        lttng-ust-dev \
+        make \
+        musl-dev \
+        openssl-dev \
+        perl && \
+    cd /tmp && \
+    git clone --depth 1 --single-branch --branch main --recursive https://github.com/dotnet/msquic && \
+    cd msquic/src/msquic && \
+    cmake -B build/linux/arm_openssl \
+       -DQUIC_OUTPUT_DIR=/tmp/msquic/src/msquic/artifacts/bin/linux/arm_Release_openssl \
+       -DCMAKE_BUILD_TYPE=Release \
+       -DCMAKE_TARGET_ARCHITECTURE=arm \
+       -DQUIC_TLS=openssl \
+       -DQUIC_ENABLE_LOGGING=true \
+       -DQUIC_USE_SYSTEM_LIBCRYPTO=true \
+       -DQUIC_BUILD_TOOLS=off \
+       -DQUIC_BUILD_TEST=off \
+       -DQUIC_BUILD_PERF=off && \
+    cmake --build build/linux/arm_openssl  --config Release && \
+    cp artifacts/bin/linux/arm_Release_openssl/libmsquic.so.* artifacts/bin/linux/arm_Release_openssl/libmsquic.lttng.so.* /usr/lib && \
+    rm -rf /tmp/msquic && \
+    apk del \
+        cmake \
+        g++ \
+        gcc \
+        git \
+        linux-headers \
+        lttng-ust-dev \
+        make \
+        musl-dev \
+        openssl-dev \
+        perl
+
+# Needed for runtime tests to pass
 ENV LANG=en-US.UTF-8
+RUN echo export LANG=${LANG}  >> /etc/profile.d/locale.sh
 
 # create helixbot user and give rights to sudo without password
-# (we use two users here to ensure volume mounting works with two possible UIDs of the host UID)
 # Alpine does not support long options
-RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1001 helixbot && \
+RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
     /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot2 && \
     chmod 755 /root && \
     echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot && \
-    echo "helixbot2 ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot2
+    echo "helixbot2 ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/helixbot2
 
 USER helixbot
 
-RUN python -m virtualenv --no-site-packages /home/helixbot/.vsts-env
+RUN python3 -m virtualenv /home/helixbot/.vsts-env

--- a/src/alpine/3.15/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.15/helix/arm32v7/Dockerfile
@@ -4,7 +4,7 @@ RUN apk update && apk add --no-cache \
     bash \
     coreutils \
     curl \
-    icu-data-full \
+    icu-data \
     icu-libs \
     iputils \
     krb5-libs \

--- a/src/alpine/3.15/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.15/helix/arm64v8/Dockerfile
@@ -1,65 +1,96 @@
-FROM alpine:3.15
+FROM arm64v8/alpine:3.15
+# Install .NET and test dependencies
+RUN apk update && apk add --no-cache \
+    bash \
+    coreutils \
+    curl \
+    icu-data-full \
+    icu-libs \
+    iputils \
+    krb5-libs \
+    lldb \
+    lttng-ust \
+    musl-locales \
+    openssl \
+    python3 \
+    sudo \
+    tzdata
 
-RUN apk update && \
-    apk add --no-cache \
-        autoconf \
-        automake \
-        bash \
-        build-base \
+RUN apk update && apk add --no-cache && \
+    apk add \
         cargo \
-        clang \
-        clang-dev \
-        cmake \
-        coreutils \
-        curl \
-        gcc \
-        gettext-dev \
-        git \
-        icu-dev \
-        iputils \
-        jq \
-        krb5-dev \
-        libtool \
-        libunwind-dev \
         libffi-dev \
         linux-headers \
-        llvm \
+        python3-dev \
+        openssl-dev && \
+    ln -sf /usr/bin/python3 /usr/bin/python && \
+    curl https://bootstrap.pypa.io/get-pip.py -o ./get-pip.py --fail --silent --show-error && \
+    python3 ./get-pip.py && rm ./get-pip.py && \
+    python3 -m pip install --upgrade pip==22.2.2 && \
+    python3 -m pip install virtualenv==20.16.5 && \
+    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    pip install ./helix_scripts-*-py3-none-any.whl && \
+    apk del \
+        cargo \
+        libffi-dev \
+        linux-headers \
+        python3-dev \
+        openssl-dev
+
+# build MsQuic as we don't have Alpine packages (yet)
+RUN apk update && apk add --no-cache && \
+    apk add \
+        cmake \
+        g++ \
+        gcc \
+        git \
+        numactl-dev \
+        linux-headers \
         lttng-ust-dev \
         make \
-        numactl-dev \
-        openssl \
+        musl-dev \
         openssl-dev \
-        paxctl \
-        py-cffi \
-        python3-dev \
-        sudo \
-        tzdata \
-        util-linux-dev \
-        wget \
-        zlib-dev
+        perl && \
+    cd /tmp && \
+    git clone --depth 1 --single-branch --branch main --recursive https://github.com/dotnet/msquic && \
+    cd msquic/src/msquic && \
+    cmake -B build/linux/arm64_openssl3 \
+       -DQUIC_OUTPUT_DIR=/tmp/msquic/src/msquic/artifacts/bin/linux/arm64_Release_openssl3 \
+       -DCMAKE_BUILD_TYPE=Release \
+       -DCMAKE_TARGET_ARCHITECTURE=arm64 \
+       -DQUIC_TLS=openssl \
+       -DQUIC_ENABLE_LOGGING=true \
+       -DQUIC_USE_SYSTEM_LIBCRYPTO=true \
+       -DQUIC_BUILD_TOOLS=off \
+       -DQUIC_BUILD_TEST=off \
+       -DQUIC_BUILD_PERF=off && \
+    cmake --build build/linux/arm64_openssl  --config Release && \
+    cp artifacts/bin/linux/arm64_Release_openssl/libmsquic.so.* artifacts/bin/linux/arm64_Release_openssl/libmsquic.lttng.so.* /usr/lib && \
+    rm -rf /tmp/msquic && \
+    apk del \
+        cmake \
+        g++ \
+        gcc \
+        git \
+        linux-headers \
+        lttng-ust-dev \
+        make \
+        musl-dev \
+        openssl-dev \
+        perl
 
-# Install Helix Dependencies
-
-RUN ln -sf /usr/bin/python3 /usr/bin/python && \
-    curl https://bootstrap.pypa.io/get-pip.py -o ./get-pip.py --fail --silent --show-error && \
-    python ./get-pip.py && rm ./get-pip.py && \
-    python -m pip install --upgrade pip==21.2.4 && \
-    python -m pip install virtualenv==16.6.0 && \
-    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    pip install ./helix_scripts-*-py3-none-any.whl
-
-# Needed for corefx tests to pass
+# Needed for runtime tests to pass
 ENV LANG=en-US.UTF-8
+RUN echo export LANG=${LANG}  >> /etc/profile.d/locale.sh
 
 # create helixbot user and give rights to sudo without password
-# (we use two users here to ensure volume mounting works with two possible UIDs of the host UID)
 # Alpine does not support long options
-RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1001 helixbot && \
+RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
     /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot2 && \
     chmod 755 /root && \
-    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot && \
-    echo "helixbot2 ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot2
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot &&  \
+    echo "helixbot2 ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/helixbot2
 
 USER helixbot
 
-RUN python -m virtualenv --no-site-packages /home/helixbot/.vsts-env
+RUN python3 -m virtualenv /home/helixbot/.vsts-env

--- a/src/alpine/3.15/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.15/helix/arm64v8/Dockerfile
@@ -89,7 +89,7 @@ RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
     /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot2 && \
     chmod 755 /root && \
     echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot &&  \
-    echo "helixbot2 ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/helixbot2
+    echo "helixbot2 ALL=(ALL)      NOPASSWD: ALL" > /etc/sudoers.d/helixbot2
 
 USER helixbot
 

--- a/src/alpine/3.15/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.15/helix/arm64v8/Dockerfile
@@ -85,7 +85,7 @@ RUN echo export LANG=${LANG}  >> /etc/profile.d/locale.sh
 
 # create helixbot user and give rights to sudo without password
 # Alpine does not support long options
-RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
+RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1001 helixbot && \
     /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot2 && \
     chmod 755 /root && \
     echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot &&  \

--- a/src/alpine/3.15/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.15/helix/arm64v8/Dockerfile
@@ -54,8 +54,8 @@ RUN apk update && apk add --no-cache && \
     cd /tmp && \
     git clone --depth 1 --single-branch --branch main --recursive https://github.com/dotnet/msquic && \
     cd msquic/src/msquic && \
-    cmake -B build/linux/arm64_openssl3 \
-       -DQUIC_OUTPUT_DIR=/tmp/msquic/src/msquic/artifacts/bin/linux/arm64_Release_openssl3 \
+    cmake -B build/linux/arm64_openssl \
+       -DQUIC_OUTPUT_DIR=/tmp/msquic/src/msquic/artifacts/bin/linux/arm64_Release_openssl \
        -DCMAKE_BUILD_TYPE=Release \
        -DCMAKE_TARGET_ARCHITECTURE=arm64 \
        -DQUIC_TLS=openssl \

--- a/src/alpine/3.15/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.15/helix/arm64v8/Dockerfile
@@ -4,7 +4,7 @@ RUN apk update && apk add --no-cache \
     bash \
     coreutils \
     curl \
-    icu-data-full \
+    icu-data \
     icu-libs \
     iputils \
     krb5-libs \

--- a/src/alpine/3.17/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.17/helix/arm32v7/Dockerfile
@@ -86,7 +86,7 @@ RUN echo export LANG=${LANG}  >> /etc/profile.d/locale.sh
 
 # create helixbot user and give rights to sudo without password
 # Alpine does not support long options
-RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
+RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1001 helixbot && \
     /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot2 && \
     chmod 755 /root && \
     echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot && \

--- a/src/alpine/3.17/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.17/helix/arm32v7/Dockerfile
@@ -90,7 +90,7 @@ RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
     /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot2 && \
     chmod 755 /root && \
     echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot && \
-    echo "helixbot2 ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/helixbot2
+    echo "helixbot2 ALL=(ALL)      NOPASSWD: ALL" > /etc/sudoers.d/helixbot2
 
 
 USER helixbot

--- a/src/alpine/3.17/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.17/helix/arm32v7/Dockerfile
@@ -87,8 +87,11 @@ RUN echo export LANG=${LANG}  >> /etc/profile.d/locale.sh
 # create helixbot user and give rights to sudo without password
 # Alpine does not support long options
 RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
+    /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot2 && \
     chmod 755 /root && \
-    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot && \
+    echo "helixbot2 ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/helixbot2
+
 
 USER helixbot
 

--- a/src/alpine/3.17/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.17/helix/arm64v8/Dockerfile
@@ -89,7 +89,7 @@ RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
     /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot2 && \
     chmod 755 /root && \
     echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot && \
-    echo "helixbot2 ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/helixbot2
+    echo "helixbot2 ALL=(ALL)      NOPASSWD: ALL" > /etc/sudoers.d/helixbot2
 
 USER helixbot
 

--- a/src/alpine/3.17/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.17/helix/arm64v8/Dockerfile
@@ -86,8 +86,10 @@ RUN echo export LANG=${LANG}  >> /etc/profile.d/locale.sh
 # create helixbot user and give rights to sudo without password
 # Alpine does not support long options
 RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
+    /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot2 && \
     chmod 755 /root && \
-    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot && \
+    echo "helixbot2 ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/helixbot2
 
 USER helixbot
 

--- a/src/alpine/3.17/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.17/helix/arm64v8/Dockerfile
@@ -85,7 +85,7 @@ RUN echo export LANG=${LANG}  >> /etc/profile.d/locale.sh
 
 # create helixbot user and give rights to sudo without password
 # Alpine does not support long options
-RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
+RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1001 helixbot && \
     /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot2 && \
     chmod 755 /root && \
     echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot && \


### PR DESCRIPTION
This brings back changes from Alpine 3.17. (after practicing with it)
This is going to be main Alpine Helix as current 3.14 is EOS soon. 
It is essentially same as 3.17 with exception of OpenSSL. 
3.15 is still on 1.1 e.g. fully supported and stable.    

I added `helixbot2` added originally in #725 and missed in new ARM images. 

https://github.com/dotnet/runtime/pull/82660 has some preliminary runs on the updated structure