### PR TITLE
Add krb5-libs to AMD64 Alpine 3.15 image

### DIFF
--- a/src/alpine/3.15/helix/amd64/Dockerfile
+++ b/src/alpine/3.15/helix/amd64/Dockerfile
@@ -7,6 +7,7 @@ RUN apk update && apk add --no-cache \
     icu-data \
     icu-libs \
     iputils \
+    krb5-libs \
     lldb \
     lttng-ust \
     musl-locales \


### PR DESCRIPTION
The AMD64 Alpine 3.15 image was missing `krb5-libs`. I confirmed that the ARM32 and ARM64  images had the package.

Fixes https://github.com/dotnet/runtime/issues/82945

/cc @wfurt 