### PR TITLE
update mariner to msquic 2.1.8

### DIFF
--- a/src/cbl-mariner/2.0/helix/amd64/Dockerfile
+++ b/src/cbl-mariner/2.0/helix/amd64/Dockerfile
@@ -18,13 +18,17 @@ RUN tdnf install --setopt tsflags=nodocs --refresh -y \
 # Install MsQuic - hack until packages are pushes to mariner repository
 # When that is done, this should go to section above.
 # Mariner already has MS repos and signing keys.
-RUN rpm -i https://packages.microsoft.com/centos/7/prod/libmsquic-2.1.4-1.x86_64.rpm
+RUN echo '[packages.microsoft.com_centos_7_prod]' > /etc/yum.repos.d/packages.microsoft.com_centos_7_prod.repo && \
+    echo 'name=Centos 7 MS repo' >>  /etc/yum.repos.d/packages.microsoft.com_centos_7_prod.repo && \
+    echo 'baseurl=https://packages.microsoft.com/centos/7/prod/' >> /etc/yum.repos.d/packages.microsoft.com_centos_7_prod.repo && \
+    echo 'enabled=1' >> /etc/yum.repos.d/packages.microsoft.com_centos_7_prod.repo && \
+    tdnf install --setopt tsflags=nodocs --refresh -y libmsquic
 
 RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     python -m pip install --upgrade pip==21.1.2 && \
     python -m pip install virtualenv==16.6.0 && \
     python -m pip install --upgrade setuptools && \
-    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \ 
+    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
     pip install ./helix_scripts-*-py3-none-any.whl && \
     rm ./helix_scripts-*-py3-none-any.whl
 


### PR DESCRIPTION
I added repo instead of specific rpm so we can get automatic updates (until MsQuic adds packages for Mariner)

```
Refreshing metadata for: 'CBL-Mariner Official Microsoft 2.0 x86_64'
Refreshing metadata for: 'CBL-Mariner Official Extras 2.0 x86_64'
Refreshing metadata for: 'CBL-Mariner Official Base 2.0 x86_64'
Refreshing metadata for: 'Centos 7 MS repo'

Installing:
libmsquic                x86_64       2.1.8-1          packages.microsoft.com_centos_7_prod  15.73M 16495240

Total installed size:  15.73M 16495240

Downloading:

Testing transaction
Running transaction
Installing/Updating: libmsquic-2.1.8-1.x86_64

Complete!

```