### PR TITLE
update MsQuic on Debian ARM32 and OpenSUSE

### DIFF
--- a/src/debian/10/helix/arm32v7/Dockerfile
+++ b/src/debian/10/helix/arm32v7/Dockerfile
@@ -47,10 +47,13 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     pip install ./helix_scripts-*-py3-none-any.whl
 
 # Add MsQuic
-# There is problem with posting, use direct link instead. (signed binaries)
-RUN curl -LO https://github.com/microsoft/msquic/releases/download/v2.1.2/libmsquic_2.1.2_armhf.deb && \
-    dpkg -i libmsquic_2.*.deb && \
-    rm libmsquic_2.*.deb
+RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
+    echo 2cfd20a306b2fa5e25522d78f2ef50a1f429d35fd30bd983e2ebffc2b80944fa microsoft.asc| sha256sum --check - && \
+    apt-key add microsoft.asc && \
+    apt-add-repository https://packages.microsoft.com/debian/10/prod && \
+    apt-get update && \
+    apt-get install libmsquic && \
+    rm -rf /var/lib/apt/lists/* microsoft.asc
 
 # Create helixbot user and give rights to sudo without password
 # (we use two users here to ensure volume mounting works with two possible UIDs of the host UID)

--- a/src/debian/10/helix/arm32v7/Dockerfile
+++ b/src/debian/10/helix/arm32v7/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update && \
         procps \
         python3-dev \
         python3-pip \
+        software-properties-common \
         sudo \
         tzdata \
         unzip \

--- a/src/debian/11/helix/arm32v7/Dockerfile
+++ b/src/debian/11/helix/arm32v7/Dockerfile
@@ -36,10 +36,14 @@ RUN apt-get update && \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
 # Add MsQuic
-# There is problem with posting, use direct link instead. (signed binaries)
-RUN curl -LO https://github.com/microsoft/msquic/releases/download/v2.1.2/libmsquic_2.1.2_armhf.deb && \
-    dpkg -i libmsquic_2.*.deb && \
-    rm libmsquic_2.*.deb
+RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
+    echo 2cfd20a306b2fa5e25522d78f2ef50a1f429d35fd30bd983e2ebffc2b80944fa microsoft.asc| sha256sum --check - && \
+    apt-key add microsoft.asc && \
+    rm microsoft.asc && \
+    apt-add-repository https://packages.microsoft.com/debian/11/prod && \
+    apt-get update && \
+    apt-get install -y libmsquic && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV LANG=en_US.utf8
 

--- a/src/opensuse/15.2/helix/amd64/Dockerfile
+++ b/src/opensuse/15.2/helix/amd64/Dockerfile
@@ -40,7 +40,8 @@ RUN wget https://packages.microsoft.com/keys/microsoft.asc && \
     echo 2cfd20a306b2fa5e25522d78f2ef50a1f429d35fd30bd983e2ebffc2b80944fa microsoft.asc | sha256sum --check - && \
     rpm --import microsoft.asc && \
     rm microsoft.asc && \
-    zypper install -y https://github.com/microsoft/msquic/releases/download/v2.1.1/libmsquic-2.1.1-1.x86_64.rpm && \
+    zypper addrepo https://packages.microsoft.com/opensuse/15/prod/ "MS Packages" && \
+    zypper install -y libmsquic && \
     zypper clean -a
 
 RUN ln -sf /usr/bin/python3 /usr/bin/python && \


### PR DESCRIPTION
- arm32 posting was fixed by MsQuic -> we can now use package manager to get 2.1.8 and future updates. 
- OpenSUSE now has package posted as well. 
```
Adding repository 'MS Packages' [......done]
Repository 'MS Packages' successfully added

URI         : https://packages.microsoft.com/opensuse/15/prod/
Enabled     : Yes
GPG Check   : Yes
Autorefresh : No
Priority    : 99 (default priority)

1 new package to install.
Overall download size: 3.9 MiB. Already cached: 0 B. After the operation, additional 15.7 MiB will be used.
Continue? [y/n/v/...? shows all options] (y): y
Retrieving package libmsquic-2.1.8-1.x86_64 (1/1),   3.9 MiB ( 15.7 MiB unpacked)
Retrieving: libmsquic-2.1.8-1.x86_64.rpm [........done (815.3 KiB/s)]

Checking for file conflicts: [...done]
(1/1) Installing: libmsquic-2.1.8-1.x86_64 [............done]
```