### PR TITLE
Add 'su' to mariner images

### DIFF
--- a/src/cbl-mariner/2.0/crossdeps/Dockerfile
+++ b/src/cbl-mariner/2.0/crossdeps/Dockerfile
@@ -2,6 +2,8 @@ FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
 
 RUN tdnf update -y && \
     tdnf install -y \
+        # Provides 'su', required by Azure DevOps
+        util-linux \
         wget \
         ca-certificates \
         git \


### PR DESCRIPTION
Builds are failing in Azure Pipelines during the "Initialize containers" step with:
```
##[error]Docker-exec executed: `su -c "echo '%azure_pipelines_sudo ALL=(ALL:ALL) NOPASSWD:ALL' >> /etc/sudoers"`; container id: `2f0b84690195e3b89ee553a19e665382f3ead9d90376bf2062087b08f5a309e0`; exit code: `126`; command output: `OCI runtime exec failed: exec failed: unable to start container process: exec: "su": executable file not found in $PATH: unknown`
```

(see https://github.com/dotnet/runtime/pull/84148)

Contributes to https://github.com/dotnet/runtime/issues/83428