### PR TITLE
Add arm mariner build images

### DIFF
--- a/src/cbl-mariner/2.0/cross/arm-alpine/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/arm-alpine/Dockerfile
@@ -1,0 +1,22 @@
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder-local AS builder
+ARG ROOTFS_DIR=/crossrootfs/arm
+
+RUN /scripts/eng/common/cross/build-rootfs.sh arm alpine3.13 --skipunmount
+
+# Add numa headers (numactl-dev is not available on Alpine 3.13 arm)
+# 2.0.14 matches the version available on Alpine 3.13 amd64.
+RUN NUMACTL_VERSION=2.0.14 && \
+    wget -O numactl.tar.gz https://github.com/numactl/numactl/archive/v${NUMACTL_VERSION}.tar.gz && \
+    echo "1ee27abd07ff6ba140aaf9bc6379b37825e54496e01d6f7343330cf1a4487035 numactl.tar.gz" | sha256sum -c && \
+    mkdir numactl && \
+    tar -xf numactl.tar.gz --directory numactl --strip-components=1 && \
+    rm numactl.tar.gz && \
+    cd numactl && \
+    mkdir $ROOTFS_DIR/usr/local/include/ && \
+    cp numacompat1.h numa.h numaif.h $ROOTFS_DIR/usr/local/include/
+
+
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-arm-local
+ARG ROOTFS_DIR=/crossrootfs/arm
+
+COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR

--- a/src/cbl-mariner/2.0/cross/arm-alpine/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/arm-alpine/Dockerfile
@@ -3,18 +3,6 @@ ARG ROOTFS_DIR=/crossrootfs/arm
 
 RUN /scripts/eng/common/cross/build-rootfs.sh arm alpine3.13 --skipunmount
 
-# Add numa headers (numactl-dev is not available on Alpine 3.13 arm)
-# 2.0.14 matches the version available on Alpine 3.13 amd64.
-RUN NUMACTL_VERSION=2.0.14 && \
-    wget -O numactl.tar.gz https://github.com/numactl/numactl/archive/v${NUMACTL_VERSION}.tar.gz && \
-    echo "1ee27abd07ff6ba140aaf9bc6379b37825e54496e01d6f7343330cf1a4487035 numactl.tar.gz" | sha256sum -c && \
-    mkdir numactl && \
-    tar -xf numactl.tar.gz --directory numactl --strip-components=1 && \
-    rm numactl.tar.gz && \
-    cd numactl && \
-    mkdir $ROOTFS_DIR/usr/local/include/ && \
-    cp numacompat1.h numa.h numaif.h $ROOTFS_DIR/usr/local/include/
-
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-arm-local
 ARG ROOTFS_DIR=/crossrootfs/arm

--- a/src/cbl-mariner/2.0/cross/arm/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/arm/Dockerfile
@@ -33,17 +33,6 @@ RUN LLVM_VERSION=12.0.1 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" && \
     mkdir -p $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     cp compiler-rt_build/lib/linux/libclang_rt.profile-armhf.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/
 
-# Add numa headers (libnuma-dev is not available on Ubuntu Xenial arm)
-# 2.0.11 matches the version available on Ubuntu Xenial amd64.
-RUN NUMACTL_VERSION=2.0.11 && \
-    wget -O numactl.tar.gz https://github.com/numactl/numactl/archive/v${NUMACTL_VERSION}.tar.gz && \
-    echo "3e099a59b2c527bcdbddd34e1952ca87462d2cef4c93da9b0bc03f02903f7089 numactl.tar.gz" | sha256sum -c && \
-    mkdir numactl && \
-    tar -xf numactl.tar.gz --directory numactl --strip-components=1 && \
-    rm numactl.tar.gz && \
-    cd numactl && \
-    cp numacompat1.h numa.h numaif.h $ROOTFS_DIR/usr/local/include/
-
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-arm-local
 ARG ROOTFS_DIR=/crossrootfs/arm

--- a/src/cbl-mariner/2.0/cross/arm/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/arm/Dockerfile
@@ -1,0 +1,51 @@
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder-local AS builder
+ARG ROOTFS_DIR=/crossrootfs/arm
+
+RUN tdnf install -y debootstrap
+
+RUN /scripts/eng/common/cross/build-rootfs.sh arm xenial --skipunmount
+
+# Build compiler-rt profile library for PGO instrumentation
+RUN mkdir compiler-rt_build && cd compiler-rt_build && \
+    BUILD_FLAGS="-v --sysroot=$ROOTFS_DIR" \
+    TARGET_TRIPLE=arm-linux-gnueabihf && \
+    cmake ../llvm-project.src/compiler-rt \
+        -DCOMPILER_RT_BUILD_PROFILE=ON \
+        -DCOMPILER_RT_BUILD_BUILTINS=OFF \
+        -DCOMPILER_RT_BUILD_SANITIZERS=OFF \
+        -DCOMPILER_RT_BUILD_XRAY=OFF \
+        -DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
+        \
+        -DCMAKE_C_COMPILER=clang \
+        -DCMAKE_CXX_COMPILER=clang++ \
+        -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld" \
+        -DCMAKE_C_COMPILER_TARGET=${TARGET_TRIPLE} \
+        -DCMAKE_CXX_COMPILER_TARGET=${TARGET_TRIPLE} \
+        -DLLVM_CONFIG_PATH=llvm-config \
+        -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=$ROOTFS_DIR/usr \
+        -DCMAKE_C_FLAGS="${BUILD_FLAGS}" \
+        -DCMAKE_CXX_FLAGS="${BUILD_FLAGS}" && \
+    make -j $(getconf _NPROCESSORS_ONLN)
+
+RUN LLVM_VERSION=12.0.1 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" && \
+    mkdir -p $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
+    cp compiler-rt_build/lib/linux/libclang_rt.profile-armhf.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/
+
+# Add numa headers (libnuma-dev is not available on Ubuntu Xenial arm)
+# 2.0.11 matches the version available on Ubuntu Xenial amd64.
+RUN NUMACTL_VERSION=2.0.11 && \
+    wget -O numactl.tar.gz https://github.com/numactl/numactl/archive/v${NUMACTL_VERSION}.tar.gz && \
+    echo "3e099a59b2c527bcdbddd34e1952ca87462d2cef4c93da9b0bc03f02903f7089 numactl.tar.gz" | sha256sum -c && \
+    mkdir numactl && \
+    tar -xf numactl.tar.gz --directory numactl --strip-components=1 && \
+    rm numactl.tar.gz && \
+    cd numactl && \
+    cp numacompat1.h numa.h numaif.h $ROOTFS_DIR/usr/local/include/
+
+
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-arm-local
+ARG ROOTFS_DIR=/crossrootfs/arm
+
+COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR

--- a/src/cbl-mariner/manifest.json
+++ b/src/cbl-mariner/manifest.json
@@ -135,6 +135,32 @@
         {
           "platforms": [
             {
+              "dockerfile": "src/cbl-mariner/2.0/cross/arm",
+              "os": "linux",
+              "osVersion": "cbl-mariner2.0",
+              "tags": {
+                "cbl-mariner-2.0-cross-arm-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "cbl-mariner-2.0-cross-arm$(FloatingTagSuffix)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/cbl-mariner/2.0/cross/arm-alpine",
+              "os": "linux",
+              "osVersion": "cbl-mariner2.0",
+              "tags": {
+                "cbl-mariner-2.0-cross-arm-alpine-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "cbl-mariner-2.0-cross-arm-alpine$(FloatingTagSuffix)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
               "dockerfile": "src/cbl-mariner/2.0/cross/arm64",
               "os": "linux",
               "osVersion": "cbl-mariner2.0",


### PR DESCRIPTION
This adds the arm images which were left out of https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/832. ~They include logic to download the numa headers, working around packages that didn't exist for arm in Ubuntu 16.04 or Alpine 3.13.~

See https://github.com/dotnet/arcade/pull/12144 for context on why we need the numa headers installed.

Contributes to https://github.com/dotnet/runtime/issues/83428

@janvorli @am11 @mthalman PTAL