### PR TITLE
Install diffutils in mariner images

### DIFF
--- a/src/cbl-mariner/2.0/crossdeps-builder/Dockerfile
+++ b/src/cbl-mariner/2.0/crossdeps-builder/Dockerfile
@@ -8,7 +8,6 @@ RUN tdnf install -y \
         debootstrap \
         # LLVM build dependencies
         texinfo \
-        diffutils \
         binutils
 
 # Obtain ubuntu package signing key (for use by debootstrap)

--- a/src/cbl-mariner/2.0/crossdeps/Dockerfile
+++ b/src/cbl-mariner/2.0/crossdeps/Dockerfile
@@ -12,6 +12,7 @@ RUN tdnf update -y && \
         awk \
         icu \
         tar \
+        diffutils \
         # Crosscomponents build dependencies
         glibc-devel \
         lttng-ust-devel \


### PR DESCRIPTION
This makes `diff` available on the mariner build images. We would rather require `diff` as a dependency in our runtime build than `git`, since it sounds like we support source-building runtime without `git` installed per https://github.com/dotnet/runtime/pull/84148#discussion_r1161028942.

@janvorli @am11 PTAL