### PR TITLE
Build llvm using clang on mariner

### DIFF
--- a/src/cbl-mariner/2.0/crossdeps-builder/Dockerfile
+++ b/src/cbl-mariner/2.0/crossdeps-builder/Dockerfile
@@ -4,6 +4,8 @@ FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-local
 COPY mariner-extended.repo /etc/yum.repos.d/
 
 RUN tdnf install -y \
+        # LLVM build dependencies
+        clang \
         # Rootfs build dependencies
         debootstrap \
         # LLVM build dependencies
@@ -52,6 +54,8 @@ RUN mkdir llvm-project.src && \
     mkdir build && cd build && \
     cmake ../llvm-project.src/llvm \
         -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_C_COMPILER=clang \
+        -DCMAKE_CXX_COMPILER=clang++ \
         -DLLVM_TARGETS_TO_BUILD="host;AArch64;ARM" \
         -Wno-dev \
         -DLLVM_ENABLE_PROJECTS="clang;lld" && \


### PR DESCRIPTION
Previously this was building with gcc 11.2.0 (which is installed as an indirect dependency of `git`, through `perl`). Building with gcc 11.2.0 hit this bug: https://github.com/dotnet/runtime/issues/84503.

Using clang to compile llvm avoids the issue described there. I also couldn't reproduce the crash with llvm 16 regardless of compiler used to build llvm. However, I figure it's best to use clang here to be safe.

@janvorli @mthalman PTAL