### PR TITLE
Add runtime build dependencies to ubuntu 22.04 image

### DIFF
--- a/src/ubuntu/22.04/amd64/Dockerfile
+++ b/src/ubuntu/22.04/amd64/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get update \
         curl \
         build-essential \
         gettext \
+        gcc-12 \
         jq \
         libgdiplus \
         libicu-dev \
@@ -50,5 +51,7 @@ RUN apt-get update \
         libtool \
         libunwind8 \
         libunwind8-dev \
+        lld \
         uuid-dev \
+        zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
These dependencies will let us use ubuntu 22.04 for non-cross builds in various ci scenarios:
- gcc-12 will let us use this image for the gcc build legs in runtime, suggested by @jkoritzinsky in https://github.com/dotnet/runtime/pull/84148#discussion_r1163163374
- zlib1g-dev is required. It is not installed explicitly in the ubuntu-18.04 images because there it is installed as a transitive dependency of `libicu-dev`.
- `lld` is required and will help fix the linux enterprise build mentioned in https://github.com/dotnet/runtime/pull/84148#issuecomment-1506517575, if we can move that to ubuntu 22.04 as well. Ubuntu 22.04 installs `lld` 14 by default, so this will let us use the size optimization added by @am11 in https://github.com/dotnet/runtime/pull/84493.