### PR TITLE
Add Azure DevOps dependencies to mariner fpm image

### DIFF
--- a/src/cbl-mariner/2.0/fpm/amd64/Dockerfile
+++ b/src/cbl-mariner/2.0/fpm/amd64/Dockerfile
@@ -1,5 +1,9 @@
 FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
 RUN tdnf install -y \
         ruby \
+        # Provides useradd, needed by Azure DevOps
+        shadow-utils \
+        # Provides su, needed by Azure DevOps
+        util-linux \
     && tdnf clean all \
     && gem install fpm

--- a/src/cbl-mariner/2.0/fpm/amd64/Dockerfile
+++ b/src/cbl-mariner/2.0/fpm/amd64/Dockerfile
@@ -1,9 +1,14 @@
 FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
 RUN tdnf install -y \
+        awk \
+        ca-certificates \
+        icu \
+        rpm-build \
         ruby \
-        # Provides useradd, needed by Azure DevOps
+        # Provides useradd
         shadow-utils \
-        # Provides su, needed by Azure DevOps
+        tar \
+        # Provides su
         util-linux \
     && tdnf clean all \
     && gem install fpm


### PR DESCRIPTION
Should help with failures ingesting https://github.com/dotnet/runtime/pull/84148 into aspnet: https://github.com/dotnet/aspnetcore/pull/47693.

@eerhardt @agocke @jkoritzinsky PTAL