### PR TITLE
Improve caching of mariner image builds

### DIFF
--- a/src/cbl-mariner/2.0/crossdeps-builder/Dockerfile
+++ b/src/cbl-mariner/2.0/crossdeps-builder/Dockerfile
@@ -1,16 +1,24 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-local
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
 
 # TODO: remove this once debootstrap is available in the base repos.
 COPY mariner-extended.repo /etc/yum.repos.d/
 
 RUN tdnf install -y \
+        # Common utilities
+        ca-certificates \
+        git \
+        tar \
+        wget \
         # LLVM build dependencies
+        binutils \
         clang \
-        # Rootfs build dependencies
-        debootstrap \
-        # LLVM build dependencies
+        cmake \
+        diffutils \
+        glibc-devel \
+        kernel-headers \
         texinfo \
-        binutils
+        # Rootfs build dependencies
+        debootstrap
 
 # Obtain ubuntu package signing key (for use by debootstrap)
 # 1. Add public key used to sign the ubuntu keyring


### PR DESCRIPTION
This changes the base of crossdeps-builder from crossdeps to the core mariner image. This way, adding dependencies to the crossdeps image doesn't require re-building LLVM. For example this should make changes like https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/847 much faster in the future.

I am hoping our infrastructure is also smart enough not to re-run the rootfs builds when `crossdeps` changes. The rootfs builds happen in a Dockerfile whose final output image is based on `crossdeps`, but the actual rootfs build step happens in a separate stage that doesn't depend on `crossdeps`. Even if that's not the case, though, this should at least avoid some LLVM re-builds.
