### PR TITLE
Remove gcc 12 from ubuntu image

### DIFF
--- a/src/ubuntu/22.04/amd64/Dockerfile
+++ b/src/ubuntu/22.04/amd64/Dockerfile
@@ -40,7 +40,6 @@ RUN apt-get update \
         curl \
         build-essential \
         gettext \
-        gcc-12 \
         jq \
         libgdiplus \
         libicu-dev \


### PR DESCRIPTION
It was added in https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/843 so that we could use it in runtime's gcc builds, but https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/850 lets us continue using the existing official debian-based image, so this is no longer necessary.

In fact, the presence of the gcc 12 toolchain directory was causing unrelated problems in https://github.com/dotnet/runtime/pull/84795, because we didn't have `libstdc++-12-dev` installed, but clang was selecting the gcc 12 toolchain. Removing it will let that build use the libstdc++ 11 that is already installed as a dependency of clang-14.

@am11 @jkoritzinsky PTAL (@am11 I can't add you directly as a reviewer or I would)