### PR TITLE
Update RISCV64 image

### DIFF
--- a/src/ubuntu/22.04/cross/riscv64/Dockerfile
+++ b/src/ubuntu/22.04/cross/riscv64/Dockerfile
@@ -2,9 +2,6 @@ FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps-local
 
 # Remove LLVM linker and install binutils-riscv64-linux-gnu
 RUN apt-get update \
-    && apt-get remove -y \
-        lld-15 \
-    && apt-get autoremove -y \
     && apt-get install -y \
         binutils-riscv64-linux-gnu \
     && rm -rf /var/lib/apt/lists/*

--- a/src/ubuntu/22.04/cross/riscv64/Dockerfile
+++ b/src/ubuntu/22.04/cross/riscv64/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps-local
 
-# Remove LLVM linker and install binutils-riscv64-linux-gnu
+# Install binutils-riscv64-linux-gnu
 RUN apt-get update \
     && apt-get install -y \
         binutils-riscv64-linux-gnu \

--- a/src/ubuntu/22.04/cross/riscv64/Dockerfile
+++ b/src/ubuntu/22.04/cross/riscv64/Dockerfile
@@ -1,3 +1,12 @@
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps-local
 
+# Remove LLVM linker and install binutils-riscv64-linux-gnu
+RUN apt-get update \
+    && apt-get remove -y \
+        lld-15 \
+    && apt-get autoremove -y \
+    && apt-get install -y \
+        binutils-riscv64-linux-gnu \
+    && rm -rf /var/lib/apt/lists/*
+
 ADD rootfs.riscv64.tar crossrootfs


### PR DESCRIPTION
- ~~Remove lld-15 due to libcoreclr.so link error~~
- Install binutils-riscv64-linux-gnu
- For RISCV64 port. https://github.com/dotnet/runtime/issues/84834