### PR TITLE
[wasm] Checkout the version tag

### DIFF
--- a/src/ubuntu/18.04/webassembly/Dockerfile
+++ b/src/ubuntu/18.04/webassembly/Dockerfile
@@ -32,6 +32,7 @@ RUN mkdir ${EMSCRIPTEN_PATH} \
     && cd ${EMSCRIPTEN_PATH} \
     && git clone https://github.com/emscripten-core/emsdk.git ${EMSDK_PATH} \
     && cd ${EMSDK_PATH} \
+    && git checkout ${EMSCRIPTEN_VERSION} \
     && ./emsdk install ${EMSCRIPTEN_VERSION}-upstream \
     && ./emsdk activate ${EMSCRIPTEN_VERSION}-upstream \
     && chmod -R 777 ${EMSCRIPTEN_PATH}

--- a/src/ubuntu/20.04/webassembly/Dockerfile
+++ b/src/ubuntu/20.04/webassembly/Dockerfile
@@ -33,6 +33,7 @@ RUN mkdir ${EMSCRIPTEN_PATH} \
     && cd ${EMSCRIPTEN_PATH} \
     && git clone https://github.com/emscripten-core/emsdk.git ${EMSDK_PATH} \
     && cd ${EMSDK_PATH} \
+    && git checkout ${EMSCRIPTEN_VERSION} \
     && ./emsdk install ${EMSCRIPTEN_VERSION}-upstream \
     && ./emsdk activate ${EMSCRIPTEN_VERSION}-upstream \
     && chmod -R 777 ${EMSCRIPTEN_PATH}

--- a/src/windowsservercore/ltsc2022/helix/webassembly-net8/Dockerfile
+++ b/src/windowsservercore/ltsc2022/helix/webassembly-net8/Dockerfile
@@ -32,6 +32,7 @@ RUN mkdir %EMSCRIPTEN_PATH% \
     && cd %EMSCRIPTEN_PATH% \
     && git clone https://github.com/emscripten-core/emsdk.git %EMSDK_PATH%
 RUN cd %EMSDK_PATH% \
+    && git checkout %EMSCRIPTEN_VERSION% \
     && .\emsdk install %EMSCRIPTEN_VERSION%-upstream  \
     && .\emsdk activate %EMSCRIPTEN_VERSION%-upstream \
     && .\upstream\emscripten\embuilder.bat build MINIMAL


### PR DESCRIPTION
When installing and activating emsdk. In latest emsdk we can endup without emscripten's node in the path, and having only really old system npm in path on Ubuntu 18.04. Update other net8 images as well to be consistent.