### PR TITLE
Add gcc 13 image

### DIFF
--- a/src/debian/12/gcc13/Dockerfile
+++ b/src/debian/12/gcc13/Dockerfile
@@ -1,0 +1,31 @@
+FROM gcc:13-bookworm
+
+# Dependencies for dotnet/runtime native components.
+RUN apt-get update && \
+    apt-get install -y \
+        cmake \
+        curl \
+        gdb \
+        git \
+        iputils-ping \
+        libicu-dev \
+        libkrb5-dev \
+        liblttng-ust-dev \
+        libssl-dev \
+        liblldb-dev \
+        lttng-tools \
+        locales \
+        locales-all \
+        python3-dev \
+        python3-pip \
+        sudo \
+        tzdata \
+    && rm -rf /var/lib/apt/lists/* \
+    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+ENV LANG=en_US.utf8
+
+# These symlinks are required because this docker has gcc-12 suffixed with version and gcc-13 unsuffixed in PATH.
+# In the runtime repo, we (by design) give precedence to suffixed compilers before selecting unsuffixed one in PATH.
+RUN ln -s $(command -v gcc) /usr/bin/gcc-13 && \
+    ln -s $(command -v g++) /usr/bin/g++-13

--- a/src/debian/manifest.json
+++ b/src/debian/manifest.json
@@ -205,6 +205,20 @@
               "variant": "v8"
             }
           ]
+        },
+        {
+          "platforms": [
+            {
+              "architecture": "amd64",
+              "dockerfile": "src/debian/12/gcc13",
+              "os": "linux",
+              "osVersion": "bookworm",
+              "tags": {
+                "debian-12-gcc13-amd64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "debian-12-gcc13-amd64$(FloatingTagSuffix)": {}
+              }
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
https://hub.docker.com/_/gcc - released gcc 13 tags yesteday. It is based on Debian 12 "bookworm" and has cmake 25.1.

Once https://github.com/dotnet/arcade/pull/13332 and this are merged, I will update runtime CI and subsequently cleanup gcc12 image.