### PR TITLE
Add sudo to the FPM CBL-Mariner image

### DIFF
--- a/src/cbl-mariner/2.0/fpm/amd64/Dockerfile
+++ b/src/cbl-mariner/2.0/fpm/amd64/Dockerfile
@@ -11,5 +11,7 @@ RUN tdnf install -y \
         tar \
         # Provides su
         util-linux \
+        # Provides sudo
+        sudo \
     && tdnf clean all \
     && gem install fpm


### PR DESCRIPTION
dotnet/installer needs sudo to make rpms.