### PR TITLE
Remove lld from Ubuntu 22.04 image

### DIFF
--- a/src/ubuntu/22.04/amd64/Dockerfile
+++ b/src/ubuntu/22.04/amd64/Dockerfile
@@ -50,7 +50,6 @@ RUN apt-get update \
         libtool \
         libunwind8 \
         libunwind8-dev \
-        lld \
         uuid-dev \
         zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This is no longer required with https://github.com/dotnet/runtime/pull/85667, and will let us switch to the Ubuntu 22.04 images for the runtime-dev-innerloop runs.