### PR TITLE
Add an AlmaLinux-based image for us to use for our source-build legs

### DIFF
--- a/src/almalinux/8/source-build/Dockerfile
+++ b/src/almalinux/8/source-build/Dockerfile
@@ -1,0 +1,41 @@
+FROM almalinux:8
+
+# Install dependencies
+
+RUN dnf install -y 'dnf-command(config-manager)' && \
+    dnf config-manager --set-enabled powertools && \
+     yum install -y \
+        "perl(Time::HiRes)" \
+        autoconf \
+        automake \
+        cmake \
+        gdb \
+        git \
+        glibc-langpack-en \
+        jq \
+        krb5-devel \
+        libcurl-devel \
+        libicu-devel \
+        libtool \
+        libuuid-devel \
+        libxml2-devel \
+        llvm-toolset \
+        lttng-ust-devel \
+        make \
+        ncurses-devel \
+        numactl-devel \
+        openssl-devel \
+        readline-devel \
+        python3 \
+        sudo \
+        swig \
+        wget \
+        which \
+        xz \
+        zlib-devel \
+    && \
+    yum clean all
+
+ENV LANG en_US.UTF-8  
+ENV LANGUAGE en_US:en  
+ENV LC_ALL en_US.UTF-8  

--- a/src/almalinux/8/source-build/amd64/Dockerfile
+++ b/src/almalinux/8/source-build/amd64/Dockerfile
@@ -2,9 +2,12 @@ FROM almalinux:8
 
 # Install dependencies
 
-RUN dnf install -y 'dnf-command(config-manager)' && \
-    dnf config-manager --set-enabled powertools && \
-     yum install -y \
+RUN dnf install -y \
+     'dnf-command(config-manager)' \
+     epel-release && \
+     dnf config-manager --set-enabled powertools && \
+     dnf config-manager --set-enabled epel && \
+     dnf install -y \
         "perl(Time::HiRes)" \
         autoconf \
         automake \
@@ -17,9 +20,12 @@ RUN dnf install -y 'dnf-command(config-manager)' && \
         libcurl-devel \
         libicu-devel \
         libtool \
+        # Requires epel
+        libunwind-devel \
         libuuid-devel \
         libxml2-devel \
         llvm-toolset \
+        # Requires powertools
         lttng-ust-devel \
         make \
         ncurses-devel \
@@ -34,8 +40,4 @@ RUN dnf install -y 'dnf-command(config-manager)' && \
         xz \
         zlib-devel \
     && \
-    yum clean all
-
-ENV LANG en_US.UTF-8  
-ENV LANGUAGE en_US:en  
-ENV LC_ALL en_US.UTF-8  
+    dnf clean all

--- a/src/almalinux/manifest.json
+++ b/src/almalinux/manifest.json
@@ -6,6 +6,15 @@
         {
           "platforms": [
             {
+              "dockerfile": "src/almalinux/8/source-build/amd64",
+              "os": "linux",
+              "osVersion": "almalinux8",
+              "tags": {
+                "almalinux-8-source-build--$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "almalinux-8-source-build$(FloatingTagSuffix)": {}
+              }
+            },
+            {
               "dockerfile": "src/almalinux/8/helix/amd64",
               "os": "linux",
               "osVersion": "almalinux8",

--- a/src/almalinux/manifest.json
+++ b/src/almalinux/manifest.json
@@ -10,7 +10,7 @@
               "os": "linux",
               "osVersion": "almalinux8",
               "tags": {
-                "almalinux-8-source-build--$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "almalinux-8-source-build-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
                 "almalinux-8-source-build$(FloatingTagSuffix)": {}
               }
             },


### PR DESCRIPTION
AlmaLinux is a better base image to use for our source-build legs as it is a rebuild of RHEL instead of a lead-ahead distro like CentOS Stream.