### PR TITLE
Add a Mariner-based Android build image

### DIFF
--- a/src/cbl-mariner/2.0/android/Dockerfile
+++ b/src/cbl-mariner/2.0/android/Dockerfile
@@ -23,6 +23,7 @@ RUN tdnf update -y \
 
 # Install Android NDK
 RUN wget https://dl.google.com/android/repository/android-ndk-r23c-linux.zip \
+    && echo "e5053c126a47e84726d9f7173a04686a71f9a67a android-ndk-r23c-linux.zip" | sha1sum -c \
     && unzip android-ndk-r23c-linux.zip -d /usr/local \
     && mv /usr/local/android-ndk-r23c /usr/local/android-ndk \
     && rm -f android-ndk-r23c-linux.zip
@@ -31,6 +32,7 @@ ENV ANDROID_NDK_ROOT=/usr/local/android-ndk
 
 # Grab the necessary Android SDK packages / tools
 RUN wget https://dl.google.com/android/repository/commandlinetools-linux-8092744_latest.zip \
+    && echo "d71f75333d79c9c6ef5c39d3456c6c58c613de30e6a751ea0dbd433e8f8b9cbf commandlinetools-linux-8092744_latest.zip" | sha256sum -c \
     && mkdir -p /usr/local/android-sdk/cmdline-tools \
     && unzip commandlinetools-linux-8092744_latest.zip -d /usr/local/android-sdk/cmdline-tools \
     && rm -f commandlinetools-linux-8092744_latest.zip

--- a/src/cbl-mariner/2.0/android/Dockerfile
+++ b/src/cbl-mariner/2.0/android/Dockerfile
@@ -7,7 +7,7 @@ RUN tdnf update -y \
         ca-certificates \
         binutils \
         cmake \
-        clang \
+        clang16 \
         diffutils \
         git \
         tar \

--- a/src/cbl-mariner/2.0/android/Dockerfile
+++ b/src/cbl-mariner/2.0/android/Dockerfile
@@ -1,0 +1,41 @@
+FROM mcr.microsoft.com/openjdk/jdk:8-mariner
+
+# Dependencies for Android build
+RUN tdnf update -y \
+    && tdnf install -y \
+        # Common dependencies
+        ca-certificates \
+        binutils \
+        cmake \
+        clang \
+        diffutils \
+        git \
+        tar \
+        util-linux \
+        wget \
+        # Crosscomponents build dependencies
+        glibc-devel \
+        kernel-headers \
+        # Runtime dependencies
+        icu \
+        # Android dependencies
+        unzip
+
+# Install Android NDK
+RUN wget https://dl.google.com/android/repository/android-ndk-r23c-linux.zip \
+    && unzip android-ndk-r23c-linux.zip -d /usr/local \
+    && mv /usr/local/android-ndk-r23c /usr/local/android-ndk \
+    && rm -f android-ndk-r23c-linux.zip
+
+ENV ANDROID_NDK_ROOT=/usr/local/android-ndk
+
+# Grab the necessary Android SDK packages / tools
+RUN wget https://dl.google.com/android/repository/commandlinetools-linux-8092744_latest.zip \
+    && mkdir -p /usr/local/android-sdk/cmdline-tools \
+    && unzip commandlinetools-linux-8092744_latest.zip -d /usr/local/android-sdk/cmdline-tools \
+    && rm -f commandlinetools-linux-8092744_latest.zip
+
+ENV ANDROID_SDK_ROOT=/usr/local/android-sdk
+
+RUN yes | $ANDROID_SDK_ROOT/cmdline-tools/cmdline-tools/bin/sdkmanager --licenses
+RUN $ANDROID_SDK_ROOT/cmdline-tools/cmdline-tools/bin/sdkmanager --install "build-tools;33.0.0" "platforms;android-33"

--- a/src/cbl-mariner/2.0/android/docker/Dockerfile
+++ b/src/cbl-mariner/2.0/android/docker/Dockerfile
@@ -1,0 +1,6 @@
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-android-local
+
+RUN tdnf update -y \
+    && tdnf install -y \
+        moby-engine \
+        moby-cli

--- a/src/cbl-mariner/manifest.json
+++ b/src/cbl-mariner/manifest.json
@@ -281,7 +281,23 @@
               "osVersion": "cbl-mariner2.0",
               "tags": {
                 "cbl-mariner-2.0-android-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "cbl-mariner-2.0-android$(FloatingTagSuffix)": {}
+                "cbl-mariner-2.0-android$(FloatingTagSuffix)": {},
+                "cbl-mariner-2.0-android-local": {
+                  "isLocal": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/cbl-mariner/2.0/android/docker",
+              "os": "linux",
+              "osVersion": "cbl-mariner2.0",
+              "tags": {
+                "cbl-mariner-2.0-android-docker-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "cbl-mariner-2.0-android-docker$(FloatingTagSuffix)": {}
               }
             }
           ]

--- a/src/cbl-mariner/manifest.json
+++ b/src/cbl-mariner/manifest.json
@@ -272,6 +272,19 @@
               }
             }
           ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/cbl-mariner/2.0/android",
+              "os": "linux",
+              "osVersion": "cbl-mariner2.0",
+              "tags": {
+                "cbl-mariner-2.0-android-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "cbl-mariner-2.0-android$(FloatingTagSuffix)": {}
+              }
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
Validated with a local build that we can build the Android target in dotnet/runtime with this image.

This change combined with the WASM image addition will enable us to move all platforms we officially build for to build from a Mariner-based image.