### PR TITLE
Add additional test deps to CentOS Stream 8 dockerfile

### DIFF
--- a/src/centos/stream8/Dockerfile
+++ b/src/centos/stream8/Dockerfile
@@ -16,6 +16,8 @@ RUN dnf install --setopt tsflags=nodocs --refresh -y \
         cmake \
         curl-devel \
         doxygen \
+        elfutils \
+        file \
         findutils \
         gcc \
         gdb \


### PR DESCRIPTION
The dependencies are needed by https://github.com/dotnet/installer/pull/16488