### PR TITLE
Add openssl headers to the Android image for linux-bionic builds

### DIFF
--- a/src/cbl-mariner/2.0/android/Dockerfile
+++ b/src/cbl-mariner/2.0/android/Dockerfile
@@ -23,6 +23,8 @@ RUN tdnf update -y \
         # Android dependencies
         zip \
         unzip \
+        # linux-bionic build dependencies
+        openssl-devel \
         # ICU dependencies
         awk
 


### PR DESCRIPTION
Linux-bionic builds copy the OpenSSL headers since they don't build against the Android crypto PAL.