### PR TITLE
Make the wasm dockerfile depend on the amd64 cross build docker image

### DIFF
--- a/src/cbl-mariner/2.0/webassembly/Dockerfile
+++ b/src/cbl-mariner/2.0/webassembly/Dockerfile
@@ -1,29 +1,13 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64-local
 
 # Dependencies for WebAssembly build
 RUN tdnf update -y \
     && tdnf install -y \
-        # Provides 'su', required by Azure DevOps
-        util-linux \
-        ca-certificates \
-        # Common runtime build dependencies
-        awk \
-        binutils \
-        cmake \
-        clang16 \
-        diffutils \
-        glibc-devel \
-        git \
-        icu \
-        kernel-headers \
-        tar \
-        openssl-devel \
-        which \
         # WebAssembly build dependencies
+        which \
         nodejs \
         python3 \
-        unzip \
-        wget
+        unzip
 
 # WebAssembly build needs typescript
 RUN npm i -g typescript

--- a/src/cbl-mariner/2.0/webassembly/Dockerfile
+++ b/src/cbl-mariner/2.0/webassembly/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64
 
 # Dependencies for WebAssembly build
 RUN tdnf update -y \

--- a/src/cbl-mariner/manifest.json
+++ b/src/cbl-mariner/manifest.json
@@ -98,7 +98,10 @@
               "osVersion": "cbl-mariner2.0",
               "tags": {
                 "cbl-mariner-2.0-cross-amd64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "cbl-mariner-2.0-cross-amd64$(FloatingTagSuffix)": {}
+                "cbl-mariner-2.0-cross-amd64$(FloatingTagSuffix)": {},
+                "cbl-mariner-2.0-cross-amd64-local": {
+                  "isLocal": true
+                }
               }
             }
           ]


### PR DESCRIPTION
Instead of using CBL-Mariner 2.0 as the base image, use our AMD64 cross build image as our base.

Using this image will enable us to build the Mono AOT compiler against the cross-rootfs when we run as WASM build. We need a mono-aot-cross built with the cross rootfs since we build/aot WASM apps on Helix when we run tests.

This work is not required for Android as we always run the AOT compiler for Android on the build machine in the dotnet/runtime pipelines.

We don't ship the AOT compilers built in the "build and test wasm/android" legs, so this change only affects the internal testing.

I'll make corresponding changes to dotnet/runtime#86806 after this PR is merged in.