### PR TITLE
add missing libnuma.so to Stream8

### DIFF
--- a/src/centos/stream8/helix/amd64/Dockerfile
+++ b/src/centos/stream8/helix/amd64/Dockerfile
@@ -23,6 +23,7 @@ RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
         libicu \
         libmsquic \
         libtool \
+        numactl-libs \
         make \
         openssl \
         openssl-devel \


### PR DESCRIPTION
fixes https://github.com/dotnet/runtime/issues/87038

```
[helixbot@933fe775248c /]$ rpm -ql libmsquic-2.2.1-1.x86_64
/usr/lib/.build-id
/usr/lib/.build-id/e6
/usr/lib/.build-id/e6/261a083176ce372df023d45f9054dd9ba76184
/usr/lib/.build-id/ec
/usr/lib/.build-id/ec/1bf138f7ca9e72881f21d777e78bb92d0e2abf
/usr/lib64/libmsquic.lttng.so.2.2.1
/usr/lib64/libmsquic.so.2
/usr/lib64/libmsquic.so.2.2.1
[helixbot@933fe775248c /]$ ldd /usr/lib64/libmsquic.so.2.2.1
	linux-vdso.so.1 (0x00007ffdfe651000)
	libcrypto.so.1.1 => /lib64/libcrypto.so.1.1 (0x00007fc5f86c0000)
	libdl.so.2 => /lib64/libdl.so.2 (0x00007fc5f84bc000)
	libnuma.so.1 => /lib64/libnuma.so.1 (0x00007fc5f82b0000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007fc5f8090000)
	libc.so.6 => /lib64/libc.so.6 (0x00007fc5f7ccb000)
	libz.so.1 => /lib64/libz.so.1 (0x00007fc5f7ab3000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fc5f8baa000)
```