### PR TITLE
Update ubuntu18.04 arm msquic packages to 2.2.0

### DIFF
--- a/src/ubuntu/18.04/helix/arm32v7/Dockerfile
+++ b/src/ubuntu/18.04/helix/arm32v7/Dockerfile
@@ -50,7 +50,7 @@ RUN apt-get update && \
 # Add MsQuic
 # MsQuic did not publish arm32 package for 18.04
 # Use direct link to signed binary for now
-RUN curl -LO https://github.com/microsoft/msquic/releases/download/v2.1.8/libmsquic_2.1.8_armhf.deb && \
+RUN curl -LO https://github.com/microsoft/msquic/releases/download/v2.2.0/libmsquic_2.2.0_armhf.deb && \
     dpkg -i libmsquic_*_armhf.deb && \
     rm -f libmsquic_*_armhf.deb
 

--- a/src/ubuntu/18.04/helix/arm64v8/Dockerfile
+++ b/src/ubuntu/18.04/helix/arm64v8/Dockerfile
@@ -52,7 +52,7 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
 # Add MsQuic
 # MsQuic did not publish arm64 package for 18.04
 # Use direct link to signed binary for now
-RUN curl -LO https://github.com/microsoft/msquic/releases/download/v2.1.8/libmsquic_2.1.8_arm64.deb && \
+RUN curl -LO https://github.com/microsoft/msquic/releases/download/v2.2.0/libmsquic_2.2.0_arm64.deb && \
     dpkg -i libmsquic_*_arm64.deb && \
     rm -f libmsquic_*_arm64.deb
 


### PR DESCRIPTION
ALPN narrowing down feature has been released with msquic 2.2.0
The pipeline fails due to some of the machines still having msquic 2.1.8
ALPN narrowing down feature UT: https://github.com/dotnet/runtime/pull/86659