### PR TITLE
Remove Fedora from base image override

### DIFF
--- a/eng/pipelines/dotnet-buildtools-prereqs-all.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-all.yml
@@ -26,7 +26,7 @@ stages:
       - template: ../../../pipelines/steps/set-base-image-override-options.yml
         parameters:
           variableName: customCopyBaseImagesArgs
-          dockerfileOs: (centos|debian|fedora|ubuntu)
+          dockerfileOs: (centos|debian|ubuntu)
           baseOverrideRegistry: $(overrideRegistry) # Comes from DotNet-Docker-Common variable group
     customBuildInitSteps:
     - template: /eng/pipelines/steps/install-cross-build-prereqs.yml
@@ -34,6 +34,6 @@ stages:
       - template: ../../../pipelines/steps/set-base-image-override-options.yml
         parameters:
           variableName: imageBuilderBuildArgs
-          dockerfileOs: (centos|debian|fedora|ubuntu)
+          dockerfileOs: (centos|debian|ubuntu)
           baseOverrideRegistry: $(overrideRegistry) # Comes from DotNet-Docker-Common variable group
     


### PR DESCRIPTION
As a result of the changes from https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/886, the Fedora builds are failing because Fedora 38 is not included in the mirrored repository that is set as part of the base image overriding. I've fixed this by just removing Fedora from list that does this overriding.