### PR TITLE
add missing libnuma to Debian 11 packages 

### DIFF
--- a/src/debian/11/helix/amd64/Dockerfile
+++ b/src/debian/11/helix/amd64/Dockerfile
@@ -48,7 +48,7 @@ RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
     rm microsoft.asc && \
     apt-add-repository https://packages.microsoft.com/debian/11/prod && \
     apt-get update && \
-    apt-get install -y libmsquic && \
+    apt-get install -y libnuma1 libmsquic && \
     rm -rf /var/lib/apt/lists/*
 
 # Create helixbot user and give rights to sudo without password

--- a/src/debian/11/helix/arm32v7/Dockerfile
+++ b/src/debian/11/helix/arm32v7/Dockerfile
@@ -42,7 +42,7 @@ RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
     rm microsoft.asc && \
     apt-add-repository https://packages.microsoft.com/debian/11/prod && \
     apt-get update && \
-    apt-get install -y libmsquic && \
+    apt-get install -y libnuma1 libmsquic && \
     rm -rf /var/lib/apt/lists/*
 
 ENV LANG=en_US.utf8

--- a/src/debian/11/helix/arm64v8/Dockerfile
+++ b/src/debian/11/helix/arm64v8/Dockerfile
@@ -51,7 +51,7 @@ RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
     rm microsoft.asc && \
     apt-add-repository https://packages.microsoft.com/debian/11/prod && \
     apt-get update && \
-    apt-get install -y libmsquic && \
+    apt-get install -y libnuma1 libmsquic && \
     rm -rf /var/lib/apt/lists/*
 
 # Create helixbot users and give rights to sudo without password


### PR DESCRIPTION
fixes https://github.com/dotnet/runtime/issues/87275, workaround for https://github.com/microsoft/msquic/issues/3421
related to https://github.com/dotnet/runtime/issues/87181