### PR TITLE
Add the VMR's additional test deps to more dockerfiles

### DIFF
--- a/src/alpine/3.17/amd64/Dockerfile
+++ b/src/alpine/3.17/amd64/Dockerfile
@@ -11,6 +11,8 @@ RUN apk update && \
         cmake \
         coreutils \
         curl \
+        elfutils \
+        file \
         gcc \
         gettext-dev \
         git \

--- a/src/centos/stream9/Dockerfile
+++ b/src/centos/stream9/Dockerfile
@@ -15,6 +15,8 @@ RUN dnf install --setopt tsflags=nodocs --refresh -y \
         cmake \
         curl-devel \
         doxygen \
+        elfutils \
+        file \
         findutils \
         gcc \
         gdb \

--- a/src/debian/11/amd64/Dockerfile
+++ b/src/debian/11/amd64/Dockerfile
@@ -10,6 +10,8 @@ RUN apt-get update \
             clang \
             cmake \
             curl \
+            elfutils \
+            file \
             g++ \
             gettext \
             gdb \

--- a/src/fedora/38/amd64/Dockerfile
+++ b/src/fedora/38/amd64/Dockerfile
@@ -57,3 +57,9 @@ RUN dnf --setopt=install_weak_deps=False install -y \
 RUN dnf --setopt=install_weak_deps=False install -y \
         openssl1.1 \
     && dnf clean all
+
+# Dependencies for VMR/source-build tests
+RUN dnf --setopt=install_weak_deps=False install -y \
+        elfutils \
+        file \
+    && dnf clean all

--- a/src/ubuntu/20.04/amd64/Dockerfile
+++ b/src/ubuntu/20.04/amd64/Dockerfile
@@ -55,3 +55,10 @@ RUN apt-get update \
         uuid-dev \
         zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
+
+# Dependencies for VMR/source-build tests
+RUN apt-get update \
+    && apt-get install -y \
+        elfutils \
+        file \
+    && rm -rf /var/lib/apt/lists/*

--- a/src/ubuntu/22.04/amd64/Dockerfile
+++ b/src/ubuntu/22.04/amd64/Dockerfile
@@ -57,3 +57,10 @@ RUN apt-get update \
         uuid-dev \
         zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
+
+# Dependencies for VMR/source-build tests
+RUN apt-get update \
+    && apt-get install -y \
+        elfutils \
+        file \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
We added it in #875 (commit b15dff8ab503f2824dfd4095ff2f743929e6f647) to CentOS Stream 8 dockerfiles, but it needs to be available in more containers as well.