### PR TITLE
Remove base image override logic for Fedora

### DIFF
--- a/eng/pipelines/dotnet-buildtools-prereqs-fedora.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-fedora.yml
@@ -24,16 +24,3 @@ stages:
   parameters:
     internalProjectName: ${{ variables.internalProjectName }}
     publicProjectName: ${{ variables.publicProjectName }}
-    ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-      customCopyBaseImagesInitSteps:
-      - template: ../../../pipelines/steps/set-base-image-override-options.yml
-        parameters:
-          variableName: customCopyBaseImagesArgs
-          dockerfileOs: fedora
-          baseOverrideRegistry: $(overrideRegistry) # Comes from DotNet-Docker-Common variable group
-      customBuildInitSteps:
-      - template: ../../../pipelines/steps/set-base-image-override-options.yml
-        parameters:
-          variableName: imageBuilderBuildArgs
-          dockerfileOs: fedora
-          baseOverrideRegistry: $(overrideRegistry) # Comes from DotNet-Docker-Common variable group


### PR DESCRIPTION
This is a continuation of the changes from https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/887. Those changes had only updated the dotnet-buildtools-prereqs-**all** pipeline but had missed the changes needed for the dotnet-buildtools-prereqs-**fedora** pipeline.