### PR TITLE
Sync debian 11 arm64v8 dockerfile with amd64

### DIFF
--- a/src/debian/11/arm64v8/Dockerfile
+++ b/src/debian/11/arm64v8/Dockerfile
@@ -10,6 +10,8 @@ RUN apt-get update \
             clang \
             cmake \
             curl \
+            elfutils \
+            file \
             g++ \
             gettext \
             gdb \


### PR DESCRIPTION
The elfutils+file changes were missed from the arm64 container.