### PR TITLE
fix build break with apt-get

### DIFF
--- a/src/debian/10/helix/amd64/Dockerfile
+++ b/src/debian/10/helix/amd64/Dockerfile
@@ -48,7 +48,7 @@ RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
     apt-key add microsoft.asc && \
     apt-add-repository https://packages.microsoft.com/debian/10/prod && \
     apt-get update && \
-    apt-get install libmsquic && \
+    apt-get install -y libmsquic && \
     rm -rf /var/lib/apt/lists/* microsoft.asc
 
 # Create helixbot user and give rights to sudo without password

--- a/src/debian/10/helix/arm32v7/Dockerfile
+++ b/src/debian/10/helix/arm32v7/Dockerfile
@@ -53,7 +53,7 @@ RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
     apt-key add microsoft.asc && \
     apt-add-repository https://packages.microsoft.com/debian/10/prod && \
     apt-get update && \
-    apt-get install libmsquic && \
+    apt-get install -y libmsquic && \
     rm -rf /var/lib/apt/lists/* microsoft.asc
 
 # Create helixbot user and give rights to sudo without password

--- a/src/debian/10/helix/arm64v8/Dockerfile
+++ b/src/debian/10/helix/arm64v8/Dockerfile
@@ -51,7 +51,7 @@ RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
     apt-key add microsoft.asc && \
     apt-add-repository https://packages.microsoft.com/debian/10/prod && \
     apt-get update && \
-    apt-get install libmsquic && \
+    apt-get install -y libmsquic && \
     rm -rf /var/lib/apt/lists/* microsoft.asc
 
 # Create helixbot user and give rights to sudo without password


### PR DESCRIPTION
https://dev.azure.com/dnceng/internal/_build/results?buildId=2197825&view=logs&j=e4e8ddad-64a9-5627-26b9-17a17ea0f8e3&t=09d4d69f-c49a-5230-9b91-fd7969eab890

```
The following additional packages will be installed:
  libnuma1
The following NEW packages will be installed:
  libmsquic libnuma1
0 upgraded, 2 newly installed, 0 to remove and 0 not upgraded.
Need to get 4,596 kB of archives.
After this operation, 17.9 MB of additional disk space will be used.
Do you want to continue? [Y/n] Abort.
```

build fails waiting for user input