### PR TITLE
Revert "add missing libnuma.so to Stream8"

### DIFF
--- a/src/centos/stream8/helix/amd64/Dockerfile
+++ b/src/centos/stream8/helix/amd64/Dockerfile
@@ -23,7 +23,6 @@ RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
         libicu \
         libmsquic \
         libtool \
-        numactl-libs \
         make \
         openssl \
         openssl-devel \


### PR DESCRIPTION
Reverts dotnet/dotnet-buildtools-prereqs-docker#884

original issue should be fixed by MsQuic 2.2.2
fixes https://github.com/dotnet/runtime/issues/87181
