### PR TITLE
Copy the sanitizer runtimes into /usr/local

### DIFF
--- a/src/cbl-mariner/2.0/cross/amd64/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder AS builder
 ARG ROOTFS_DIR=/crossrootfs/x64
 
 RUN /scripts/eng/common/cross/build-rootfs.sh x64 xenial --skipunmount
@@ -34,13 +34,19 @@ RUN mkdir compiler-rt_build && cd compiler-rt_build && \
         -DCMAKE_CXX_FLAGS="${BUILD_FLAGS}" && \
     make -j $(getconf _NPROCESSORS_ONLN)
 
+ARG SANITIZER_RUNTIMES_DIR=/sanitizer-runtimes
+
 RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" && \
     mkdir -p $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     cp compiler-rt_build/lib/linux/libclang_rt.profile-x86_64.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
+    mkdir /sanitizer-runtimes && \
+    cp compiler-rt_build/lib/linux/libclang_rt.*-x86_64.a $SANITIZER_RUNTIMES_DIR && \
     cp -r compiler-rt_build/include/sanitizer $ROOTFS_DIR/usr/include
 
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm
 ARG ROOTFS_DIR=/crossrootfs/x64
+ARG LLVM_VERSION_MAJOR=16
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR
+COPY --from=builder /sanitizer-runtimes /usr/local/lib/clang/$LLVM_VERSION_MAJOR/lib/linux/

--- a/src/cbl-mariner/2.0/cross/amd64/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder-local AS builder
 ARG ROOTFS_DIR=/crossrootfs/x64
 
 RUN /scripts/eng/common/cross/build-rootfs.sh x64 xenial --skipunmount
@@ -34,9 +34,7 @@ RUN mkdir compiler-rt_build && cd compiler-rt_build && \
         -DCMAKE_CXX_FLAGS="${BUILD_FLAGS}" && \
     make -j $(getconf _NPROCESSORS_ONLN)
 
-ARG SANITIZER_RUNTIMES_DIR=/sanitizer-runtimes
-
-RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" && \
+RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTIMES_DIR=/sanitizer-runtimes && \
     mkdir -p $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     cp compiler-rt_build/lib/linux/libclang_rt.profile-x86_64.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     mkdir /sanitizer-runtimes && \
@@ -44,7 +42,7 @@ RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" && \
     cp -r compiler-rt_build/include/sanitizer $ROOTFS_DIR/usr/include
 
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
 ARG ROOTFS_DIR=/crossrootfs/x64
 ARG LLVM_VERSION_MAJOR=16
 

--- a/src/cbl-mariner/2.0/cross/amd64/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/amd64/Dockerfile
@@ -37,7 +37,7 @@ RUN mkdir compiler-rt_build && cd compiler-rt_build && \
 RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTIMES_DIR=/sanitizer-runtimes && \
     mkdir -p $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     cp compiler-rt_build/lib/linux/libclang_rt.profile-x86_64.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
-    mkdir /sanitizer-runtimes && \
+    mkdir ${SANITIZER_RUNTIMES_DIR} && \
     cp compiler-rt_build/lib/linux/libclang_rt.*-x86_64.a $SANITIZER_RUNTIMES_DIR && \
     cp -r compiler-rt_build/include/sanitizer $ROOTFS_DIR/usr/include
 

--- a/src/cbl-mariner/2.0/cross/arm/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/arm/Dockerfile
@@ -34,14 +34,13 @@ RUN mkdir compiler-rt_build && cd compiler-rt_build && \
         -DCMAKE_CXX_FLAGS="${BUILD_FLAGS}" && \
     make -j $(getconf _NPROCESSORS_ONLN)
 
-ARG SANITIZER_RUNTIMES_DIR=/sanitizer-runtimes
-
-RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" && \
+RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTIMES_DIR=/sanitizer-runtimes && \
     mkdir -p $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     cp compiler-rt_build/lib/linux/libclang_rt.profile-armhf.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     mkdir /sanitizer-runtimes && \
     cp compiler-rt_build/lib/linux/libclang_rt.*-armhf.a $SANITIZER_RUNTIMES_DIR && \
     cp -r compiler-rt_build/include/sanitizer $ROOTFS_DIR/usr/include
+
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
 ARG ROOTFS_DIR=/crossrootfs/arm

--- a/src/cbl-mariner/2.0/cross/arm/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/arm/Dockerfile
@@ -37,7 +37,7 @@ RUN mkdir compiler-rt_build && cd compiler-rt_build && \
 RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTIMES_DIR=/sanitizer-runtimes && \
     mkdir -p $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     cp compiler-rt_build/lib/linux/libclang_rt.profile-armhf.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
-    mkdir /sanitizer-runtimes && \
+    mkdir ${SANITIZER_RUNTIMES_DIR} && \
     cp compiler-rt_build/lib/linux/libclang_rt.*-armhf.a $SANITIZER_RUNTIMES_DIR && \
     cp -r compiler-rt_build/include/sanitizer $ROOTFS_DIR/usr/include
 

--- a/src/cbl-mariner/2.0/cross/arm/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/arm/Dockerfile
@@ -34,13 +34,18 @@ RUN mkdir compiler-rt_build && cd compiler-rt_build && \
         -DCMAKE_CXX_FLAGS="${BUILD_FLAGS}" && \
     make -j $(getconf _NPROCESSORS_ONLN)
 
+ARG SANITIZER_RUNTIMES_DIR=/sanitizer-runtimes
+
 RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" && \
     mkdir -p $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
-    cp compiler-rt_build/lib/linux/libclang_rt.*-armhf.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
+    cp compiler-rt_build/lib/linux/libclang_rt.profile-armhf.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
+    mkdir /sanitizer-runtimes && \
+    cp compiler-rt_build/lib/linux/libclang_rt.*-armhf.a $SANITIZER_RUNTIMES_DIR && \
     cp -r compiler-rt_build/include/sanitizer $ROOTFS_DIR/usr/include
-
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
 ARG ROOTFS_DIR=/crossrootfs/arm
+ARG LLVM_VERSION_MAJOR=16
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR
+COPY --from=builder /sanitizer-runtimes /usr/local/lib/clang/$LLVM_VERSION_MAJOR/lib/linux/

--- a/src/cbl-mariner/2.0/cross/arm64/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/arm64/Dockerfile
@@ -37,7 +37,7 @@ RUN mkdir compiler-rt_build && cd compiler-rt_build && \
 RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTIMES_DIR=/sanitizer-runtimes && \
     mkdir -p $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     cp compiler-rt_build/lib/linux/libclang_rt.profile-aarch64.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
-    mkdir /sanitizer-runtimes && \
+    mkdir ${SANITIZER_RUNTIMES_DIR} && \
     cp compiler-rt_build/lib/linux/libclang_rt.*-aarch64.a $SANITIZER_RUNTIMES_DIR && \
     cp -r compiler-rt_build/include/sanitizer $ROOTFS_DIR/usr/include
 

--- a/src/cbl-mariner/2.0/cross/arm64/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/arm64/Dockerfile
@@ -34,13 +34,19 @@ RUN mkdir compiler-rt_build && cd compiler-rt_build && \
         -DCMAKE_CXX_FLAGS="${BUILD_FLAGS}" && \
     make -j $(getconf _NPROCESSORS_ONLN)
 
+ARG SANITIZER_RUNTIMES_DIR=/sanitizer-runtimes
+
 RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" && \
     mkdir -p $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
-    cp compiler-rt_build/lib/linux/libclang_rt.*-aarch64.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
+    cp compiler-rt_build/lib/linux/libclang_rt.profile-aarch64.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
+    mkdir /sanitizer-runtimes && \
+    cp compiler-rt_build/lib/linux/libclang_rt.*-aarch64.a $SANITIZER_RUNTIMES_DIR && \
     cp -r compiler-rt_build/include/sanitizer $ROOTFS_DIR/usr/include
 
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
 ARG ROOTFS_DIR=/crossrootfs/arm64
+ARG LLVM_VERSION_MAJOR=16
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR
+COPY --from=builder /sanitizer-runtimes /usr/local/lib/clang/$LLVM_VERSION_MAJOR/lib/linux/

--- a/src/cbl-mariner/2.0/cross/arm64/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/arm64/Dockerfile
@@ -34,9 +34,7 @@ RUN mkdir compiler-rt_build && cd compiler-rt_build && \
         -DCMAKE_CXX_FLAGS="${BUILD_FLAGS}" && \
     make -j $(getconf _NPROCESSORS_ONLN)
 
-ARG SANITIZER_RUNTIMES_DIR=/sanitizer-runtimes
-
-RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" && \
+RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTIMES_DIR=/sanitizer-runtimes && \
     mkdir -p $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     cp compiler-rt_build/lib/linux/libclang_rt.profile-aarch64.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     mkdir /sanitizer-runtimes && \

--- a/src/cbl-mariner/2.0/cross/bionic/amd64/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/bionic/amd64/Dockerfile
@@ -42,7 +42,7 @@ RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTI
     cp -r compiler-rt_build/include/sanitizer $ROOTFS_DIR/usr/include
 
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
 ARG ROOTFS_DIR=/crossrootfs/x64
 ARG LLVM_VERSION_MAJOR=16
 

--- a/src/cbl-mariner/2.0/cross/bionic/amd64/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/bionic/amd64/Dockerfile
@@ -34,13 +34,19 @@ RUN mkdir compiler-rt_build && cd compiler-rt_build && \
         -DCMAKE_CXX_FLAGS="${BUILD_FLAGS}" && \
     make -j $(getconf _NPROCESSORS_ONLN)
 
+ARG SANITIZER_RUNTIMES_DIR=/sanitizer-runtimes
+
 RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" && \
     mkdir -p $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     cp compiler-rt_build/lib/linux/libclang_rt.profile-x86_64.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
+    mkdir /sanitizer-runtimes && \
+    cp compiler-rt_build/lib/linux/libclang_rt.*-x86_64.a $SANITIZER_RUNTIMES_DIR && \
     cp -r compiler-rt_build/include/sanitizer $ROOTFS_DIR/usr/include
 
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm
 ARG ROOTFS_DIR=/crossrootfs/x64
+ARG LLVM_VERSION_MAJOR=16
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR
+COPY --from=builder /sanitizer-runtimes /usr/local/lib/clang/$LLVM_VERSION_MAJOR/lib/linux/

--- a/src/cbl-mariner/2.0/cross/bionic/amd64/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/bionic/amd64/Dockerfile
@@ -37,7 +37,7 @@ RUN mkdir compiler-rt_build && cd compiler-rt_build && \
 RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTIMES_DIR=/sanitizer-runtimes && \
     mkdir -p $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     cp compiler-rt_build/lib/linux/libclang_rt.profile-x86_64.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
-    mkdir /sanitizer-runtimes && \
+    mkdir ${SANITIZER_RUNTIMES_DIR} && \
     cp compiler-rt_build/lib/linux/libclang_rt.*-x86_64.a $SANITIZER_RUNTIMES_DIR && \
     cp -r compiler-rt_build/include/sanitizer $ROOTFS_DIR/usr/include
 

--- a/src/cbl-mariner/2.0/cross/bionic/amd64/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/bionic/amd64/Dockerfile
@@ -34,9 +34,7 @@ RUN mkdir compiler-rt_build && cd compiler-rt_build && \
         -DCMAKE_CXX_FLAGS="${BUILD_FLAGS}" && \
     make -j $(getconf _NPROCESSORS_ONLN)
 
-ARG SANITIZER_RUNTIMES_DIR=/sanitizer-runtimes
-
-RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" && \
+RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTIMES_DIR=/sanitizer-runtimes && \
     mkdir -p $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     cp compiler-rt_build/lib/linux/libclang_rt.profile-x86_64.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     mkdir /sanitizer-runtimes && \

--- a/src/cbl-mariner/2.0/cross/bionic/arm/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/bionic/arm/Dockerfile
@@ -34,14 +34,13 @@ RUN mkdir compiler-rt_build && cd compiler-rt_build && \
         -DCMAKE_CXX_FLAGS="${BUILD_FLAGS}" && \
     make -j $(getconf _NPROCESSORS_ONLN)
 
-ARG SANITIZER_RUNTIMES_DIR=/sanitizer-runtimes
-
-RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" && \
+RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTIMES_DIR=/sanitizer-runtimes && \
     mkdir -p $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     cp compiler-rt_build/lib/linux/libclang_rt.profile-armhf.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     mkdir /sanitizer-runtimes && \
     cp compiler-rt_build/lib/linux/libclang_rt.*-armhf.a $SANITIZER_RUNTIMES_DIR && \
     cp -r compiler-rt_build/include/sanitizer $ROOTFS_DIR/usr/include
+
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
 ARG ROOTFS_DIR=/crossrootfs/arm

--- a/src/cbl-mariner/2.0/cross/bionic/arm/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/bionic/arm/Dockerfile
@@ -37,7 +37,7 @@ RUN mkdir compiler-rt_build && cd compiler-rt_build && \
 RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTIMES_DIR=/sanitizer-runtimes && \
     mkdir -p $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     cp compiler-rt_build/lib/linux/libclang_rt.profile-armhf.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
-    mkdir /sanitizer-runtimes && \
+    mkdir ${SANITIZER_RUNTIMES_DIR} && \
     cp compiler-rt_build/lib/linux/libclang_rt.*-armhf.a $SANITIZER_RUNTIMES_DIR && \
     cp -r compiler-rt_build/include/sanitizer $ROOTFS_DIR/usr/include
 

--- a/src/cbl-mariner/2.0/cross/bionic/arm/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/bionic/arm/Dockerfile
@@ -34,13 +34,18 @@ RUN mkdir compiler-rt_build && cd compiler-rt_build && \
         -DCMAKE_CXX_FLAGS="${BUILD_FLAGS}" && \
     make -j $(getconf _NPROCESSORS_ONLN)
 
+ARG SANITIZER_RUNTIMES_DIR=/sanitizer-runtimes
+
 RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" && \
     mkdir -p $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
-    cp compiler-rt_build/lib/linux/libclang_rt.*-armhf.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
+    cp compiler-rt_build/lib/linux/libclang_rt.profile-armhf.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
+    mkdir /sanitizer-runtimes && \
+    cp compiler-rt_build/lib/linux/libclang_rt.*-armhf.a $SANITIZER_RUNTIMES_DIR && \
     cp -r compiler-rt_build/include/sanitizer $ROOTFS_DIR/usr/include
-
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
 ARG ROOTFS_DIR=/crossrootfs/arm
+ARG LLVM_VERSION_MAJOR=16
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR
+COPY --from=builder /sanitizer-runtimes /usr/local/lib/clang/$LLVM_VERSION_MAJOR/lib/linux/

--- a/src/cbl-mariner/2.0/cross/bionic/arm64/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/bionic/arm64/Dockerfile
@@ -37,7 +37,7 @@ RUN mkdir compiler-rt_build && cd compiler-rt_build && \
 RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTIMES_DIR=/sanitizer-runtimes && \
     mkdir -p $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     cp compiler-rt_build/lib/linux/libclang_rt.profile-aarch64.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
-    mkdir /sanitizer-runtimes && \
+    mkdir ${SANITIZER_RUNTIMES_DIR} && \
     cp compiler-rt_build/lib/linux/libclang_rt.*-aarch64.a $SANITIZER_RUNTIMES_DIR && \
     cp -r compiler-rt_build/include/sanitizer $ROOTFS_DIR/usr/include
 

--- a/src/cbl-mariner/2.0/cross/bionic/arm64/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/bionic/arm64/Dockerfile
@@ -34,13 +34,19 @@ RUN mkdir compiler-rt_build && cd compiler-rt_build && \
         -DCMAKE_CXX_FLAGS="${BUILD_FLAGS}" && \
     make -j $(getconf _NPROCESSORS_ONLN)
 
+ARG SANITIZER_RUNTIMES_DIR=/sanitizer-runtimes
+
 RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" && \
     mkdir -p $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
-    cp compiler-rt_build/lib/linux/libclang_rt.*-aarch64.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
+    cp compiler-rt_build/lib/linux/libclang_rt.profile-aarch64.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
+    mkdir /sanitizer-runtimes && \
+    cp compiler-rt_build/lib/linux/libclang_rt.*-aarch64.a $SANITIZER_RUNTIMES_DIR && \
     cp -r compiler-rt_build/include/sanitizer $ROOTFS_DIR/usr/include
 
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
 ARG ROOTFS_DIR=/crossrootfs/arm64
+ARG LLVM_VERSION_MAJOR=16
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR
+COPY --from=builder /sanitizer-runtimes /usr/local/lib/clang/$LLVM_VERSION_MAJOR/lib/linux/

--- a/src/cbl-mariner/2.0/cross/bionic/arm64/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/bionic/arm64/Dockerfile
@@ -34,9 +34,7 @@ RUN mkdir compiler-rt_build && cd compiler-rt_build && \
         -DCMAKE_CXX_FLAGS="${BUILD_FLAGS}" && \
     make -j $(getconf _NPROCESSORS_ONLN)
 
-ARG SANITIZER_RUNTIMES_DIR=/sanitizer-runtimes
-
-RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" && \
+RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTIMES_DIR=/sanitizer-runtimes && \
     mkdir -p $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     cp compiler-rt_build/lib/linux/libclang_rt.profile-aarch64.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     mkdir /sanitizer-runtimes && \

--- a/src/cbl-mariner/2.0/cross/bionic/x86/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/bionic/x86/Dockerfile
@@ -37,7 +37,7 @@ RUN mkdir compiler-rt_build && cd compiler-rt_build && \
 RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTIMES_DIR=/sanitizer-runtimes && \
     mkdir -p $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     cp compiler-rt_build/lib/linux/libclang_rt.profile-i386.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
-    mkdir /sanitizer-runtimes && \
+    mkdir ${SANITIZER_RUNTIMES_DIR} && \
     cp compiler-rt_build/lib/linux/libclang_rt.*-i386.a $SANITIZER_RUNTIMES_DIR && \
     cp -r compiler-rt_build/include/sanitizer $ROOTFS_DIR/usr/include
 

--- a/src/cbl-mariner/2.0/cross/bionic/x86/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/bionic/x86/Dockerfile
@@ -34,9 +34,7 @@ RUN mkdir compiler-rt_build && cd compiler-rt_build && \
         -DCMAKE_CXX_FLAGS="${BUILD_FLAGS}" && \
     make -j $(getconf _NPROCESSORS_ONLN)
 
-ARG SANITIZER_RUNTIMES_DIR=/sanitizer-runtimes
-
-RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" && \
+RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTIMES_DIR=/sanitizer-runtimes && \
     mkdir -p $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     cp compiler-rt_build/lib/linux/libclang_rt.profile-i386.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     mkdir /sanitizer-runtimes && \
@@ -44,7 +42,7 @@ RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" && \
     cp -r compiler-rt_build/include/sanitizer $ROOTFS_DIR/usr/include
 
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
 ARG ROOTFS_DIR=/crossrootfs/x86
 ARG LLVM_VERSION_MAJOR=16
 

--- a/src/cbl-mariner/2.0/cross/bionic/x86/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/bionic/x86/Dockerfile
@@ -34,13 +34,19 @@ RUN mkdir compiler-rt_build && cd compiler-rt_build && \
         -DCMAKE_CXX_FLAGS="${BUILD_FLAGS}" && \
     make -j $(getconf _NPROCESSORS_ONLN)
 
+ARG SANITIZER_RUNTIMES_DIR=/sanitizer-runtimes
+
 RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" && \
     mkdir -p $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
-    cp compiler-rt_build/lib/linux/libclang_rt.*-i386.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
+    cp compiler-rt_build/lib/linux/libclang_rt.profile-i386.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
+    mkdir /sanitizer-runtimes && \
+    cp compiler-rt_build/lib/linux/libclang_rt.*-i386.a $SANITIZER_RUNTIMES_DIR && \
     cp -r compiler-rt_build/include/sanitizer $ROOTFS_DIR/usr/include
 
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm
 ARG ROOTFS_DIR=/crossrootfs/x86
+ARG LLVM_VERSION_MAJOR=16
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR
+COPY --from=builder /sanitizer-runtimes /usr/local/lib/clang/$LLVM_VERSION_MAJOR/lib/linux/

--- a/src/cbl-mariner/2.0/cross/x86/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/x86/Dockerfile
@@ -37,7 +37,7 @@ RUN mkdir compiler-rt_build && cd compiler-rt_build && \
 RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTIMES_DIR=/sanitizer-runtimes && \
     mkdir -p $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     cp compiler-rt_build/lib/linux/libclang_rt.profile-i386.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
-    mkdir /sanitizer-runtimes && \
+    mkdir ${SANITIZER_RUNTIMES_DIR} && \
     cp compiler-rt_build/lib/linux/libclang_rt.*-i386.a $SANITIZER_RUNTIMES_DIR && \
     cp -r compiler-rt_build/include/sanitizer $ROOTFS_DIR/usr/include
 

--- a/src/cbl-mariner/2.0/cross/x86/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/x86/Dockerfile
@@ -34,9 +34,7 @@ RUN mkdir compiler-rt_build && cd compiler-rt_build && \
         -DCMAKE_CXX_FLAGS="${BUILD_FLAGS}" && \
     make -j $(getconf _NPROCESSORS_ONLN)
 
-ARG SANITIZER_RUNTIMES_DIR=/sanitizer-runtimes
-
-RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" && \
+RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTIMES_DIR=/sanitizer-runtimes && \
     mkdir -p $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     cp compiler-rt_build/lib/linux/libclang_rt.profile-i386.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     mkdir /sanitizer-runtimes && \
@@ -44,7 +42,7 @@ RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" && \
     cp -r compiler-rt_build/include/sanitizer $ROOTFS_DIR/usr/include
 
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
 ARG ROOTFS_DIR=/crossrootfs/x86
 ARG LLVM_VERSION_MAJOR=16
 

--- a/src/cbl-mariner/2.0/cross/x86/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/x86/Dockerfile
@@ -34,13 +34,19 @@ RUN mkdir compiler-rt_build && cd compiler-rt_build && \
         -DCMAKE_CXX_FLAGS="${BUILD_FLAGS}" && \
     make -j $(getconf _NPROCESSORS_ONLN)
 
+ARG SANITIZER_RUNTIMES_DIR=/sanitizer-runtimes
+
 RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" && \
     mkdir -p $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
-    cp compiler-rt_build/lib/linux/libclang_rt.*-i386.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
+    cp compiler-rt_build/lib/linux/libclang_rt.profile-i386.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
+    mkdir /sanitizer-runtimes && \
+    cp compiler-rt_build/lib/linux/libclang_rt.*-i386.a $SANITIZER_RUNTIMES_DIR && \
     cp -r compiler-rt_build/include/sanitizer $ROOTFS_DIR/usr/include
 
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm
 ARG ROOTFS_DIR=/crossrootfs/x86
+ARG LLVM_VERSION_MAJOR=16
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR
+COPY --from=builder /sanitizer-runtimes /usr/local/lib/clang/$LLVM_VERSION_MAJOR/lib/linux/


### PR DESCRIPTION
This seems to be required by clang 16.