### PR TITLE
Add libatomic to Centos Stream 8 image

### DIFF
--- a/src/centos/stream8/Dockerfile
+++ b/src/centos/stream8/Dockerfile
@@ -26,6 +26,7 @@ RUN dnf install --setopt tsflags=nodocs --refresh -y \
         hostname \
         jq \
         krb5-devel \
+        # new dependency required when linking against libc++ instead of libstdc++ \
         libatomic \
         libcurl-devel \
         libedit-devel \

--- a/src/centos/stream8/Dockerfile
+++ b/src/centos/stream8/Dockerfile
@@ -26,6 +26,7 @@ RUN dnf install --setopt tsflags=nodocs --refresh -y \
         hostname \
         jq \
         krb5-devel \
+        libatomic \
         libcurl-devel \
         libedit-devel \
         libicu-devel \


### PR DESCRIPTION
The CentOS 8 image is used to run Mono LLVM AOT tests, in the interim, until Mono's AOT compiler is updated to use `llvm-as` instead of GNU Binutils `as`. However, LLVM 16 introduces a dependency on libatomic.so.1 which is satisfied on Mariner, but is absent on our CentOS Stream 8 image.

Fixing Mono's aot-compiler.c is the better long-term solution, but this unblocks test failures on the LLVM 16 integration work.