### PR TITLE
Add sanitizer headers under the clang resource directory

### DIFF
--- a/src/cbl-mariner/2.0/cross/amd64/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/amd64/Dockerfile
@@ -38,8 +38,7 @@ RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTI
     mkdir -p $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     cp compiler-rt_build/lib/linux/libclang_rt.profile-x86_64.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     mkdir ${SANITIZER_RUNTIMES_DIR} && \
-    cp compiler-rt_build/lib/linux/libclang_rt.*-x86_64.a $SANITIZER_RUNTIMES_DIR && \
-    cp -r compiler-rt_build/include/sanitizer $ROOTFS_DIR/usr/include
+    cp compiler-rt_build/lib/linux/libclang_rt.*-x86_64.a $SANITIZER_RUNTIMES_DIR
 
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
@@ -48,3 +47,4 @@ ARG LLVM_VERSION_MAJOR=16
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR
 COPY --from=builder /sanitizer-runtimes /usr/local/lib/clang/$LLVM_VERSION_MAJOR/lib/linux/
+COPY --from=builder compiler-rt_build/include/sanitizer /usr/local/lib/clang/$LLVM_VERSION_MAJOR/include/sanitizer/

--- a/src/cbl-mariner/2.0/cross/arm/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/arm/Dockerfile
@@ -38,8 +38,7 @@ RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTI
     mkdir -p $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     cp compiler-rt_build/lib/linux/libclang_rt.profile-armhf.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     mkdir ${SANITIZER_RUNTIMES_DIR} && \
-    cp compiler-rt_build/lib/linux/libclang_rt.*-armhf.a $SANITIZER_RUNTIMES_DIR && \
-    cp -r compiler-rt_build/include/sanitizer $ROOTFS_DIR/usr/include
+    cp compiler-rt_build/lib/linux/libclang_rt.*-armhf.a $SANITIZER_RUNTIMES_DIR
 
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
@@ -48,3 +47,4 @@ ARG LLVM_VERSION_MAJOR=16
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR
 COPY --from=builder /sanitizer-runtimes /usr/local/lib/clang/$LLVM_VERSION_MAJOR/lib/linux/
+COPY --from=builder compiler-rt_build/include/sanitizer /usr/local/lib/clang/$LLVM_VERSION_MAJOR/include/sanitizer/

--- a/src/cbl-mariner/2.0/cross/arm64/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/arm64/Dockerfile
@@ -38,8 +38,7 @@ RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTI
     mkdir -p $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     cp compiler-rt_build/lib/linux/libclang_rt.profile-aarch64.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     mkdir ${SANITIZER_RUNTIMES_DIR} && \
-    cp compiler-rt_build/lib/linux/libclang_rt.*-aarch64.a $SANITIZER_RUNTIMES_DIR && \
-    cp -r compiler-rt_build/include/sanitizer $ROOTFS_DIR/usr/include
+    cp compiler-rt_build/lib/linux/libclang_rt.*-aarch64.a $SANITIZER_RUNTIMES_DIR
 
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
@@ -48,3 +47,4 @@ ARG LLVM_VERSION_MAJOR=16
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR
 COPY --from=builder /sanitizer-runtimes /usr/local/lib/clang/$LLVM_VERSION_MAJOR/lib/linux/
+COPY --from=builder compiler-rt_build/include/sanitizer /usr/local/lib/clang/$LLVM_VERSION_MAJOR/include/sanitizer/

--- a/src/cbl-mariner/2.0/cross/bionic/amd64/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/bionic/amd64/Dockerfile
@@ -38,8 +38,7 @@ RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTI
     mkdir -p $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     cp compiler-rt_build/lib/linux/libclang_rt.profile-x86_64.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     mkdir ${SANITIZER_RUNTIMES_DIR} && \
-    cp compiler-rt_build/lib/linux/libclang_rt.*-x86_64.a $SANITIZER_RUNTIMES_DIR && \
-    cp -r compiler-rt_build/include/sanitizer $ROOTFS_DIR/usr/include
+    cp compiler-rt_build/lib/linux/libclang_rt.*-x86_64.a $SANITIZER_RUNTIMES_DIR
 
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
@@ -48,3 +47,4 @@ ARG LLVM_VERSION_MAJOR=16
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR
 COPY --from=builder /sanitizer-runtimes /usr/local/lib/clang/$LLVM_VERSION_MAJOR/lib/linux/
+COPY --from=builder compiler-rt_build/include/sanitizer /usr/local/lib/clang/$LLVM_VERSION_MAJOR/include/sanitizer/

--- a/src/cbl-mariner/2.0/cross/bionic/arm/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/bionic/arm/Dockerfile
@@ -38,8 +38,7 @@ RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTI
     mkdir -p $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     cp compiler-rt_build/lib/linux/libclang_rt.profile-armhf.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     mkdir ${SANITIZER_RUNTIMES_DIR} && \
-    cp compiler-rt_build/lib/linux/libclang_rt.*-armhf.a $SANITIZER_RUNTIMES_DIR && \
-    cp -r compiler-rt_build/include/sanitizer $ROOTFS_DIR/usr/include
+    cp compiler-rt_build/lib/linux/libclang_rt.*-armhf.a $SANITIZER_RUNTIMES_DIR
 
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
@@ -48,3 +47,4 @@ ARG LLVM_VERSION_MAJOR=16
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR
 COPY --from=builder /sanitizer-runtimes /usr/local/lib/clang/$LLVM_VERSION_MAJOR/lib/linux/
+COPY --from=builder compiler-rt_build/include/sanitizer /usr/local/lib/clang/$LLVM_VERSION_MAJOR/include/sanitizer/

--- a/src/cbl-mariner/2.0/cross/bionic/arm64/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/bionic/arm64/Dockerfile
@@ -38,8 +38,7 @@ RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTI
     mkdir -p $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     cp compiler-rt_build/lib/linux/libclang_rt.profile-aarch64.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     mkdir ${SANITIZER_RUNTIMES_DIR} && \
-    cp compiler-rt_build/lib/linux/libclang_rt.*-aarch64.a $SANITIZER_RUNTIMES_DIR && \
-    cp -r compiler-rt_build/include/sanitizer $ROOTFS_DIR/usr/include
+    cp compiler-rt_build/lib/linux/libclang_rt.*-aarch64.a $SANITIZER_RUNTIMES_DIR
 
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
@@ -48,3 +47,4 @@ ARG LLVM_VERSION_MAJOR=16
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR
 COPY --from=builder /sanitizer-runtimes /usr/local/lib/clang/$LLVM_VERSION_MAJOR/lib/linux/
+COPY --from=builder compiler-rt_build/include/sanitizer /usr/local/lib/clang/$LLVM_VERSION_MAJOR/include/sanitizer/

--- a/src/cbl-mariner/2.0/cross/bionic/x86/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/bionic/x86/Dockerfile
@@ -38,8 +38,7 @@ RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTI
     mkdir -p $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     cp compiler-rt_build/lib/linux/libclang_rt.profile-i386.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     mkdir ${SANITIZER_RUNTIMES_DIR} && \
-    cp compiler-rt_build/lib/linux/libclang_rt.*-i386.a $SANITIZER_RUNTIMES_DIR && \
-    cp -r compiler-rt_build/include/sanitizer $ROOTFS_DIR/usr/include
+    cp compiler-rt_build/lib/linux/libclang_rt.*-i386.a $SANITIZER_RUNTIMES_DIR
 
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
@@ -48,3 +47,4 @@ ARG LLVM_VERSION_MAJOR=16
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR
 COPY --from=builder /sanitizer-runtimes /usr/local/lib/clang/$LLVM_VERSION_MAJOR/lib/linux/
+COPY --from=builder compiler-rt_build/include/sanitizer /usr/local/lib/clang/$LLVM_VERSION_MAJOR/include/sanitizer/

--- a/src/cbl-mariner/2.0/cross/x86/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/x86/Dockerfile
@@ -38,8 +38,7 @@ RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTI
     mkdir -p $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     cp compiler-rt_build/lib/linux/libclang_rt.profile-i386.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
     mkdir ${SANITIZER_RUNTIMES_DIR} && \
-    cp compiler-rt_build/lib/linux/libclang_rt.*-i386.a $SANITIZER_RUNTIMES_DIR && \
-    cp -r compiler-rt_build/include/sanitizer $ROOTFS_DIR/usr/include
+    cp compiler-rt_build/lib/linux/libclang_rt.*-i386.a $SANITIZER_RUNTIMES_DIR
 
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
@@ -48,3 +47,4 @@ ARG LLVM_VERSION_MAJOR=16
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR
 COPY --from=builder /sanitizer-runtimes /usr/local/lib/clang/$LLVM_VERSION_MAJOR/lib/linux/
+COPY --from=builder compiler-rt_build/include/sanitizer /usr/local/lib/clang/$LLVM_VERSION_MAJOR/include/sanitizer/


### PR DESCRIPTION
We're trying to start using the official ASAN headers in https://github.com/dotnet/runtime/pull/89204 and we're hitting issues about where to include them from.

This PR updates them to be placed next to clang like they are in a standard clang installation and not in the rootfs like we were doing