### PR TITLE
Default job timeouts to an integer value

### DIFF
--- a/eng/pipelines/dotnet-buildtools-prereqs-alpine-pr.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-alpine-pr.yml
@@ -24,3 +24,4 @@ stages:
   parameters:
     internalProjectName: ${{ variables.internalProjectName }}
     publicProjectName: ${{ variables.publicProjectName }}
+    linuxArmBuildJobTimeout: 120

--- a/eng/pipelines/dotnet-buildtools-prereqs-alpine.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-alpine.yml
@@ -24,3 +24,4 @@ stages:
   parameters:
     internalProjectName: ${{ variables.internalProjectName }}
     publicProjectName: ${{ variables.publicProjectName }}
+    linuxArmBuildJobTimeout: 120

--- a/eng/pipelines/stages/build-test-publish-repo.yml
+++ b/eng/pipelines/stages/build-test-publish-repo.yml
@@ -2,8 +2,8 @@ parameters:
   noCache: false
   internalProjectName: null
   publicProjectName: null
-  linuxAmdBuildJobTimeout: null
-  linuxArmBuildJobTimeout: null
+  linuxAmdBuildJobTimeout: 60
+  linuxArmBuildJobTimeout: 60
   customBuildInitSteps: []
   customCopyBaseImagesInitSteps: []
 

--- a/src/almalinux/8/helix/amd64/Dockerfile
+++ b/src/almalinux/8/helix/amd64/Dockerfile
@@ -4,7 +4,7 @@ FROM almalinux:8
 # (Use centos/8 rather than rhel/8 because the latter doesn't have
 #  libmsquic except in the 8.1-specific packages feed.)
 RUN rpm -Uvh https://packages.microsoft.com/config/centos/8/packages-microsoft-prod.rpm && \
-    yum update && \
+    yum update -y && \
     yum install -y \
         # Get recent python3 This is needed to get a pip recent enough
         # not to fail the build when installing cryptography library as


### PR DESCRIPTION
When attempting to run a build for a pipeline that doesn't set the job timeout, it gets the following error:

```
/eng/common/templates/jobs/build-images.yml (Line: 24, Col: 21): Expected an integer value. Actual value: 'null'
```

This is a regression caused by the changes in https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/901. The [default values for the timeouts are set to `null`](https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/213a54af419383d9a8f1f7b3dc4b474c3af64e39/eng/pipelines/stages/build-test-publish-repo.yml#L5-L6) which is not a valid value.

Fixed by setting them to an integer value.