### PR TITLE
Add images with both "host" and "target" crossroots in one image.

### DIFF
--- a/src/cbl-mariner/2.0/cross/biarch/amd64-alpine/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/biarch/amd64-alpine/Dockerfile
@@ -1,0 +1,7 @@
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64-alpine-local AS crossrootbiarch
+
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64
+
+# Copy crossrootfs from Alpine build image, so we can build and cross-compile
+# cross compilers within the same build system (e.g. required for Node.js)
+COPY --from=crossrootbiarch /crossrootfs/x64 /crossrootfs/x64-alpine

--- a/src/cbl-mariner/2.0/cross/biarch/amd64-alpine/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/biarch/amd64-alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64-alpine-local AS crossrootbiarch
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64-local
 
 # Copy crossrootfs from Alpine build image, so we can build and cross-compile
 # cross compilers within the same build system (e.g. required for Node.js)

--- a/src/cbl-mariner/2.0/cross/biarch/arm64-alpine/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/biarch/arm64-alpine/Dockerfile
@@ -1,0 +1,7 @@
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm64-alpine-local AS crossrootbiarch
+
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64
+
+# Copy crossrootfs from Alpine build image, so we can build and cross-compile
+# cross compilers within the same build system (e.g. required for Node.js)
+COPY --from=crossrootbiarch /crossrootfs/arm64 /crossrootfs/arm64-alpine

--- a/src/cbl-mariner/2.0/cross/biarch/arm64-alpine/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/biarch/arm64-alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm64-alpine-local AS crossrootbiarch
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64-local
 
 # Copy crossrootfs from Alpine build image, so we can build and cross-compile
 # cross compilers within the same build system (e.g. required for Node.js)

--- a/src/cbl-mariner/2.0/cross/biarch/arm64/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/biarch/arm64/Dockerfile
@@ -1,0 +1,7 @@
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm64-local AS crossrootbiarch
+
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64
+
+# Copy crossrootfs from ARM64 build image, so we can build and cross-compile
+# cross compilers within the same build system (e.g. required for Node.js)
+COPY --from=crossrootbiarch /crossrootfs/arm64 /crossrootfs/arm64

--- a/src/cbl-mariner/2.0/cross/biarch/arm64/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/biarch/arm64/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm64-local AS crossrootbiarch
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64-local
 
 # Copy crossrootfs from ARM64 build image, so we can build and cross-compile
 # cross compilers within the same build system (e.g. required for Node.js)

--- a/src/cbl-mariner/manifest.json
+++ b/src/cbl-mariner/manifest.json
@@ -360,7 +360,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner2.0",
               "tags": {
-                "cbl-mariner-2.0-cross-biarch-amd64-amd64-alpine$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "cbl-mariner-2.0-cross-biarch-amd64-amd64-alpine-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
                 "cbl-mariner-2.0-cross-biarch-amd64-amd64-alpine$(FloatingTagSuffix)": {}
               }
             }

--- a/src/cbl-mariner/manifest.json
+++ b/src/cbl-mariner/manifest.json
@@ -321,6 +321,45 @@
         {
           "platforms": [
             {
+              "dockerfile": "src/cbl-mariner/2.0/cross/biarch/arm64",
+              "os": "linux",
+              "osVersion": "cbl-mariner2.0",
+              "tags": {
+                "cbl-mariner-2.0-cross-biarch-amd64-arm64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "cbl-mariner-2.0-cross-biarch-amd64-arm64$(FloatingTagSuffix)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/cbl-mariner/2.0/cross/biarch/arm64-alpine",
+              "os": "linux",
+              "osVersion": "cbl-mariner2.0",
+              "tags": {
+                "cbl-mariner-2.0-cross-biarch-amd64-arm64-alpine-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "cbl-mariner-2.0-cross-biarch-amd64-arm64-alpine$(FloatingTagSuffix)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/cbl-mariner/2.0/cross/biarch/amd64-alpine",
+              "os": "linux",
+              "osVersion": "cbl-mariner2.0",
+              "tags": {
+                "cbl-mariner-2.0-cross-biarch-amd64-amd64-alpine$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "cbl-mariner-2.0-cross-biarch-amd64-amd64-alpine$(FloatingTagSuffix)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
               "dockerfile": "src/cbl-mariner/2.0/webassembly",
               "os": "linux",
               "osVersion": "cbl-mariner2.0",

--- a/src/cbl-mariner/manifest.json
+++ b/src/cbl-mariner/manifest.json
@@ -114,7 +114,10 @@
               "osVersion": "cbl-mariner2.0",
               "tags": {
                 "cbl-mariner-2.0-cross-amd64-alpine-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "cbl-mariner-2.0-cross-amd64-alpine$(FloatingTagSuffix)": {}
+                "cbl-mariner-2.0-cross-amd64-alpine$(FloatingTagSuffix)": {},
+                "cbl-mariner-2.0-cross-amd64-alpine-local": {
+                  "isLocal": true
+                }
               }
             }
           ]
@@ -153,7 +156,10 @@
               "osVersion": "cbl-mariner2.0",
               "tags": {
                 "cbl-mariner-2.0-cross-arm64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "cbl-mariner-2.0-cross-arm64$(FloatingTagSuffix)": {}
+                "cbl-mariner-2.0-cross-arm64$(FloatingTagSuffix)": {},
+                "cbl-mariner-2.0-cross-arm64-local": {
+                  "isLocal": true
+                }
               }
             }
           ]
@@ -166,7 +172,10 @@
               "osVersion": "cbl-mariner2.0",
               "tags": {
                 "cbl-mariner-2.0-cross-arm64-alpine-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "cbl-mariner-2.0-cross-arm64-alpine$(FloatingTagSuffix)": {}
+                "cbl-mariner-2.0-cross-arm64-alpine$(FloatingTagSuffix)": {},
+                "cbl-mariner-2.0-cross-arm64-alpine-local": {
+                  "isLocal": true
+                }
               }
             }
           ]


### PR DESCRIPTION
This is required in some cases - e.g. compiling node.js for ARM64/Alpine, and the ever-broken ARM64 runtime perf lane (where we need headers for ARM64 available alongside linkable libraries for AMD64, depending on the build phase).

As is, we've achieved the same result largely by accident in the pre-Mariner build images, where we have enough x64 in the host OS to link successfully, and the ARM64 files in the crossroot.

The precedent on this is https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/901 which fixed our Android cross-compiler builds, by offering both Android and $HOST in the same system

If at some point in the future we move from building on x64 to building on ARM64, we will need the equivalent images for that.