### PR TITLE
Add git to Docker TestRunner image

### DIFF
--- a/src/cbl-mariner/2.0/docker-testrunner/Dockerfile
+++ b/src/cbl-mariner/2.0/docker-testrunner/Dockerfile
@@ -10,5 +10,6 @@ RUN tdnf install -y \
         moby-buildx \
         moby-cli \
         # Test dependencies
+        git \
         powershell \
     && tdnf clean all


### PR DESCRIPTION
To facilitate https://github.com/dotnet/dotnet-docker/issues/4843, this adds git to the Docker testrunner in order to show a rich diff between file lists of SDK contents. There's precedent for using Git in the source-build SDK comparison tests: https://github.com/dotnet/installer/blob/b1a461bdca599a57ee454502015263c9896c8970/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/BaselineHelper.cs#L83