### PR TITLE
Add `sudo` to mariner helix container

### DIFF
--- a/src/cbl-mariner/2.0/helix/amd64/Dockerfile
+++ b/src/cbl-mariner/2.0/helix/amd64/Dockerfile
@@ -12,6 +12,7 @@ RUN tdnf install --setopt tsflags=nodocs --refresh -y \
          libmsquic \
          python3-pip \
          shadow-utils \
+         sudo \
          tzdata \
          which \
     && tdnf clean all


### PR DESCRIPTION
The mariner helix container doesn't have `sudo` installed despite configuring `helixbot` with passwordless-sudo privileges. This means helix jobs that use this container have no simple way of elevating. Other helix container do have `sudo`, e.g.:
- https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/fee9ecbf01f747cac49181cf33cf6900c0b0ebb2/src/debian/12/helix/amd64/Dockerfile#L28
- https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/fee9ecbf01f747cac49181cf33cf6900c0b0ebb2/src/fedora/38/helix/amd64/Dockerfile#L13
- https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/fee9ecbf01f747cac49181cf33cf6900c0b0ebb2/src/ubuntu/22.04/helix/amd64/Dockerfile#L33