### PR TITLE
Unblock Debian build by disabling arm32 images

### DIFF
--- a/src/debian/manifest.json
+++ b/src/debian/manifest.json
@@ -20,21 +20,6 @@
         {
           "platforms": [
             {
-              "architecture": "arm",
-              "dockerfile": "src/debian/10/helix/arm32v7",
-              "os": "linux",
-              "osVersion": "buster",
-              "tags": {
-                "debian-10-helix-arm32v7-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "debian-10-helix-arm32v7$(FloatingTagSuffix)": {}
-              },
-              "variant": "v7"
-            }
-          ]
-        },
-        {
-          "platforms": [
-            {
               "architecture": "arm64",
               "dockerfile": "src/debian/10/helix/arm64v8",
               "os": "linux",
@@ -72,21 +57,6 @@
                 "debian-11-helix-amd64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
                 "debian-11-helix-amd64$(FloatingTagSuffix)": {}
               }
-            }
-          ]
-        },
-        {
-          "platforms": [
-            {
-              "architecture": "arm",
-              "dockerfile": "src/debian/11/helix/arm32v7",
-              "os": "linux",
-              "osVersion": "bullseye",
-              "tags": {
-                "debian-11-helix-arm32v7-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "debian-11-helix-arm32v7$(FloatingTagSuffix)": {}
-              },
-              "variant": "v7"
             }
           ]
         },

--- a/src/raspbian/manifest.json
+++ b/src/raspbian/manifest.json
@@ -20,22 +20,6 @@
               "variant": "v7"
             }
           ]
-        },
-
-        {
-          "platforms": [
-            {
-              "architecture": "arm",
-              "dockerfile": "src/raspbian/10/helix/arm32v6",
-              "os": "linux",
-              "osVersion": "buster",
-              "tags": {
-                "raspbian-10-helix-arm32v6-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "raspbian-10-helix-arm32v6$(FloatingTagSuffix)": {}
-              },
-              "variant": "v6"
-            }
-          ]
         }
       ]
     }


### PR DESCRIPTION
- Disable arm32 debian images
- Also disable raspbian

Context: https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/925#issuecomment-1771743023

Debian builds stopped working because the python Cryptography wheel doesn't ship binaries for arm32. It tries to compile itself from source. In Ubuntu, we can do that by installing Rust. Debian's Rust version isn't new enough to compile Cryptography. The fix will be more involved so for now we need to disable Debian builds by removing the images from the manifest. This will unblock builds and PRs in this repo.