### PR TITLE
Build clang-tools-extra to get clang-tidy

### DIFF
--- a/src/cbl-mariner/2.0/crossdeps-builder/Dockerfile
+++ b/src/cbl-mariner/2.0/crossdeps-builder/Dockerfile
@@ -63,7 +63,7 @@ RUN mkdir llvm-project.src && \
         -DCMAKE_CXX_COMPILER=clang++ \
         -DLLVM_TARGETS_TO_BUILD="host;AArch64;ARM" \
         -Wno-dev \
-        -DLLVM_ENABLE_PROJECTS="clang;lld" && \
+        -DLLVM_ENABLE_PROJECTS="clang;lld;clang-tools-extra" && \
     make -j $(getconf _NPROCESSORS_ONLN) && \
     make install
 


### PR DESCRIPTION
clang-tidy is one of the tools used in the JIT formatting scripts, along with clang-format.

Clang-format is already included today in the image (it builds as part of the `clang` project).