### PR TITLE
enable Debian 11 arm32 image

### DIFF
--- a/src/debian/11/helix/arm32v7/Dockerfile
+++ b/src/debian/11/helix/arm32v7/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && \
         libunwind8 \
         locales \
         locales-all \
+        python3-cryptography \
         python3-dev \
         python3-pip \
         software-properties-common \

--- a/src/debian/manifest.json
+++ b/src/debian/manifest.json
@@ -76,6 +76,21 @@
           ]
         },
         {
+            "platforms": [
+            {
+              "architecture": "arm",
+              "dockerfile": "src/debian/11/helix/arm32v7",
+              "os": "linux",
+              "osVersion": "bullseye",
+              "tags": {
+                "debian-11-helix-arm32v7-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "debian-11-helix-arm32v7$(FloatingTagSuffix)": {}
+              },
+              "variant": "v7"
+            }
+          ]
+        },
+        {
           "platforms": [
             {
               "architecture": "arm64",


### PR DESCRIPTION
this reverts part of #927. It seems like using OS `cryptography`  does the trick without dependency on `rust`.

I did not bother with 10. We should perhaps move to 12 eventually if we want to keep two different versions. 

cc: @CarnaViire