### PR TITLE
Switch centos from stream9-development to stream9

### DIFF
--- a/src/centos/stream9/Dockerfile
+++ b/src/centos/stream9/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream9-development
+FROM quay.io/centos/centos:stream9
 
 # Install dependencies
 

--- a/src/centos/stream9/helix/amd64/Dockerfile
+++ b/src/centos/stream9/helix/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream9-development
+FROM quay.io/centos/centos:stream9
 
 # Install dependencies
 RUN dnf install --setopt tsflags=nodocs --refresh -y \


### PR DESCRIPTION
https://quay.io/repository/centos/centos?tab=tags says the `stream9-development` tag was last updated a year ago. `stream8` and `stream9` seem to be constantly updated. So use those instead.