### PR TITLE
Pin msquic to pre-regression revision on Alpine Arm32

### DIFF
--- a/src/alpine/3.15/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.15/helix/arm32v7/Dockerfile
@@ -54,7 +54,7 @@ RUN apk update && apk add --no-cache && \
         openssl-dev \
         perl && \
     cd /tmp && \
-    git clone --depth 1 --single-branch --branch alpine-arm32-pin-2023-08 --recursive https://github.com/dotnet/msquic && \
+    git clone --depth 1 --single-branch --branch msquic-v2.2.2 --recursive https://github.com/dotnet/msquic && \
     cd msquic/src/msquic && \
     cmake -B build/linux/arm_openssl \
        -DQUIC_OUTPUT_DIR=/tmp/msquic/src/msquic/artifacts/bin/linux/arm_Release_openssl \

--- a/src/alpine/3.15/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.15/helix/arm32v7/Dockerfile
@@ -54,7 +54,7 @@ RUN apk update && apk add --no-cache && \
         openssl-dev \
         perl && \
     cd /tmp && \
-    git clone --depth 1 --single-branch --branch main --recursive https://github.com/dotnet/msquic && \
+    git clone --depth 1 --single-branch --branch alpine-arm32-pin-2023-08 --recursive https://github.com/dotnet/msquic && \
     cd msquic/src/msquic && \
     cmake -B build/linux/arm_openssl \
        -DQUIC_OUTPUT_DIR=/tmp/msquic/src/msquic/artifacts/bin/linux/arm_Release_openssl \

--- a/src/alpine/3.16/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.16/helix/arm32v7/Dockerfile
@@ -53,7 +53,7 @@ RUN apk update && apk add --no-cache && \
         openssl-dev \
         perl && \
     cd /tmp && \
-    git clone --depth 1 --single-branch --branch alpine-arm32-pin-2023-08 --recursive https://github.com/dotnet/msquic && \
+    git clone --depth 1 --single-branch --branch msquic-v2.2.2 --recursive https://github.com/dotnet/msquic && \
     cd msquic/src/msquic && \
     cmake -B build/linux/arm_openssl \
        -DQUIC_OUTPUT_DIR=/tmp/msquic/src/msquic/artifacts/bin/linux/arm_Release_openssl \

--- a/src/alpine/3.16/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.16/helix/arm32v7/Dockerfile
@@ -53,7 +53,7 @@ RUN apk update && apk add --no-cache && \
         openssl-dev \
         perl && \
     cd /tmp && \
-    git clone --depth 1 --single-branch --branch main --recursive https://github.com/dotnet/msquic && \
+    git clone --depth 1 --single-branch --branch alpine-arm32-pin-2023-08 --recursive https://github.com/dotnet/msquic && \
     cd msquic/src/msquic && \
     cmake -B build/linux/arm_openssl \
        -DQUIC_OUTPUT_DIR=/tmp/msquic/src/msquic/artifacts/bin/linux/arm_Release_openssl \


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/91757

While pinning to a docker tag temporarily mitigated the issue above, it doesn't allow us to consume any of the docker image updates, that are unrelated to msquic, e.g. see https://github.com/dotnet/dnceng/issues/1423#issuecomment-1823466181.

Changing it to pin to a pre-regression msquic revision instead of main, so we can "unlock" the image in runtime CI again.

cc @wfurt