### PR TITLE
Disable failing Debian Arm32 Helix image build

### DIFF
--- a/src/debian/manifest.json
+++ b/src/debian/manifest.json
@@ -76,21 +76,6 @@
           ]
         },
         {
-            "platforms": [
-            {
-              "architecture": "arm",
-              "dockerfile": "src/debian/11/helix/arm32v7",
-              "os": "linux",
-              "osVersion": "bullseye",
-              "tags": {
-                "debian-11-helix-arm32v7-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "debian-11-helix-arm32v7$(FloatingTagSuffix)": {}
-              },
-              "variant": "v7"
-            }
-          ]
-        },
-        {
           "platforms": [
             {
               "architecture": "arm64",


### PR DESCRIPTION
The version of `python3-cryptography` provided by Debian (added in https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/929) no longer satisfies Helix's requirements, causing the build to fail. We should disable the build to unblock other image builds.
 
@wfurt and @dougbu are working on getting this build fixed in the meantime.