### PR TITLE
use icu-data-full for runtime tests to pass

### DIFF
--- a/src/alpine/3.16/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.16/helix/arm32v7/Dockerfile
@@ -4,7 +4,7 @@ RUN apk update && apk add --no-cache \
     bash \
     coreutils \
     curl \
-    icu-data \
+    icu-data-full \
     icu-libs \
     iputils \
     krb5-libs \

--- a/src/alpine/3.16/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.16/helix/arm64v8/Dockerfile
@@ -4,7 +4,7 @@ RUN apk update && apk add --no-cache \
     bash \
     coreutils \
     curl \
-    icu-data \
+    icu-data-full \
     icu-libs \
     iputils \
     krb5-libs \


### PR DESCRIPTION
This is one more follow-up on  #931 - we need full ICU data set and that got missed from ARM in initial version. 