### PR TITLE
Update NodeJS on Windows for Wasm tests

### DIFF
--- a/src/windowsservercore/ltsc2022/helix/webassembly/Dockerfile
+++ b/src/windowsservercore/ltsc2022/helix/webassembly/Dockerfile
@@ -36,7 +36,7 @@ RUN cd %EMSDK_PATH% \
     && .\emsdk activate %EMSCRIPTEN_VERSION%-upstream
 
 # install Node JS
-ENV NODE_VERSION 17.3.1
+ENV NODE_VERSION 18.17.1
 
 RUN curl -SL --output %TEMP%\nodejs.msi https://nodejs.org/dist/v%NODE_VERSION%/node-v%NODE_VERSION%-x64.msi
 RUN msiexec /i %TEMP%\nodejs.msi /quiet /passive /qn /norestart


### PR DESCRIPTION
Motivation:
we are running the same test on Linux and Windows, using NodeJS. Because the response of APIs differ between NodeJS versions, one OS fails, the other passes. We would like to keep it consistent.

Sample run with this situation: https://dev.azure.com/dnceng-public/public/_build/results?buildId=489358&view=results.
Why this version - in the quoted run we can see logs from Linux
```
[17:05:45] info: Using js engine NodeJS from path /usr/bin/node
[17:05:45] info: v18.17.1
```
the version is copied from there.