### PR TITLE
Add msquic to debian12

### DIFF
--- a/src/debian/12/helix/amd64/Dockerfile
+++ b/src/debian/12/helix/amd64/Dockerfile
@@ -44,6 +44,7 @@ RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
     apt-key add microsoft.asc && \
     rm microsoft.asc && \
     apt-add-repository https://packages.microsoft.com/debian/12/prod && \
+    echo deb https://packages.microsoft.com/debian/12/prod bookworm main >> /etc/apt/sources.list.d/microsoft.list && \
     apt-get update && \
     apt-get install -y libmsquic && \
     rm -rf /var/lib/apt/lists/*

--- a/src/debian/12/helix/amd64/Dockerfile
+++ b/src/debian/12/helix/amd64/Dockerfile
@@ -38,6 +38,16 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     python3 -m pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
     python3 -m pip install ./helix_scripts-*-py3-none-any.whl --break-system-packages
 
+# Add MsQuic
+RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
+    echo 2cfd20a306b2fa5e25522d78f2ef50a1f429d35fd30bd983e2ebffc2b80944fa microsoft.asc| sha256sum --check - && \
+    apt-key add microsoft.asc && \
+    rm microsoft.asc && \
+    apt-add-repository https://packages.microsoft.com/debian/12/prod && \
+    apt-get update && \
+    apt-get install -y libmsquic && \
+    rm -rf /var/lib/apt/lists/*
+
 # Create helixbot user and give rights to sudo without password
 # additionally, preinstall the virtualenv packages used for VSTS reporting to save time
 RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm helixbot && \

--- a/src/debian/12/helix/amd64/Dockerfile
+++ b/src/debian/12/helix/amd64/Dockerfile
@@ -43,7 +43,6 @@ RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
     echo 2cfd20a306b2fa5e25522d78f2ef50a1f429d35fd30bd983e2ebffc2b80944fa microsoft.asc| sha256sum --check - && \
     apt-key add microsoft.asc && \
     rm microsoft.asc && \
-    apt-add-repository https://packages.microsoft.com/debian/12/prod && \
     echo deb https://packages.microsoft.com/debian/12/prod bookworm main >> /etc/apt/sources.list.d/microsoft.list && \
     apt-get update && \
     apt-get install -y libmsquic && \

--- a/src/debian/12/helix/arm64v8/Dockerfile
+++ b/src/debian/12/helix/arm64v8/Dockerfile
@@ -47,6 +47,7 @@ RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
     apt-key add microsoft.asc && \
     rm microsoft.asc && \
     apt-add-repository https://packages.microsoft.com/debian/12/prod && \
+    echo deb https://packages.microsoft.com/debian/12/prod bookworm main >> /etc/apt/sources.list.d/microsoft.list && \
     apt-get update && \
     apt-get install -y libmsquic && \
     rm -rf /var/lib/apt/lists/*

--- a/src/debian/12/helix/arm64v8/Dockerfile
+++ b/src/debian/12/helix/arm64v8/Dockerfile
@@ -46,7 +46,6 @@ RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
     echo 2cfd20a306b2fa5e25522d78f2ef50a1f429d35fd30bd983e2ebffc2b80944fa microsoft.asc| sha256sum --check - && \
     apt-key add microsoft.asc && \
     rm microsoft.asc && \
-    apt-add-repository https://packages.microsoft.com/debian/12/prod && \
     echo deb https://packages.microsoft.com/debian/12/prod bookworm main >> /etc/apt/sources.list.d/microsoft.list && \
     apt-get update && \
     apt-get install -y libmsquic && \

--- a/src/debian/12/helix/arm64v8/Dockerfile
+++ b/src/debian/12/helix/arm64v8/Dockerfile
@@ -41,6 +41,16 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     export CRYPTOGRAPHY_DONT_BUILD_RUST=1 && \
     python3  -m pip install ./helix_scripts-*-py3-none-any.whl --break-system-packages
 
+# Add MsQuic
+RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
+    echo 2cfd20a306b2fa5e25522d78f2ef50a1f429d35fd30bd983e2ebffc2b80944fa microsoft.asc| sha256sum --check - && \
+    apt-key add microsoft.asc && \
+    rm microsoft.asc && \
+    apt-add-repository https://packages.microsoft.com/debian/12/prod && \
+    apt-get update && \
+    apt-get install -y libmsquic && \
+    rm -rf /var/lib/apt/lists/*
+
 # Create helixbot users and give rights to sudo without password
 # (we use two users here to ensure volume mounting works with two possible UIDs of the host UID)
 # additionally, preinstall the virtualenv packages used for VSTS reporting to save time


### PR DESCRIPTION
ASP.NET Core uses debian12 arm64 and it fails because quic isn't present.

@wfurt since you've updated msquic previously.