### PR TITLE
Added in docker image for ML.Net for centos-stream8

### DIFF
--- a/src/centos/manifest.json
+++ b/src/centos/manifest.json
@@ -82,7 +82,10 @@
               "osVersion": "centos-stream8",
               "tags": {
                 "centos-stream8-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "centos-stream8$(FloatingTagSuffix)": {}
+                "centos-stream8$(FloatingTagSuffix)": {},
+                "centos-stream8-local": {
+                  "isLocal": true
+                }
               }
             }
           ]
@@ -96,6 +99,19 @@
               "tags": {
                 "centos-stream8-helix-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
                 "centos-stream8-helix$(FloatingTagSuffix)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/centos/stream8/mlnet",
+              "os": "linux",
+              "osVersion": "centos-stream8",
+              "tags": {
+                "centos-stream8-mlnet-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "centos-stream8-mlnet$(FloatingTagSuffix)": {}
               }
             }
           ]

--- a/src/centos/stream8/mlnet/Dockerfile
+++ b/src/centos/stream8/mlnet/Dockerfile
@@ -1,0 +1,33 @@
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8-local
+
+USER root
+
+RUN dnf install --setopt tsflags=nodocs -y \
+    cmake \
+    clang
+
+# Install openmp from llvm 3.9.1.
+RUN wget http://releases.llvm.org/3.9.1/openmp-3.9.1.src.tar.xz && \
+    mkdir -p llvm-3.9.1.src/openmp && \
+    tar -xf openmp-3.9.1.src.tar.xz --strip 1 -C llvm-3.9.1.src/openmp && \
+    rm -f openmp-3.9.1.src.tar.xz && \
+    \
+    mkdir llvmbuild && \
+    cd llvmbuild && \
+    cmake \
+        -DCMAKE_CXX_COMPILER=/usr/bin/clang++ \
+        -DCMAKE_C_COMPILER=/usr/bin/clang \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DLLVM_LIBDIR_SUFFIX=64\
+        -DLLVM_ENABLE_EH=1 \
+        -DLLVM_ENABLE_RTTI=1 \
+        ../llvm-3.9.1.src/openmp \
+     && \
+     make -j $(($(getconf _NPROCESSORS_ONLN)+1)) && \
+     make install && \
+     cd .. && \
+     rm -f -r llvmbuild && \
+     rm -f -r llvm-3.9.1.src
+
+# Sets the library path to pickup openmp
+ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64


### PR DESCRIPTION
Adding in a docker image for ML.NET for Centos-stream8. It also sets the base centos-stream8 to local so that I can directly use it as the starter point.