### PR TITLE
Add centos-stream8-mlnet-helix image

### DIFF
--- a/src/centos/manifest.json
+++ b/src/centos/manifest.json
@@ -111,7 +111,23 @@
               "osVersion": "centos-stream8",
               "tags": {
                 "centos-stream8-mlnet-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "centos-stream8-mlnet$(FloatingTagSuffix)": {}
+                "centos-stream8-mlnet$(FloatingTagSuffix)": {},
+                "centos-stream8-mlnet-local": {
+                  "isLocal": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/centos/stream8/mlnet/helix",
+              "os": "linux",
+              "osVersion": "centos-stream8",
+              "tags": {
+                "centos-stream8-mlnet-helix-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "centos-stream8-mlnet-helix$(FloatingTagSuffix)": {}
               }
             }
           ]

--- a/src/centos/stream8/mlnet/helix/Dockerfile
+++ b/src/centos/stream8/mlnet/helix/Dockerfile
@@ -1,0 +1,18 @@
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8-mlnet-local
+
+RUN ln -sf /usr/bin/python3 /usr/bin/python && \
+    python -m pip install --upgrade pip==20.2 && \
+    python -m pip install virtualenv==16.6.0 && \
+    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    pip install ./helix_scripts-*-py3-none-any.whl
+
+ENV LANG=en_US.utf8
+
+# create helixbot user and give rights to sudo without password
+RUN /usr/sbin/adduser --uid 1000 --shell /bin/bash --gid adm helixbot && \
+    chmod 755 /root && \
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
+
+USER helixbot
+
+RUN python -m virtualenv --no-site-packages /home/helixbot/.vsts-env


### PR DESCRIPTION
Create a helix image for mlnet - based off the build image which has our pre-requisites - add the helix-scripts python installation and helix user setup.