### PR TITLE
[ASP.NET Core] Update Centos8 Dockerfile to add support for node 20 as required for ASP.NET Core

### DIFF
--- a/src/centos/stream8/Dockerfile
+++ b/src/centos/stream8/Dockerfile
@@ -44,6 +44,7 @@ RUN dnf install --setopt tsflags=nodocs --refresh -y \
         lzma \
         make \
         ncurses-devel \
+        nodejs:20 \
         numactl-devel \
         openssl-devel \
         procps-ng \

--- a/src/centos/stream8/Dockerfile
+++ b/src/centos/stream8/Dockerfile
@@ -7,6 +7,7 @@ RUN dnf install --setopt tsflags=nodocs --refresh -y \
     && \
     dnf config-manager --set-enabled powertools \
     && \
+    dnf module install --setopt tsflags=nodocs -y nodejs:20/common && \
     dnf install -y epel-release && \
     dnf install --setopt tsflags=nodocs -y \
         "perl(Time::HiRes)" \
@@ -44,7 +45,6 @@ RUN dnf install --setopt tsflags=nodocs --refresh -y \
         lzma \
         make \
         ncurses-devel \
-        nodejs:20/common \
         numactl-devel \
         openssl-devel \
         procps-ng \

--- a/src/centos/stream8/Dockerfile
+++ b/src/centos/stream8/Dockerfile
@@ -44,7 +44,7 @@ RUN dnf install --setopt tsflags=nodocs --refresh -y \
         lzma \
         make \
         ncurses-devel \
-        nodejs:20 \
+        nodejs:20/common \
         numactl-devel \
         openssl-devel \
         procps-ng \


### PR DESCRIPTION
* The ASP.NET Core build has had checked-in versions of their JavaScript assets to enable source building ASP.NET.
* This was done as a stopgap to enable progress on source build at the cost of the developer experience for devs in the ASP.NET Core repo.
* Enabling source build required us to move to standard JS tooling (NPM) which we recently did.

This PR installs the required dependencies on the base image we are using so that we can source build our JS assets instead of having to check-in built versions.