### PR TITLE
Add required packages to Alpine 3.19

### DIFF
--- a/src/alpine/3.19/WithNode/amd64/Dockerfile
+++ b/src/alpine/3.19/WithNode/amd64/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-local
 
-RUN apk update && apk add --no-cache git nodejs npm
+RUN apk update && apk add --no-cache nodejs npm
 
 # Add label for bring your own node in azure devops
 LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/bin/node"

--- a/src/alpine/3.19/amd64/Dockerfile
+++ b/src/alpine/3.19/amd64/Dockerfile
@@ -2,18 +2,41 @@ FROM alpine:3.19
 
 # Install .NET and test dependencies
 RUN apk update && apk add --no-cache \
-    bash \
-    coreutils \
-    curl \
-    icu-data-full \
-    icu-libs \
-    iputils \
-    krb5-libs \
-    lldb \
-    llvm \
-    lttng-ust \
-    musl-locales \
-    openssl \
-    python3 \
-    sudo \
-    tzdata
+        autoconf \
+        automake \
+        bash \
+        build-base \
+        clang \
+        clang-dev \
+        cmake \
+        coreutils \
+        curl \
+        elfutils \
+        file \
+        gcc \
+        gettext-dev \
+        git \
+        icu-data-full \
+        icu-dev \
+        jq \
+        krb5-dev \
+        libtool \
+        libunwind-dev \
+        linux-headers \
+        lld \
+        lldb-dev \
+        llvm \
+        lttng-ust-dev \
+        make \
+        numactl-dev \
+        openssl \
+        openssl-dev \
+        paxctl \
+        py3-lldb \
+        python3-dev \
+        shadow \
+        sudo \
+        tzdata \
+        util-linux-dev \
+        which \
+        zlib-dev


### PR DESCRIPTION
This resolves in an issue in source build where the Alpine 3.19 image doesn't contain clang.

The previous Alpine 3.17 image was working perfectly so I've ported over all the packages that were installed there.