### PR TITLE
Add mariner images for s390x and ppc64le

### DIFF
--- a/src/cbl-mariner/2.0/cross/ppc64le/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/ppc64le/Dockerfile
@@ -1,0 +1,9 @@
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder-local AS builder
+ARG ROOTFS_DIR=/crossrootfs/ppc64le
+
+RUN /scripts/eng/common/cross/build-rootfs.sh bionic ppc64le
+
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
+ARG ROOTFS_DIR=/crossrootfs/ppc64le
+
+COPY --from=builder "$ROOTFS_DIR" "$ROOTFS_DIR"

--- a/src/cbl-mariner/2.0/cross/s390x/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/s390x/Dockerfile
@@ -1,0 +1,22 @@
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder-local AS builder
+ARG ROOTFS_DIR=/crossrootfs/s390x
+
+RUN /scripts/eng/common/cross/build-rootfs.sh bionic s390x
+
+# build ld from binutils since llvm's lld only supports s390x since 18.0 but we're using 16.0
+# this can be removed once crossdeps-builder switches to llvm 18.0
+RUN tdnf install -y awk && \
+    wget https://sourceware.org/pub/binutils/snapshots/binutils-2.41.90.tar.xz -O binutils.tar.xz && \
+    echo "6e990c6e40000acedb9928fa6b6a32a164f3119740a95c40e7a85c6461dbdda5 binutils.tar.xz" | sha256sum -c && \
+    mkdir binutils.src && \
+    tar -xf binutils.tar.xz --directory=binutils.src --strip-components=1 && \
+    cd binutils.src && \
+    ./configure --target=s390x-linux-gnu --prefix=/binutils.install --disable-nls --disable-werror && \
+    make -j $(getconf _NPROCESSORS_ONLN) && \
+    make install -C ld
+
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
+ARG ROOTFS_DIR=/crossrootfs/s390x
+
+COPY --from=builder "$ROOTFS_DIR" "$ROOTFS_DIR"
+COPY --from=builder /binutils.install/s390x-linux-gnu/bin/ld /usr/local/bin/s390x-linux-gnu-ld

--- a/src/cbl-mariner/2.0/crossdeps-builder/Dockerfile
+++ b/src/cbl-mariner/2.0/crossdeps-builder/Dockerfile
@@ -61,7 +61,7 @@ RUN wget https://releases.llvm.org/release-keys.asc && \
     gpg --keyring /release-keys.gpg --verify llvm-project.src.tar.xz.sig && \
     rm llvm-project.src.tar.xz.sig
 
-# Build LLVM cross-toolchain (with support for targeting arm architectures)
+# Build LLVM cross-toolchain (with support for targeting x86/x64, arm64, arm, s390x and ppc64le architectures)
 RUN mkdir llvm-project.src && \
     tar -xf llvm-project.src.tar.xz --directory llvm-project.src --strip-components=1 && \
     rm llvm-project.src.tar.xz && \
@@ -70,7 +70,7 @@ RUN mkdir llvm-project.src && \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_C_COMPILER=clang \
         -DCMAKE_CXX_COMPILER=clang++ \
-        -DLLVM_TARGETS_TO_BUILD="host;AArch64;ARM" \
+        -DLLVM_TARGETS_TO_BUILD="X86;AArch64;ARM;PowerPC;SystemZ" \
         -Wno-dev \
         -DLLVM_ENABLE_PROJECTS="clang;lld;clang-tools-extra" && \
     make -j $(getconf _NPROCESSORS_ONLN) && \

--- a/src/cbl-mariner/2.0/crossdeps/Dockerfile
+++ b/src/cbl-mariner/2.0/crossdeps/Dockerfile
@@ -2,14 +2,12 @@ FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
 
 RUN tdnf update -y && \
     tdnf install -y \
-
         # Provides 'su', required by Azure DevOps
         ca-certificates \
         git \
         sudo \
         util-linux \
         wget \
-
         # Common runtime build dependencies
         awk \
         cmake \
@@ -17,11 +15,9 @@ RUN tdnf update -y && \
         icu \
         tar \
         zlib-devel \
-
         # Crosscomponents build dependencies
         glibc-devel \
         kernel-headers \
         lttng-ust-devel \
-
         # Jit rolling build dependency
         python3-pip

--- a/src/cbl-mariner/manifest.json
+++ b/src/cbl-mariner/manifest.json
@@ -224,6 +224,32 @@
         {
           "platforms": [
             {
+              "dockerfile": "src/cbl-mariner/2.0/cross/s390x",
+              "os": "linux",
+              "osVersion": "cbl-mariner2.0",
+              "tags": {
+                "cbl-mariner-2.0-cross-s390x-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "cbl-mariner-2.0-cross-s390x$(FloatingTagSuffix)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/cbl-mariner/2.0/cross/ppc64le",
+              "os": "linux",
+              "osVersion": "cbl-mariner2.0",
+              "tags": {
+                "cbl-mariner-2.0-cross-ppc64le-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "cbl-mariner-2.0-cross-ppc64le$(FloatingTagSuffix)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
               "dockerfile": "src/cbl-mariner/2.0/fpm/amd64",
               "os": "linux",
               "osVersion": "cbl-mariner2.0",


### PR DESCRIPTION
For s390x we build GNU ld since llvm's ld doesn't support this arch until 18.0.