### PR TITLE
Update to llvm 18 in Ubuntu 22.04 cross images

### DIFF
--- a/src/ubuntu/22.04/crossdeps/Dockerfile
+++ b/src/ubuntu/22.04/crossdeps/Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get update \
         libzstd-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# install llvm-toolchain v17 using official script
+# install llvm-toolchain using official script
 RUN wget -O- https://apt.llvm.org/llvm.sh | bash -s -- 18 \
         clang \
         clang-tools \

--- a/src/ubuntu/22.04/crossdeps/Dockerfile
+++ b/src/ubuntu/22.04/crossdeps/Dockerfile
@@ -40,7 +40,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # install llvm-toolchain v17 using official script
-RUN wget -O- https://apt.llvm.org/llvm.sh | bash -s -- 17 \
+RUN wget -O- https://apt.llvm.org/llvm.sh | bash -s -- 18 \
         clang \
         clang-tools \
         liblldb-dev \


### PR DESCRIPTION
Contains improvements for riscv64 among other architectures.

cc @janvorli