### PR TITLE
Use .NET 1ES hosted pool for public builds

### DIFF
--- a/eng/pipelines/stages/build-test-publish-repo.yml
+++ b/eng/pipelines/stages/build-test-publish-repo.yml
@@ -14,6 +14,11 @@ stages:
     internalProjectName: ${{ parameters.internalProjectName }}
     publicProjectName: ${{ parameters.publicProjectName }}
 
+    ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
+      linuxAmd64Pool:
+      name: NetCore-Public
+      demands: ImageOverride -equals build.ubuntu.2204.amd64.open
+
     linuxAmdBuildJobTimeout: ${{ parameters.linuxAmdBuildJobTimeout }}
     linuxArmBuildJobTimeout: ${{ parameters.linuxArmBuildJobTimeout }}
 

--- a/eng/pipelines/stages/build-test-publish-repo.yml
+++ b/eng/pipelines/stages/build-test-publish-repo.yml
@@ -16,8 +16,8 @@ stages:
 
     ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
       linuxAmd64Pool:
-      name: NetCore-Public
-      demands: ImageOverride -equals build.ubuntu.2204.amd64.open
+        name: NetCore-Public
+        demands: ImageOverride -equals build.ubuntu.2204.amd64.open
 
     linuxAmdBuildJobTimeout: ${{ parameters.linuxAmdBuildJobTimeout }}
     linuxArmBuildJobTimeout: ${{ parameters.linuxArmBuildJobTimeout }}


### PR DESCRIPTION
This should fix #983, by switching back to the 1ES pool for PR validation. Was removed in https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/980/commits/fd31d1c3ccc8e3f9470187a2fc513b13ebe482c6