### PR TITLE
Add lldb-devel in mariner cross images

### DIFF
--- a/src/cbl-mariner/2.0/crossdeps/Dockerfile
+++ b/src/cbl-mariner/2.0/crossdeps/Dockerfile
@@ -20,7 +20,9 @@ RUN tdnf update -y && \
         kernel-headers \
         lttng-ust-devel \
         # Jit rolling build dependency
-        python3-pip
+        python3-pip \
+        # diagnostics build dependency
+        lldb-devel
 
 # Validate checksums with keyring after https://github.com/microsoft/azurelinux/issues/3142 is resolved
 ENV NODE_VERSION=20.11.1


### PR DESCRIPTION
Needed by: https://github.com/dotnet/diagnostics/pull/4561

Replaces: https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/985

No need to undo the old PR.

