### PR TITLE
Remove sudo from mariner images

### DIFF
--- a/src/cbl-mariner/2.0/crossdeps/Dockerfile
+++ b/src/cbl-mariner/2.0/crossdeps/Dockerfile
@@ -5,7 +5,6 @@ RUN tdnf update -y && \
         # Provides 'su', required by Azure DevOps
         ca-certificates \
         git \
-        sudo \
         util-linux \
         wget \
         # Common runtime build dependencies


### PR DESCRIPTION
Per https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/990 we would like to avoid installing `sudo` onto our build images if possible.

This was added for https://github.com/dotnet/llvm-project/pull/456, which I believe didn't end up using `sudo`. @am11 PTAL