### PR TITLE
Enable SHA1 signatures in CentOS Stream9

### DIFF
--- a/src/centos/stream9/Dockerfile
+++ b/src/centos/stream9/Dockerfile
@@ -57,4 +57,7 @@ RUN dnf install --setopt tsflags=nodocs --refresh -y \
     && \
     dnf clean all
 
-ENV NO_UPDATE_NOTIFIER=true
+ENV \
+    NO_UPDATE_NOTIFIER=true \
+    # Sha1 is disabled by default centos:stream9 but sevaral CI jobs still rely on it.
+    OPENSSL_ENABLE_SHA1_SIGNATURES=1


### PR DESCRIPTION
See https://github.com/dotnet/installer/pull/19436 and https://github.com/dotnet/installer/pull/19318 for usages.  https://github.com/dotnet/installer/pull/19318 in particular doesn't have a mechanism to specify at the pipeline level with the current constructs.