### PR TITLE
Build LLVM with zlib support, remove clang-17

### DIFF
--- a/src/azurelinux/3.0/crossdeps-builder-net8.0/Dockerfile
+++ b/src/azurelinux/3.0/crossdeps-builder-net8.0/Dockerfile
@@ -14,6 +14,7 @@ RUN tdnf install -y \
         glibc-devel \
         kernel-headers \
         texinfo \
+        zlib-devel \
         # Rootfs build dependencies
         bzip2-devel \
         debootstrap \

--- a/src/azurelinux/3.0/crossdeps/Dockerfile
+++ b/src/azurelinux/3.0/crossdeps/Dockerfile
@@ -20,7 +20,5 @@ RUN tdnf update -y && \
         lttng-ust-devel \
         # Jit rolling build dependency
         python3-pip \
-        # diagnostics build dependency
-        lldb-devel \
         # aspnetcore build dependencies
         nodejs


### PR DESCRIPTION
This fixes two problems with the Azure Linux images when building runtime:
- lld was failing because it didn't have zlib support

  The mariner images had zlib-devel installed as a dependency of other packages (debootstrap, binutils), which no longer bring in zlib-devel on Azure Linux.
- The toolchain was picking up clang-17 instead of our source-built clang-16

  This was brought in by the lldb-devel package, so removing it for now. We may need to build this from source for the diagnostics repo.