### PR TITLE
Install libmsquic in CentOS Stream 9 image

### DIFF
--- a/src/centos/stream9/helix/amd64/Dockerfile
+++ b/src/centos/stream9/helix/amd64/Dockerfile
@@ -8,7 +8,7 @@ RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
     dnf install --setopt tsflags=nodocs --refresh -y \
         dnf-plugins-core \
     && \
-    dnf https://packages.microsoft.com/rhel/9/prod \
+    dnf config-manager --add-repo https://packages.microsoft.com/rhel/9/prod \
     && \
     dnf install --setopt tsflags=nodocs -y --allowerasing \
         autoconf \

--- a/src/centos/stream9/helix/amd64/Dockerfile
+++ b/src/centos/stream9/helix/amd64/Dockerfile
@@ -1,10 +1,14 @@
 FROM quay.io/centos/centos:stream9
 
 # Install dependencies
-RUN dnf install --setopt tsflags=nodocs --refresh -y \
+RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
+    echo 2cfd20a306b2fa5e25522d78f2ef50a1f429d35fd30bd983e2ebffc2b80944fa microsoft.asc| sha256sum --check - && \
+    rpm --import microsoft.asc && \
+    rm microsoft.asc && \
+    dnf install --setopt tsflags=nodocs --refresh -y \
         dnf-plugins-core \
     && \
-    dnf config-manager --set-enabled crb \
+    dnf config-manager --add-repo https://packages.microsoft.com/centos/8/prod \
     && \
     dnf install --setopt tsflags=nodocs -y --allowerasing \
         autoconf \

--- a/src/centos/stream9/helix/amd64/Dockerfile
+++ b/src/centos/stream9/helix/amd64/Dockerfile
@@ -8,7 +8,7 @@ RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
     dnf install --setopt tsflags=nodocs --refresh -y \
         dnf-plugins-core \
     && \
-    dnf config-manager --add-repo https://packages.microsoft.com/centos/8/prod \
+    dnf https://packages.microsoft.com/rhel/9/prod \
     && \
     dnf install --setopt tsflags=nodocs -y --allowerasing \
         autoconf \
@@ -21,6 +21,7 @@ RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
         git-core \
         iputils \
         libicu \
+        libmsquic \
         libtool \
         llvm \
         make \


### PR DESCRIPTION
For https://github.com/dotnet/runtime/pull/101073#issuecomment-2059427197

I couldn't figure out how to use the referenced RHEL 9 image. If there is a good pattern for to that, we can adopt that.

@wfurt 