### PR TITLE
Increase build timeout for "all" pipeline

### DIFF
--- a/eng/pipelines/dotnet-buildtools-prereqs-all.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-all.yml
@@ -31,7 +31,7 @@ extends:
       parameters:
         internalProjectName: ${{ variables.internalProjectName }}
         publicProjectName: ${{ variables.publicProjectName }}
-        linuxAmdBuildJobTimeout: 360
+        linuxAmdBuildJobTimeout: 480
         linuxArmBuildJobTimeout: 300
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           customCopyBaseImagesInitSteps:


### PR DESCRIPTION
Related to https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1006. This also needs to be applied to the "all" pipeline since it may also end up building Mariner images. Essentially, this timeout needs to be whatever the largest timeout is amongst the OS-specific pipelines.