### PR TITLE
Resolve gem install errors

### DIFF
--- a/src/ubuntu/18.04/amd64/Dockerfile
+++ b/src/ubuntu/18.04/amd64/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update \
         wget \
     && rm -rf /var/lib/apt/lists/* \
     && gem install public_suffix -v 4.0.7 \
+    && gem install dotenv -v 2.8.1 \
     && gem install fpm \
     && wget https://cmake.org/files/v3.23/cmake-3.23.1-linux-x86_64.tar.gz \
     && tar -xf cmake-3.23.1-linux-x86_64.tar.gz --strip 1 -C /usr/local \

--- a/src/ubuntu/18.04/arm32v7/Dockerfile
+++ b/src/ubuntu/18.04/arm32v7/Dockerfile
@@ -19,5 +19,6 @@ RUN apt-get update && \
         libkrb5-dev \
         ruby-dev \
     && gem install public_suffix -v 4.0.7 \
+    && gem install dotenv -v 2.8.1 \
     && gem install fpm \
     && rm -rf /var/lib/apt/lists/*

--- a/src/ubuntu/18.04/arm64v8/Dockerfile
+++ b/src/ubuntu/18.04/arm64v8/Dockerfile
@@ -19,5 +19,6 @@ RUN apt-get update && \
         libkrb5-dev \
         ruby-dev \
     && gem install public_suffix -v 4.0.7 \
+    && gem install dotenv -v 2.8.1 \
     && gem install fpm \
     && rm -rf /var/lib/apt/lists/*

--- a/src/ubuntu/18.04/coredeps/Dockerfile
+++ b/src/ubuntu/18.04/coredeps/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update \
         tar \
         zip \
     && gem install public_suffix -v 4.0.7 \
+    && gem install dotenv -v 2.8.1 \
     && gem install fpm \
     && rm -rf /var/lib/apt/lists/* \
     && npm install -g azure-cli@0.9.20 \


### PR DESCRIPTION
When attempting to run `gem install fpm`, it would get the following error:

```
105.2 ERROR:  Error installing fpm:
105.2 	The last version of dotenv (>= 0) to support your Ruby & RubyGems was 2.8.1. Try installing it with `gem install dotenv -v 2.8.1` and then running the current command again
105.2 	dotenv requires Ruby version >= 3.0. The current ruby version is 2.5.0.
```

This is resolved by upgrading the version of `dotenv` to the version supported by Ruby 2.8.1.