### PR TITLE
Install tar on cbl-mariner helix dockerfile

### DIFF
--- a/src/cbl-mariner/2.0/helix/amd64/Dockerfile
+++ b/src/cbl-mariner/2.0/helix/amd64/Dockerfile
@@ -13,6 +13,7 @@ RUN tdnf install --setopt tsflags=nodocs --refresh -y \
          llvm \
          python3-pip \
          shadow-utils \
+         tar \
          tzdata \
          which \
     && tdnf clean all


### PR DESCRIPTION
Should fix https://github.com/dotnet/aspnetcore/issues/54775

> ./installjdk.sh: line 44: tar: command not found