### PR TITLE
Use Mariner not Ubuntu as armv6 host image

### DIFF
--- a/src/cbl-mariner/2.0/cross/armv6/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/armv6/Dockerfile
@@ -1,0 +1,16 @@
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder-local AS builder
+ARG ROOTFS_DIR=/crossrootfs/armv6
+
+# Install raspbian package signing keys
+RUN wget http://raspbian.raspberrypi.org/raspbian/pool/main/r/raspbian-archive-keyring/raspbian-archive-keyring_20120528.2.tar.gz && \
+    echo "b3f22fa8d63d8d2f8b81f77784c3dc8f65fd6a10eadda63ac30a2da483ffc9d6ac72d0b5d3d0d5bdf2a61ca264a26fa071aed3acc780f062c8ab27a2e5ac6d49 raspbian-archive-keyring_20120528.2.tar.gz" | sha512sum -c && \
+    tar xf raspbian-archive-keyring_20120528.2.tar.gz && \
+    mv raspbian-archive-keyring-20120528.2/keyrings/raspbian-archive-keyring.gpg /usr/share/keyrings/ && \
+    rm -r raspbian-archive-keyring_20120528.2.tar.gz raspbian-archive-keyring-20120528.2
+
+RUN /scripts/eng/common/cross/build-rootfs.sh armv6 bullseye
+
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
+ARG ROOTFS_DIR=/crossrootfs/armv6
+
+COPY --from=builder "$ROOTFS_DIR" "$ROOTFS_DIR"

--- a/src/cbl-mariner/2.0/cross/armv6/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/armv6/Dockerfile
@@ -8,7 +8,7 @@ RUN wget http://raspbian.raspberrypi.org/raspbian/pool/main/r/raspbian-archive-k
     mv raspbian-archive-keyring-20120528.2/keyrings/raspbian-archive-keyring.gpg /usr/share/keyrings/ && \
     rm -r raspbian-archive-keyring_20120528.2.tar.gz raspbian-archive-keyring-20120528.2
 
-RUN /scripts/eng/common/cross/build-rootfs.sh armv6 bullseye
+RUN /scripts/eng/common/cross/build-rootfs.sh armv6 buster
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
 ARG ROOTFS_DIR=/crossrootfs/armv6

--- a/src/cbl-mariner/manifest.json
+++ b/src/cbl-mariner/manifest.json
@@ -198,6 +198,22 @@
         {
           "platforms": [
             {
+              "dockerfile": "src/cbl-mariner/2.0/cross/armv6",
+              "os": "linux",
+              "osVersion": "cbl-mariner2.0",
+              "tags": {
+                "cbl-mariner-2.0-cross-armv6-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "cbl-mariner-2.0-cross-armv6$(FloatingTagSuffix)": {},
+                "cbl-mariner-2.0-cross-armv6-local": {
+                  "isLocal": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
               "dockerfile": "src/cbl-mariner/2.0/cross/x86",
               "os": "linux",
               "osVersion": "cbl-mariner2.0",

--- a/src/ubuntu/20.04/cross/armv6/10/Dockerfile
+++ b/src/ubuntu/20.04/cross/armv6/10/Dockerfile
@@ -1,3 +1,0 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-crossdeps-local
-
-ADD rootfs.armv6.tar crossrootfs

--- a/src/ubuntu/20.04/cross/armv6/10/hooks/post-build
+++ b/src/ubuntu/20.04/cross/armv6/10/hooks/post-build
@@ -1,1 +1,0 @@
-../../../../../build-scripts/build-rootfs-cleanup.sh

--- a/src/ubuntu/20.04/cross/armv6/10/hooks/pre-build
+++ b/src/ubuntu/20.04/cross/armv6/10/hooks/pre-build
@@ -1,5 +1,0 @@
-#!/usr/bin/env sh
-
-SCRIPT=$(readlink -f "$0")
-SCRIPTPATH=$(dirname "$SCRIPT")
-$SCRIPTPATH/../../../../../build-scripts/run-arcade-build-rootfs.sh ubuntu-20.04 raspbian armv6

--- a/src/ubuntu/manifest.json
+++ b/src/ubuntu/manifest.json
@@ -485,19 +485,6 @@
         {
           "platforms": [
             {
-              "dockerfile": "src/ubuntu/20.04/cross/armv6/10",
-              "os": "linux",
-              "osVersion": "focal",
-              "tags": {
-                "ubuntu-20.04-cross-armv6-raspbian-10-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "ubuntu-20.04-cross-armv6-raspbian-10$(FloatingTagSuffix)": {}
-              }
-            }
-          ]
-        },
-        {
-          "platforms": [
-            {
               "architecture": "amd64",
               "dockerfile": "src/ubuntu/20.04/helix/amd64",
               "os": "linux",


### PR DESCRIPTION
This is expected to fail until https://github.com/dotnet/arcade/pull/14730 is merged (it doesn't need to flow to any branches once merged since rootfs generation always uses arcade git main)