### PR TITLE
Switch from dotnet/msquic to microsoft/msquic

### DIFF
--- a/src/alpine/3.16/helix/amd64/Dockerfile
+++ b/src/alpine/3.16/helix/amd64/Dockerfile
@@ -69,8 +69,8 @@ RUN apk update && apk add --no-cache && \
         openssl-dev \
         perl && \
     cd /tmp && \
-    git clone --depth 1 --single-branch --branch main --recursive https://github.com/dotnet/msquic && \
-    cd msquic/src/msquic && \
+    git clone --depth 1 --single-branch --branch main --recursive https://github.com/microsoft/msquic && \
+    cd msquic && \
     cmake -B build/linux/x64_openssl \
        -DQUIC_OUTPUT_DIR=/tmp/msquic/src/msquic/artifacts/bin/linux/x64_Release_openssl \
        -DCMAKE_BUILD_TYPE=Release \

--- a/src/alpine/3.16/helix/amd64/Dockerfile
+++ b/src/alpine/3.16/helix/amd64/Dockerfile
@@ -72,7 +72,7 @@ RUN apk update && apk add --no-cache && \
     git clone --depth 1 --single-branch --branch main --recursive https://github.com/microsoft/msquic && \
     cd msquic && \
     cmake -B build/linux/x64_openssl \
-       -DQUIC_OUTPUT_DIR=/tmp/msquic/src/msquic/artifacts/bin/linux/x64_Release_openssl \
+       -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/x64_Release_openssl \
        -DCMAKE_BUILD_TYPE=Release \
        -DQUIC_TLS=openssl \
        -DQUIC_ENABLE_LOGGING=true \

--- a/src/alpine/3.16/helix/amd64/Dockerfile
+++ b/src/alpine/3.16/helix/amd64/Dockerfile
@@ -69,7 +69,7 @@ RUN apk update && apk add --no-cache && \
         openssl-dev \
         perl && \
     cd /tmp && \
-    git clone --depth 1 --single-branch --branch main --recursive https://github.com/microsoft/msquic && \
+    git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://github.com/microsoft/msquic && \
     cd msquic && \
     cmake -B build/linux/x64_openssl \
        -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/x64_Release_openssl \

--- a/src/alpine/3.16/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.16/helix/arm64v8/Dockerfile
@@ -53,7 +53,7 @@ RUN apk update && apk add --no-cache && \
         openssl-dev \
         perl && \
     cd /tmp && \
-    git clone --depth 1 --single-branch --branch main --recursive https://github.com/microsoft/msquic && \
+    git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://github.com/microsoft/msquic && \
     cd msquic && \
     cmake -B build/linux/arm64_openssl \
        -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/arm64_Release_openssl \

--- a/src/alpine/3.16/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.16/helix/arm64v8/Dockerfile
@@ -53,8 +53,8 @@ RUN apk update && apk add --no-cache && \
         openssl-dev \
         perl && \
     cd /tmp && \
-    git clone --depth 1 --single-branch --branch main --recursive https://github.com/dotnet/msquic && \
-    cd msquic/src/msquic && \
+    git clone --depth 1 --single-branch --branch main --recursive https://github.com/microsoft/msquic && \
+    cd msquic && \
     cmake -B build/linux/arm64_openssl \
        -DQUIC_OUTPUT_DIR=/tmp/msquic/src/msquic/artifacts/bin/linux/arm64_Release_openssl \
        -DCMAKE_BUILD_TYPE=Release \

--- a/src/alpine/3.16/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.16/helix/arm64v8/Dockerfile
@@ -56,7 +56,7 @@ RUN apk update && apk add --no-cache && \
     git clone --depth 1 --single-branch --branch main --recursive https://github.com/microsoft/msquic && \
     cd msquic && \
     cmake -B build/linux/arm64_openssl \
-       -DQUIC_OUTPUT_DIR=/tmp/msquic/src/msquic/artifacts/bin/linux/arm64_Release_openssl \
+       -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/arm64_Release_openssl \
        -DCMAKE_BUILD_TYPE=Release \
        -DCMAKE_TARGET_ARCHITECTURE=arm64 \
        -DQUIC_TLS=openssl \

--- a/src/alpine/3.17/helix/amd64/Dockerfile
+++ b/src/alpine/3.17/helix/amd64/Dockerfile
@@ -54,8 +54,8 @@ RUN apk update && apk add --no-cache && \
         openssl-dev \
         perl && \
     cd /tmp && \
-    git clone --depth 1 --single-branch --branch main --recursive https://github.com/dotnet/msquic && \
-    cd msquic/src/msquic && \
+    git clone --depth 1 --single-branch --branch main --recursive https://github.com/microsoft/msquic && \
+    cd msquic && \
     cmake -B build/linux/x64_openssl3 \
        -DQUIC_OUTPUT_DIR=/tmp/msquic/src/msquic/artifacts/bin/linux/x64_Release_openssl3 \
        -DCMAKE_BUILD_TYPE=Release \

--- a/src/alpine/3.17/helix/amd64/Dockerfile
+++ b/src/alpine/3.17/helix/amd64/Dockerfile
@@ -57,7 +57,7 @@ RUN apk update && apk add --no-cache && \
     git clone --depth 1 --single-branch --branch main --recursive https://github.com/microsoft/msquic && \
     cd msquic && \
     cmake -B build/linux/x64_openssl3 \
-       -DQUIC_OUTPUT_DIR=/tmp/msquic/src/msquic/artifacts/bin/linux/x64_Release_openssl3 \
+       -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/x64_Release_openssl3 \
        -DCMAKE_BUILD_TYPE=Release \
        -DQUIC_TLS=openssl3 \
        -DQUIC_ENABLE_LOGGING=true \

--- a/src/alpine/3.17/helix/amd64/Dockerfile
+++ b/src/alpine/3.17/helix/amd64/Dockerfile
@@ -54,7 +54,7 @@ RUN apk update && apk add --no-cache && \
         openssl-dev \
         perl && \
     cd /tmp && \
-    git clone --depth 1 --single-branch --branch main --recursive https://github.com/microsoft/msquic && \
+    git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://github.com/microsoft/msquic && \
     cd msquic && \
     cmake -B build/linux/x64_openssl3 \
        -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/x64_Release_openssl3 \

--- a/src/alpine/3.17/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.17/helix/arm32v7/Dockerfile
@@ -54,7 +54,7 @@ RUN apk update && apk add --no-cache && \
         openssl-dev \
         perl && \
     cd /tmp && \
-    git clone --depth 1 --single-branch --branch main --recursive https://github.com/microsoft/msquic && \
+    git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://github.com/microsoft/msquic && \
     cd msquic && \
     cmake -B build/linux/arm_openssl3 \
        -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/arm_Release_openssl3 \

--- a/src/alpine/3.17/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.17/helix/arm32v7/Dockerfile
@@ -57,7 +57,7 @@ RUN apk update && apk add --no-cache && \
     git clone --depth 1 --single-branch --branch main --recursive https://github.com/microsoft/msquic && \
     cd msquic && \
     cmake -B build/linux/arm_openssl3 \
-       -DQUIC_OUTPUT_DIR=/tmp/msquic/src/msquic/artifacts/bin/linux/arm_Release_openssl3 \
+       -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/arm_Release_openssl3 \
        -DCMAKE_BUILD_TYPE=Release \
        -DCMAKE_TARGET_ARCHITECTURE=arm \
        -DQUIC_TLS=openssl3 \

--- a/src/alpine/3.17/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.17/helix/arm32v7/Dockerfile
@@ -54,8 +54,8 @@ RUN apk update && apk add --no-cache && \
         openssl-dev \
         perl && \
     cd /tmp && \
-    git clone --depth 1 --single-branch --branch main --recursive https://github.com/dotnet/msquic && \
-    cd msquic/src/msquic && \
+    git clone --depth 1 --single-branch --branch main --recursive https://github.com/microsoft/msquic && \
+    cd msquic && \
     cmake -B build/linux/arm_openssl3 \
        -DQUIC_OUTPUT_DIR=/tmp/msquic/src/msquic/artifacts/bin/linux/arm_Release_openssl3 \
        -DCMAKE_BUILD_TYPE=Release \

--- a/src/alpine/3.17/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.17/helix/arm64v8/Dockerfile
@@ -53,8 +53,8 @@ RUN apk update && apk add --no-cache && \
         openssl-dev \
         perl && \
     cd /tmp && \
-    git clone --depth 1 --single-branch --branch main --recursive https://github.com/dotnet/msquic && \
-    cd msquic/src/msquic && \
+    git clone --depth 1 --single-branch --branch main --recursive https://github.com/microsoft/msquic && \
+    cd msquic && \
     cmake -B build/linux/arm64_openssl3 \
        -DQUIC_OUTPUT_DIR=/tmp/msquic/src/msquic/artifacts/bin/linux/arm64_Release_openssl3 \
        -DCMAKE_BUILD_TYPE=Release \

--- a/src/alpine/3.17/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.17/helix/arm64v8/Dockerfile
@@ -53,7 +53,7 @@ RUN apk update && apk add --no-cache && \
         openssl-dev \
         perl && \
     cd /tmp && \
-    git clone --depth 1 --single-branch --branch main --recursive https://github.com/microsoft/msquic && \
+    git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://github.com/microsoft/msquic && \
     cd msquic && \
     cmake -B build/linux/arm64_openssl3 \
        -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/arm64_Release_openssl3 \

--- a/src/alpine/3.17/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.17/helix/arm64v8/Dockerfile
@@ -56,7 +56,7 @@ RUN apk update && apk add --no-cache && \
     git clone --depth 1 --single-branch --branch main --recursive https://github.com/microsoft/msquic && \
     cd msquic && \
     cmake -B build/linux/arm64_openssl3 \
-       -DQUIC_OUTPUT_DIR=/tmp/msquic/src/msquic/artifacts/bin/linux/arm64_Release_openssl3 \
+       -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/arm64_Release_openssl3 \
        -DCMAKE_BUILD_TYPE=Release \
        -DCMAKE_TARGET_ARCHITECTURE=arm64 \
        -DQUIC_TLS=openssl3 \

--- a/src/alpine/3.18/helix/amd64/Dockerfile
+++ b/src/alpine/3.18/helix/amd64/Dockerfile
@@ -54,8 +54,8 @@ RUN apk update && apk add --no-cache && \
         openssl-dev \
         perl && \
     cd /tmp && \
-    git clone --depth 1 --single-branch --branch main --recursive https://github.com/dotnet/msquic && \
-    cd msquic/src/msquic && \
+    git clone --depth 1 --single-branch --branch main --recursive https://github.com/microsoft/msquic && \
+    cd msquic && \
     cmake -B build/linux/x64_openssl3 \
        -DQUIC_OUTPUT_DIR=/tmp/msquic/src/msquic/artifacts/bin/linux/x64_Release_openssl3 \
        -DCMAKE_BUILD_TYPE=Release \

--- a/src/alpine/3.18/helix/amd64/Dockerfile
+++ b/src/alpine/3.18/helix/amd64/Dockerfile
@@ -57,7 +57,7 @@ RUN apk update && apk add --no-cache && \
     git clone --depth 1 --single-branch --branch main --recursive https://github.com/microsoft/msquic && \
     cd msquic && \
     cmake -B build/linux/x64_openssl3 \
-       -DQUIC_OUTPUT_DIR=/tmp/msquic/src/msquic/artifacts/bin/linux/x64_Release_openssl3 \
+       -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/x64_Release_openssl3 \
        -DCMAKE_BUILD_TYPE=Release \
        -DQUIC_TLS=openssl3 \
        -DQUIC_ENABLE_LOGGING=true \

--- a/src/alpine/3.18/helix/amd64/Dockerfile
+++ b/src/alpine/3.18/helix/amd64/Dockerfile
@@ -54,7 +54,7 @@ RUN apk update && apk add --no-cache && \
         openssl-dev \
         perl && \
     cd /tmp && \
-    git clone --depth 1 --single-branch --branch main --recursive https://github.com/microsoft/msquic && \
+    git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://github.com/microsoft/msquic && \
     cd msquic && \
     cmake -B build/linux/x64_openssl3 \
        -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/x64_Release_openssl3 \

--- a/src/alpine/3.18/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.18/helix/arm32v7/Dockerfile
@@ -54,7 +54,7 @@ RUN apk update && apk add --no-cache && \
         openssl-dev \
         perl && \
     cd /tmp && \
-    git clone --depth 1 --single-branch --branch main --recursive https://github.com/microsoft/msquic && \
+    git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://github.com/microsoft/msquic && \
     cd msquic && \
     cmake -B build/linux/arm_openssl3 \
        -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/arm_Release_openssl3 \

--- a/src/alpine/3.18/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.18/helix/arm32v7/Dockerfile
@@ -57,7 +57,7 @@ RUN apk update && apk add --no-cache && \
     git clone --depth 1 --single-branch --branch main --recursive https://github.com/microsoft/msquic && \
     cd msquic && \
     cmake -B build/linux/arm_openssl3 \
-       -DQUIC_OUTPUT_DIR=/tmp/msquic/src/msquic/artifacts/bin/linux/arm_Release_openssl3 \
+       -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/arm_Release_openssl3 \
        -DCMAKE_BUILD_TYPE=Release \
        -DCMAKE_TARGET_ARCHITECTURE=arm \
        -DQUIC_TLS=openssl3 \

--- a/src/alpine/3.18/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.18/helix/arm32v7/Dockerfile
@@ -54,8 +54,8 @@ RUN apk update && apk add --no-cache && \
         openssl-dev \
         perl && \
     cd /tmp && \
-    git clone --depth 1 --single-branch --branch main --recursive https://github.com/dotnet/msquic && \
-    cd msquic/src/msquic && \
+    git clone --depth 1 --single-branch --branch main --recursive https://github.com/microsoft/msquic && \
+    cd msquic && \
     cmake -B build/linux/arm_openssl3 \
        -DQUIC_OUTPUT_DIR=/tmp/msquic/src/msquic/artifacts/bin/linux/arm_Release_openssl3 \
        -DCMAKE_BUILD_TYPE=Release \

--- a/src/alpine/3.18/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.18/helix/arm64v8/Dockerfile
@@ -53,8 +53,8 @@ RUN apk update && apk add --no-cache && \
         openssl-dev \
         perl && \
     cd /tmp && \
-    git clone --depth 1 --single-branch --branch main --recursive https://github.com/dotnet/msquic && \
-    cd msquic/src/msquic && \
+    git clone --depth 1 --single-branch --branch main --recursive https://github.com/microsoft/msquic && \
+    cd msquic && \
     cmake -B build/linux/arm64_openssl3 \
        -DQUIC_OUTPUT_DIR=/tmp/msquic/src/msquic/artifacts/bin/linux/arm64_Release_openssl3 \
        -DCMAKE_BUILD_TYPE=Release \

--- a/src/alpine/3.18/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.18/helix/arm64v8/Dockerfile
@@ -53,7 +53,7 @@ RUN apk update && apk add --no-cache && \
         openssl-dev \
         perl && \
     cd /tmp && \
-    git clone --depth 1 --single-branch --branch main --recursive https://github.com/microsoft/msquic && \
+    git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://github.com/microsoft/msquic && \
     cd msquic && \
     cmake -B build/linux/arm64_openssl3 \
        -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/arm64_Release_openssl3 \

--- a/src/alpine/3.18/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.18/helix/arm64v8/Dockerfile
@@ -56,7 +56,7 @@ RUN apk update && apk add --no-cache && \
     git clone --depth 1 --single-branch --branch main --recursive https://github.com/microsoft/msquic && \
     cd msquic && \
     cmake -B build/linux/arm64_openssl3 \
-       -DQUIC_OUTPUT_DIR=/tmp/msquic/src/msquic/artifacts/bin/linux/arm64_Release_openssl3 \
+       -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/arm64_Release_openssl3 \
        -DCMAKE_BUILD_TYPE=Release \
        -DCMAKE_TARGET_ARCHITECTURE=arm64 \
        -DQUIC_TLS=openssl3 \


### PR DESCRIPTION
In order to archive https://github.com/dotnet/msquic we have to get rid of the references. This change replaces the dotnet repo with the official MsQuic one.