### PR TITLE
Update pr triggers for eng validation pipeline

### DIFF
--- a/eng/pipelines/dotnet-buildtools-prereqs-eng.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-eng.yml
@@ -4,9 +4,13 @@ pr:
     include:
     - main
   paths:
+    include:
+    - eng/*
+    - manifest.json
+    - build.ps1
+    - .dockerignore
     exclude:
     - src/*
-    - README.md
 
 resources:
   repositories:


### PR DESCRIPTION
This should prevent us from burning 8 hours of compute on PRs like https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1019.