### PR TITLE
Increase timeout for Azure Linux builds

### DIFF
--- a/eng/pipelines/dotnet-buildtools-prereqs-azurelinux-pr.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-azurelinux-pr.yml
@@ -24,6 +24,6 @@ stages:
   parameters:
     internalProjectName: ${{ variables.internalProjectName }}
     publicProjectName: ${{ variables.publicProjectName }}
-    linuxAmdBuildJobTimeout: 360
+    linuxAmdBuildJobTimeout: 480
     customBuildInitSteps:
     - template: /eng/pipelines/steps/install-cross-build-prereqs.yml

--- a/eng/pipelines/dotnet-buildtools-prereqs-azurelinux.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-azurelinux.yml
@@ -27,6 +27,6 @@ extends:
       parameters:
         internalProjectName: ${{ variables.internalProjectName }}
         publicProjectName: ${{ variables.publicProjectName }}
-        linuxAmdBuildJobTimeout: 360
+        linuxAmdBuildJobTimeout: 480
         customBuildInitSteps:
         - template: /eng/pipelines/steps/install-cross-build-prereqs.yml@self


### PR DESCRIPTION
The internal build for https://dev.azure.com/dnceng-public/public/_build/results?buildId=655018&view=results timed out after six hours. The public one finished after 5h44m, which is cutting it pretty close so I'm increasing the timeouts for both pipelines.