### PR TITLE
Bring back the libc++ image changes

### DIFF
--- a/src/azurelinux/3.0/cross/amd64-alpine-net9.0/Dockerfile
+++ b/src/azurelinux/3.0/cross/amd64-alpine-net9.0/Dockerfile
@@ -3,6 +3,32 @@ ARG ROOTFS_DIR=/crossrootfs/x64
 
 RUN /scripts/eng/common/cross/build-rootfs.sh x64 alpine3.13 --skipunmount
 
+RUN TARGET_TRIPLE="x86_64-alpine-linux-musl" && \
+    cmake -S llvm-project.src/runtimes -B runtimes \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_ASM_COMPILER=clang \
+        -DCMAKE_C_COMPILER=clang \
+        -DCMAKE_CXX_COMPILER=clang++ \
+        -DCMAKE_ASM_COMPILER_TARGET="$TARGET_TRIPLE" \
+        -DCMAKE_C_COMPILER_TARGET="$TARGET_TRIPLE" \
+        -DCMAKE_CXX_COMPILER_TARGET="$TARGET_TRIPLE" \
+        # We're going to link the static libraries we build here into PIC images, so build the static libraries as PIC.
+        -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+        -DCMAKE_SYSROOT="$ROOTFS_DIR" \
+        # Specify linker to use for exes directly for CMake toolchain detection
+        -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld" \
+        # Don't search for tools in the sysroot as we're cross-compiling
+        -DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM="NEVER" \
+        -DLLVM_USE_LINKER=lld \
+        -DLLVM_ENABLE_RUNTIMES="libcxx" \
+        -DLIBCXX_ENABLE_SHARED=OFF \
+        -DLIBCXX_HAS_MUSL_LIBC=ON \
+        -DLIBCXX_CXX_ABI=libstdc++ \
+        -DLIBCXX_CXX_ABI_INCLUDE_PATHS="$ROOTFS_DIR/usr/include/c++/10.2.1/;$ROOTFS_DIR/usr/include/c++/10.2.1/$TARGET_TRIPLE" && \
+    cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
+    cmake --install runtimes --prefix "$ROOTFS_DIR/usr" && \
+    # Copy libstdc++'s cxxabi.h header file to libc++'s include directory so that builds that use libc++ can find it.
+    cp "$ROOTFS_DIR/usr/include/c++/10.2.1/cxxabi.h" "$ROOTFS_DIR/usr/include/c++/v1/"
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-llvm-net9.0-local
 ARG ROOTFS_DIR=/crossrootfs/x64

--- a/src/azurelinux/3.0/cross/amd64-alpine-net9.0/Dockerfile
+++ b/src/azurelinux/3.0/cross/amd64-alpine-net9.0/Dockerfile
@@ -26,9 +26,7 @@ RUN TARGET_TRIPLE="x86_64-alpine-linux-musl" && \
         -DLIBCXX_CXX_ABI=libstdc++ \
         -DLIBCXX_CXX_ABI_INCLUDE_PATHS="$ROOTFS_DIR/usr/include/c++/10.2.1/;$ROOTFS_DIR/usr/include/c++/10.2.1/$TARGET_TRIPLE" && \
     cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
-    cmake --install runtimes --prefix "$ROOTFS_DIR/usr" && \
-    # Copy libstdc++'s cxxabi.h header file to libc++'s include directory so that builds that use libc++ can find it.
-    cp "$ROOTFS_DIR/usr/include/c++/10.2.1/cxxabi.h" "$ROOTFS_DIR/usr/include/c++/v1/"
+    cmake --install runtimes --prefix "$ROOTFS_DIR/usr"
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-llvm-net9.0-local
 ARG ROOTFS_DIR=/crossrootfs/x64

--- a/src/azurelinux/3.0/cross/amd64-net9.0-asan/Dockerfile
+++ b/src/azurelinux/3.0/cross/amd64-net9.0-asan/Dockerfile
@@ -1,9 +1,9 @@
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-builder-net9.0-local AS builder
-ARG ROOTFS_DIR=/crossrootfs/arm64
+ARG ROOTFS_DIR=/crossrootfs/x64
 
-RUN /scripts/eng/common/cross/build-rootfs.sh arm64 xenial --skipunmount
+RUN /scripts/eng/common/cross/build-rootfs.sh x64 xenial --skipunmount
 
-RUN TARGET_TRIPLE="aarch64-linux-gnu" && \
+RUN TARGET_TRIPLE="x86_64-linux-gnu" && \
     CLANG_MAJOR_VERSION=$(clang --version | grep -oP "(?<=version )\d+") && \
     cmake -S llvm-project.src/runtimes -B runtimes \
         -DCMAKE_BUILD_TYPE=Release \
@@ -21,30 +21,27 @@ RUN TARGET_TRIPLE="aarch64-linux-gnu" && \
         # Don't search for tools in the sysroot as we're cross-compiling
         -DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM="NEVER" \
         -DLLVM_USE_LINKER=lld \
-        -DLLVM_ENABLE_RUNTIMES="libcxx;compiler-rt" \
+        -DLLVM_ENABLE_RUNTIMES="compiler-rt;libcxx;libcxxabi" \
         -DLIBCXX_ENABLE_SHARED=OFF \
+        -DLIBCXX_CXX_ABI="libcxxabi" \
+        -DLIBCXX_STATICALLY_LINK_ABI_IN_STATIC_LIBRARY=ON \
+        -DLLVM_USE_SANITIZER="Address" \
         -DLIBCXXABI_ENABLE_SHARED=OFF \
         -DLIBCXXABI_USE_LLVM_UNWINDER=OFF \
-        -DLIBCXX_CXX_ABI=libstdc++ \
-        -DLIBCXX_CXX_ABI_INCLUDE_PATHS="$ROOTFS_DIR/usr/include/c++/5.4.0/;$ROOTFS_DIR/usr/include/$TARGET_TRIPLE" \
         -DCOMPILER_RT_CXX_LIBRARY="libcxx" \
         -DCOMPILER_RT_STATIC_CXX_LIBRARY=ON \
-        -DCOMPILER_RT_BUILD_SANITIZERS=OFF \
-        -DCOMPILER_RT_BUILD_MEMPROF=OFF \
-        # The libfuzzer build in LLVM doesn't correctly forward the required CMake properties to the "fuzzed libc++" build
-        # so skip it here.
-        -DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
+        -DSANITIZER_CXX_ABI_LIBNAME="libc++" \ 
         -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON \
         -DCOMPILER_RT_INSTALL_PATH="/usr/local/lib/clang/$CLANG_MAJOR_VERSION" && \
-    cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
-    cmake --install runtimes --prefix "$ROOTFS_DIR/usr" && \
-    # Copy libstdc++'s cxxabi.h header file to libc++'s include directory so that builds that use libc++ can find it.
-    cp "$ROOTFS_DIR/usr/include/c++/5.4.0/cxxabi.h" "$ROOTFS_DIR/usr/include/c++/v1/"
+    # Install the compiler-rt headers first so we can build a sanitized libcxxabi and libcxx
+    cmake --install runtimes --component compiler-rt-headers && \
+    cmake --build runtimes -j && \
+    cmake --install runtimes --prefix "$ROOTFS_DIR/usr"
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-llvm-net9.0-local
-ARG ROOTFS_DIR=/crossrootfs/arm64
+ARG ROOTFS_DIR=/crossrootfs/x64
 
-COPY --from=builder /usr/local/lib/clang /usr/local/lib/clang/
+COPY --from=builder /usr/local/lib/clang /usr/local/lib/clang
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR
 
 # Compat with dotnet/runtime's custom resource dir override for PGO and sanitizer builds:

--- a/src/azurelinux/3.0/cross/amd64-net9.0-sanitizer/Dockerfile
+++ b/src/azurelinux/3.0/cross/amd64-net9.0-sanitizer/Dockerfile
@@ -1,7 +1,9 @@
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-builder-net9.0-local AS builder
 ARG ROOTFS_DIR=/crossrootfs/x64
 
-RUN /scripts/eng/common/cross/build-rootfs.sh x64 xenial --skipunmount
+# Use Ubuntu Bionic as the base image for the rootfs
+# to get a new enough libstdc++ for the sanitizer runtimes and instrumentation.
+RUN /scripts/eng/common/cross/build-rootfs.sh x64 bionic --skipunmount
 
 RUN TARGET_TRIPLE="x86_64-linux-gnu" && \
     CLANG_MAJOR_VERSION=$(clang --version | grep -oP "(?<=version )\d+") && \
@@ -21,20 +23,19 @@ RUN TARGET_TRIPLE="x86_64-linux-gnu" && \
         # Don't search for tools in the sysroot as we're cross-compiling
         -DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM="NEVER" \
         -DLLVM_USE_LINKER=lld \
-        -DLLVM_ENABLE_RUNTIMES="compiler-rt;libcxx;libcxxabi" \
+        -DLLVM_ENABLE_RUNTIMES="compiler-rt;libcxx" \
         -DLIBCXX_ENABLE_SHARED=OFF \
-        -DLIBCXX_CXX_ABI="libcxxabi" \
-        -DLIBCXX_STATICALLY_LINK_ABI_IN_STATIC_LIBRARY=ON \
-        -DLLVM_USE_SANITIZER="Address" \
-        -DLIBCXXABI_ENABLE_SHARED=OFF \
-        -DLIBCXXABI_USE_LLVM_UNWINDER=OFF \
+        -DLIBCXX_CXX_ABI="libstdc++" \
+        -DLIBCXX_CXX_ABI_INCLUDE_PATHS="$ROOTFS_DIR/usr/include/c++/7.5.0/;$ROOTFS_DIR/usr/include/$TARGET_TRIPLE" \
         -DCOMPILER_RT_CXX_LIBRARY="libcxx" \
         -DCOMPILER_RT_STATIC_CXX_LIBRARY=ON \
-        -DSANITIZER_CXX_ABI_LIBNAME="libc++" \ 
+        -DSANITIZER_CXX_ABI_LIBNAME="libstdc++" \ 
+        -DCOMPILER_RT_BUILD_MEMPROF=OFF \
+        # The libfuzzer build in LLVM doesn't correctly forward the required CMake properties to the "fuzzed libc++" build
+        # so skip it here.
+        -DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
         -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON \
         -DCOMPILER_RT_INSTALL_PATH="/usr/local/lib/clang/$CLANG_MAJOR_VERSION" && \
-    # Install the compiler-rt headers first so we can build a sanitized libcxxabi and libcxx
-    cmake --install runtimes --component compiler-rt-headers && \
     cmake --build runtimes -j && \
     cmake --install runtimes --prefix "$ROOTFS_DIR/usr"
 

--- a/src/azurelinux/3.0/cross/amd64-net9.0/Dockerfile
+++ b/src/azurelinux/3.0/cross/amd64-net9.0/Dockerfile
@@ -3,48 +3,51 @@ ARG ROOTFS_DIR=/crossrootfs/x64
 
 RUN /scripts/eng/common/cross/build-rootfs.sh x64 xenial --skipunmount
 
-# Build compiler-rt profile library for PGO instrumentation
-RUN mkdir compiler-rt_build && cd compiler-rt_build && \
-    BUILD_FLAGS="-v --sysroot=$ROOTFS_DIR" \
-    TARGET_TRIPLE="x86_64-linux-gnu" && \
-    cmake ../llvm-project.src/compiler-rt \
-        -DCOMPILER_RT_BUILD_PROFILE=ON \
-        -DCOMPILER_RT_BUILD_SANITIZERS=ON \
-        -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON \
-        \
-        -DCOMPILER_RT_BUILD_BUILTINS=OFF \
-        -DCOMPILER_RT_BUILD_CRT=OFF \
-        -DCOMPILER_RT_BUILD_GWP_ASAN=OFF \
-        -DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
-        -DCOMPILER_RT_BUILD_MEMPROF=OFF \
-        -DCOMPILER_RT_BUILD_ORC=OFF \
-        -DCOMPILER_RT_BUILD_XRAY=OFF \
-        \
+RUN TARGET_TRIPLE="x86_64-linux-gnu" && \
+    CLANG_MAJOR_VERSION=$(clang --version | grep -oP "(?<=version )\d+") && \
+    cmake -S llvm-project.src/runtimes -B runtimes \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_ASM_COMPILER=clang \
         -DCMAKE_C_COMPILER=clang \
         -DCMAKE_CXX_COMPILER=clang++ \
-        -DCMAKE_SHARED_LINKER_FLAGS="-fuse-ld=lld" \
+        -DCMAKE_ASM_COMPILER_TARGET="$TARGET_TRIPLE" \
+        -DCMAKE_C_COMPILER_TARGET="$TARGET_TRIPLE" \
+        -DCMAKE_CXX_COMPILER_TARGET="$TARGET_TRIPLE" \
+        # We're going to link the static libraries we build here into PIC images, so build the static libraries as PIC.
+        -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+        -DCMAKE_SYSROOT="$ROOTFS_DIR" \
+        # Specify linker to use for exes directly for CMake toolchain detection
         -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld" \
-        -DCMAKE_ASM_COMPILER_TARGET="${TARGET_TRIPLE}" \
-        -DCMAKE_C_COMPILER_TARGET="${TARGET_TRIPLE}" \
-        -DCMAKE_CXX_COMPILER_TARGET="${TARGET_TRIPLE}" \
-        -DCMAKE_ASM_FLAGS="${BUILD_FLAGS}" \
-        -DCMAKE_C_FLAGS="${BUILD_FLAGS}" \
-        -DCMAKE_CXX_FLAGS="${BUILD_FLAGS}" && \
-    make -j $(getconf _NPROCESSORS_ONLN)
-
-RUN LLVM_VERSION=18.1.4 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTIMES_DIR=/sanitizer-runtimes && \
-    mkdir -p $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
-    cp compiler-rt_build/lib/linux/libclang_rt.profile-x86_64.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
-    mkdir ${SANITIZER_RUNTIMES_DIR} && \
-    cp compiler-rt_build/lib/linux/libclang_rt.*-x86_64.a $SANITIZER_RUNTIMES_DIR
-
+        # Don't search for tools in the sysroot as we're cross-compiling
+        -DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM="NEVER" \
+        -DLLVM_USE_LINKER=lld \
+        -DLLVM_ENABLE_RUNTIMES="libcxx;compiler-rt" \
+        -DLIBCXX_ENABLE_SHARED=OFF \
+        -DLIBCXX_CXX_ABI=libstdc++ \
+        -DLIBCXX_CXX_ABI_INCLUDE_PATHS="$ROOTFS_DIR/usr/include/c++/5.4.0/;$ROOTFS_DIR/usr/include/$TARGET_TRIPLE" \
+        -DCOMPILER_RT_CXX_LIBRARY="libcxx" \
+        -DCOMPILER_RT_STATIC_CXX_LIBRARY=ON \
+        -DCOMPILER_RT_BUILD_SANITIZERS=OFF \ 
+        -DCOMPILER_RT_BUILD_MEMPROF=OFF \
+        # The libfuzzer build in LLVM doesn't correctly forward the required CMake properties to the "fuzzed libc++" build
+        # so skip it here.
+        -DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
+        -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON \
+        -DCOMPILER_RT_INSTALL_PATH="/usr/local/lib/clang/$CLANG_MAJOR_VERSION" && \
+    cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
+    cmake --install runtimes --prefix "$ROOTFS_DIR/usr" && \
+    # Copy libstdc++'s cxxabi.h header file to libc++'s include directory so that builds that use libc++ can find it.
+    cp "$ROOTFS_DIR/usr/include/c++/5.4.0/cxxabi.h" "$ROOTFS_DIR/usr/include/c++/v1/"
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-llvm-net9.0-local
 ARG ROOTFS_DIR=/crossrootfs/x64
-ARG LLVM_VERSION_MAJOR=18
 
+COPY --from=builder /usr/local/lib/clang /usr/local/lib/clang/
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR
-COPY --from=builder /sanitizer-runtimes /usr/local/lib/clang/$LLVM_VERSION_MAJOR/lib/linux/
-COPY --from=builder compiler-rt_build/include/sanitizer /usr/local/lib/clang/$LLVM_VERSION_MAJOR/include/sanitizer/
+
+# Compat with dotnet/runtime's custom resource dir override for PGO and sanitizer builds:
+# Once we update dotnet/runtime to not override the resource directory, we can remove this step.
+RUN CLANG_VERSION=$(clang --version | grep -oP "(?<=version )[0-9.]+") &&  \
+    CLANG_MAJOR_VERSION=$(echo $CLANG_VERSION | grep -oP "\d+" | head -1) && \
+    mkdir -p "$ROOTFS_DIR/usr/lib/llvm-$CLANG_VERSION/lib" && \
+    cp -R /usr/local/lib/clang "$ROOTFS_DIR/usr/lib/llvm-$CLANG_VERSION/lib/clang" 

--- a/src/azurelinux/3.0/cross/amd64-net9.0/Dockerfile
+++ b/src/azurelinux/3.0/cross/amd64-net9.0/Dockerfile
@@ -35,9 +35,7 @@ RUN TARGET_TRIPLE="x86_64-linux-gnu" && \
         -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON \
         -DCOMPILER_RT_INSTALL_PATH="/usr/local/lib/clang/$CLANG_MAJOR_VERSION" && \
     cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
-    cmake --install runtimes --prefix "$ROOTFS_DIR/usr" && \
-    # Copy libstdc++'s cxxabi.h header file to libc++'s include directory so that builds that use libc++ can find it.
-    cp "$ROOTFS_DIR/usr/include/c++/5.4.0/cxxabi.h" "$ROOTFS_DIR/usr/include/c++/v1/"
+    cmake --install runtimes --prefix "$ROOTFS_DIR/usr"
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-llvm-net9.0-local
 ARG ROOTFS_DIR=/crossrootfs/x64

--- a/src/azurelinux/3.0/cross/arm-alpine-net9.0/Dockerfile
+++ b/src/azurelinux/3.0/cross/arm-alpine-net9.0/Dockerfile
@@ -3,6 +3,32 @@ ARG ROOTFS_DIR=/crossrootfs/arm
 
 RUN /scripts/eng/common/cross/build-rootfs.sh arm alpine3.13 --skipunmount
 
+RUN TARGET_TRIPLE="armv7-alpine-linux-musleabihf" && \
+    cmake -S llvm-project.src/runtimes -B runtimes \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_ASM_COMPILER=clang \
+        -DCMAKE_C_COMPILER=clang \
+        -DCMAKE_CXX_COMPILER=clang++ \
+        -DCMAKE_ASM_COMPILER_TARGET="$TARGET_TRIPLE" \
+        -DCMAKE_C_COMPILER_TARGET="$TARGET_TRIPLE" \
+        -DCMAKE_CXX_COMPILER_TARGET="$TARGET_TRIPLE" \
+        # We're going to link the static libraries we build here into PIC images, so build the static libraries as PIC.
+        -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+        -DCMAKE_SYSROOT="$ROOTFS_DIR" \
+        # Specify linker to use for exes directly for CMake toolchain detection
+        -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld" \
+        # Don't search for tools in the sysroot as we're cross-compiling
+        -DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM="NEVER" \
+        -DLLVM_USE_LINKER=lld \
+        -DLLVM_ENABLE_RUNTIMES="libcxx" \
+        -DLIBCXX_ENABLE_SHARED=OFF \
+        -DLIBCXX_HAS_MUSL_LIBC=ON \
+        -DLIBCXX_CXX_ABI=libstdc++ \
+        -DLIBCXX_CXX_ABI_INCLUDE_PATHS="$ROOTFS_DIR/usr/include/c++/10.2.1/;$ROOTFS_DIR/usr/include/c++/10.2.1/$TARGET_TRIPLE" && \
+    cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
+    cmake --install runtimes --prefix "$ROOTFS_DIR/usr" && \
+    # Copy libstdc++'s cxxabi.h header file to libc++'s include directory so that builds that use libc++ can find it.
+    cp "$ROOTFS_DIR/usr/include/c++/10.2.1/cxxabi.h" "$ROOTFS_DIR/usr/include/c++/v1/"
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-llvm-net9.0-local
 ARG ROOTFS_DIR=/crossrootfs/arm

--- a/src/azurelinux/3.0/cross/arm-alpine-net9.0/Dockerfile
+++ b/src/azurelinux/3.0/cross/arm-alpine-net9.0/Dockerfile
@@ -26,9 +26,7 @@ RUN TARGET_TRIPLE="armv7-alpine-linux-musleabihf" && \
         -DLIBCXX_CXX_ABI=libstdc++ \
         -DLIBCXX_CXX_ABI_INCLUDE_PATHS="$ROOTFS_DIR/usr/include/c++/10.2.1/;$ROOTFS_DIR/usr/include/c++/10.2.1/$TARGET_TRIPLE" && \
     cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
-    cmake --install runtimes --prefix "$ROOTFS_DIR/usr" && \
-    # Copy libstdc++'s cxxabi.h header file to libc++'s include directory so that builds that use libc++ can find it.
-    cp "$ROOTFS_DIR/usr/include/c++/10.2.1/cxxabi.h" "$ROOTFS_DIR/usr/include/c++/v1/"
+    cmake --install runtimes --prefix "$ROOTFS_DIR/usr"
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-llvm-net9.0-local
 ARG ROOTFS_DIR=/crossrootfs/arm

--- a/src/azurelinux/3.0/cross/arm-net9.0/Dockerfile
+++ b/src/azurelinux/3.0/cross/arm-net9.0/Dockerfile
@@ -35,9 +35,7 @@ RUN TARGET_TRIPLE="arm-linux-gnueabihf" && \
         -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON \
         -DCOMPILER_RT_INSTALL_PATH="/usr/local/lib/clang/$CLANG_MAJOR_VERSION" && \
     cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
-    cmake --install runtimes --prefix "$ROOTFS_DIR/usr" && \
-    # Copy libstdc++'s cxxabi.h header file to libc++'s include directory so that builds that use libc++ can find it.
-    cp "$ROOTFS_DIR/usr/include/c++/5.4.0/cxxabi.h" "$ROOTFS_DIR/usr/include/c++/v1/"
+    cmake --install runtimes --prefix "$ROOTFS_DIR/usr"
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-llvm-net9.0-local
 ARG ROOTFS_DIR=/crossrootfs/arm

--- a/src/azurelinux/3.0/cross/arm-net9.0/Dockerfile
+++ b/src/azurelinux/3.0/cross/arm-net9.0/Dockerfile
@@ -3,48 +3,51 @@ ARG ROOTFS_DIR=/crossrootfs/arm
 
 RUN /scripts/eng/common/cross/build-rootfs.sh arm xenial --skipunmount
 
-# Build compiler-rt profile library for PGO instrumentation
-RUN mkdir compiler-rt_build && cd compiler-rt_build && \
-    BUILD_FLAGS="-v --sysroot=$ROOTFS_DIR" \
-    TARGET_TRIPLE="arm-linux-gnueabihf" && \
-    cmake ../llvm-project.src/compiler-rt \
-        -DCOMPILER_RT_BUILD_PROFILE=ON \
-        -DCOMPILER_RT_BUILD_SANITIZERS=ON \
-        -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON \
-        \
-        -DCOMPILER_RT_BUILD_BUILTINS=OFF \
-        -DCOMPILER_RT_BUILD_CRT=OFF \
-        -DCOMPILER_RT_BUILD_GWP_ASAN=OFF \
-        -DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
-        -DCOMPILER_RT_BUILD_MEMPROF=OFF \
-        -DCOMPILER_RT_BUILD_ORC=OFF \
-        -DCOMPILER_RT_BUILD_XRAY=OFF \
-        \
+RUN TARGET_TRIPLE="arm-linux-gnueabihf" && \
+    CLANG_MAJOR_VERSION=$(clang --version | grep -oP "(?<=version )\d+") && \
+    cmake -S llvm-project.src/runtimes -B runtimes \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_ASM_COMPILER=clang \
         -DCMAKE_C_COMPILER=clang \
         -DCMAKE_CXX_COMPILER=clang++ \
-        -DCMAKE_SHARED_LINKER_FLAGS="-fuse-ld=lld" \
+        -DCMAKE_ASM_COMPILER_TARGET="$TARGET_TRIPLE" \
+        -DCMAKE_C_COMPILER_TARGET="$TARGET_TRIPLE" \
+        -DCMAKE_CXX_COMPILER_TARGET="$TARGET_TRIPLE" \
+        # We're going to link the static libraries we build here into PIC images, so build the static libraries as PIC.
+        -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+        -DCMAKE_SYSROOT="$ROOTFS_DIR" \
+        # Specify linker to use for exes directly for CMake toolchain detection
         -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld" \
-        -DCMAKE_ASM_COMPILER_TARGET="${TARGET_TRIPLE}" \
-        -DCMAKE_C_COMPILER_TARGET="${TARGET_TRIPLE}" \
-        -DCMAKE_CXX_COMPILER_TARGET="${TARGET_TRIPLE}" \
-        -DCMAKE_ASM_FLAGS="${BUILD_FLAGS}" \
-        -DCMAKE_C_FLAGS="${BUILD_FLAGS}" \
-        -DCMAKE_CXX_FLAGS="${BUILD_FLAGS}" && \
-    make -j $(getconf _NPROCESSORS_ONLN)
-
-RUN LLVM_VERSION=18.1.4 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTIMES_DIR=/sanitizer-runtimes && \
-    mkdir -p $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
-    cp compiler-rt_build/lib/linux/libclang_rt.profile-armhf.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
-    mkdir ${SANITIZER_RUNTIMES_DIR} && \
-    cp compiler-rt_build/lib/linux/libclang_rt.*-armhf.a $SANITIZER_RUNTIMES_DIR
-
+        # Don't search for tools in the sysroot as we're cross-compiling
+        -DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM="NEVER" \
+        -DLLVM_USE_LINKER=lld \
+        -DLLVM_ENABLE_RUNTIMES="libcxx;compiler-rt" \
+        -DLIBCXX_ENABLE_SHARED=OFF \
+        -DLIBCXX_CXX_ABI=libstdc++ \
+        -DLIBCXX_CXX_ABI_INCLUDE_PATHS="$ROOTFS_DIR/usr/include/c++/5.4.0/;$ROOTFS_DIR/usr/include/$TARGET_TRIPLE" \
+        -DCOMPILER_RT_CXX_LIBRARY="libcxx" \
+        -DCOMPILER_RT_STATIC_CXX_LIBRARY=ON \
+        -DCOMPILER_RT_BUILD_SANITIZERS=OFF \
+        -DCOMPILER_RT_BUILD_MEMPROF=OFF \
+        # The libfuzzer build in LLVM doesn't correctly forward the required CMake properties to the "fuzzed libc++" build
+        # so skip it here.
+        -DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
+        -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON \
+        -DCOMPILER_RT_INSTALL_PATH="/usr/local/lib/clang/$CLANG_MAJOR_VERSION" && \
+    cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
+    cmake --install runtimes --prefix "$ROOTFS_DIR/usr" && \
+    # Copy libstdc++'s cxxabi.h header file to libc++'s include directory so that builds that use libc++ can find it.
+    cp "$ROOTFS_DIR/usr/include/c++/5.4.0/cxxabi.h" "$ROOTFS_DIR/usr/include/c++/v1/"
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-llvm-net9.0-local
 ARG ROOTFS_DIR=/crossrootfs/arm
-ARG LLVM_VERSION_MAJOR=18
 
+COPY --from=builder /usr/local/lib/clang /usr/local/lib/clang/
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR
-COPY --from=builder /sanitizer-runtimes /usr/local/lib/clang/$LLVM_VERSION_MAJOR/lib/linux/
-COPY --from=builder compiler-rt_build/include/sanitizer /usr/local/lib/clang/$LLVM_VERSION_MAJOR/include/sanitizer/
+
+# Compat with dotnet/runtime's custom resource dir override for PGO and sanitizer builds:
+# Once we update dotnet/runtime to not override the resource directory, we can remove this step.
+RUN CLANG_VERSION=$(clang --version | grep -oP "(?<=version )[0-9.]+") &&  \
+    CLANG_MAJOR_VERSION=$(echo $CLANG_VERSION | grep -oP "\d+" | head -1) && \
+    mkdir -p "$ROOTFS_DIR/usr/lib/llvm-$CLANG_VERSION/lib" && \
+    cp -R /usr/local/lib/clang "$ROOTFS_DIR/usr/lib/llvm-$CLANG_VERSION/lib/clang" 

--- a/src/azurelinux/3.0/cross/arm64-alpine-net9.0/Dockerfile
+++ b/src/azurelinux/3.0/cross/arm64-alpine-net9.0/Dockerfile
@@ -3,6 +3,32 @@ ARG ROOTFS_DIR=/crossrootfs/arm64
 
 RUN /scripts/eng/common/cross/build-rootfs.sh arm64 alpine3.13 --skipunmount
 
+RUN TARGET_TRIPLE="aarch64-alpine-linux-musl" && \
+    cmake -S llvm-project.src/runtimes -B runtimes \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_ASM_COMPILER=clang \
+        -DCMAKE_C_COMPILER=clang \
+        -DCMAKE_CXX_COMPILER=clang++ \
+        -DCMAKE_ASM_COMPILER_TARGET="$TARGET_TRIPLE" \
+        -DCMAKE_C_COMPILER_TARGET="$TARGET_TRIPLE" \
+        -DCMAKE_CXX_COMPILER_TARGET="$TARGET_TRIPLE" \
+        # We're going to link the static libraries we build here into PIC images, so build the static libraries as PIC.
+        -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+        -DCMAKE_SYSROOT="$ROOTFS_DIR" \
+        # Specify linker to use for exes directly for CMake toolchain detection
+        -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld" \
+        # Don't search for tools in the sysroot as we're cross-compiling
+        -DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM="NEVER" \
+        -DLLVM_USE_LINKER=lld \
+        -DLLVM_ENABLE_RUNTIMES="libcxx" \
+        -DLIBCXX_ENABLE_SHARED=OFF \
+        -DLIBCXX_HAS_MUSL_LIBC=ON \
+        -DLIBCXX_CXX_ABI=libstdc++ \
+        -DLIBCXX_CXX_ABI_INCLUDE_PATHS="$ROOTFS_DIR/usr/include/c++/10.2.1/;$ROOTFS_DIR/usr/include/c++/10.2.1/$TARGET_TRIPLE" && \
+    cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
+    cmake --install runtimes --prefix "$ROOTFS_DIR/usr" && \
+    # Copy libstdc++'s cxxabi.h header file to libc++'s include directory so that builds that use libc++ can find it.
+    cp "$ROOTFS_DIR/usr/include/c++/10.2.1/cxxabi.h" "$ROOTFS_DIR/usr/include/c++/v1/"
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-llvm-net9.0-local
 ARG ROOTFS_DIR=/crossrootfs/arm64

--- a/src/azurelinux/3.0/cross/arm64-alpine-net9.0/Dockerfile
+++ b/src/azurelinux/3.0/cross/arm64-alpine-net9.0/Dockerfile
@@ -26,9 +26,7 @@ RUN TARGET_TRIPLE="aarch64-alpine-linux-musl" && \
         -DLIBCXX_CXX_ABI=libstdc++ \
         -DLIBCXX_CXX_ABI_INCLUDE_PATHS="$ROOTFS_DIR/usr/include/c++/10.2.1/;$ROOTFS_DIR/usr/include/c++/10.2.1/$TARGET_TRIPLE" && \
     cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
-    cmake --install runtimes --prefix "$ROOTFS_DIR/usr" && \
-    # Copy libstdc++'s cxxabi.h header file to libc++'s include directory so that builds that use libc++ can find it.
-    cp "$ROOTFS_DIR/usr/include/c++/10.2.1/cxxabi.h" "$ROOTFS_DIR/usr/include/c++/v1/"
+    cmake --install runtimes --prefix "$ROOTFS_DIR/usr"
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-llvm-net9.0-local
 ARG ROOTFS_DIR=/crossrootfs/arm64

--- a/src/azurelinux/3.0/cross/arm64-net9.0/Dockerfile
+++ b/src/azurelinux/3.0/cross/arm64-net9.0/Dockerfile
@@ -37,9 +37,7 @@ RUN TARGET_TRIPLE="aarch64-linux-gnu" && \
         -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON \
         -DCOMPILER_RT_INSTALL_PATH="/usr/local/lib/clang/$CLANG_MAJOR_VERSION" && \
     cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
-    cmake --install runtimes --prefix "$ROOTFS_DIR/usr" && \
-    # Copy libstdc++'s cxxabi.h header file to libc++'s include directory so that builds that use libc++ can find it.
-    cp "$ROOTFS_DIR/usr/include/c++/5.4.0/cxxabi.h" "$ROOTFS_DIR/usr/include/c++/v1/"
+    cmake --install runtimes --prefix "$ROOTFS_DIR/usr"
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-llvm-net9.0-local
 ARG ROOTFS_DIR=/crossrootfs/arm64

--- a/src/azurelinux/3.0/cross/x86-net9.0/Dockerfile
+++ b/src/azurelinux/3.0/cross/x86-net9.0/Dockerfile
@@ -3,53 +3,7 @@ ARG ROOTFS_DIR=/crossrootfs/x86
 
 RUN /scripts/eng/common/cross/build-rootfs.sh x86 xenial --skipunmount
 
-RUN TARGET_TRIPLE="i386-linux-gnu" && \
-    CLANG_MAJOR_VERSION=$(clang --version | grep -oP "(?<=version )\d+") && \
-    cmake -S llvm-project.src/runtimes -B runtimes \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_ASM_COMPILER=clang \
-        -DCMAKE_C_COMPILER=clang \
-        -DCMAKE_CXX_COMPILER=clang++ \
-        -DCMAKE_ASM_COMPILER_TARGET="$TARGET_TRIPLE" \
-        -DCMAKE_C_COMPILER_TARGET="$TARGET_TRIPLE" \
-        -DCMAKE_CXX_COMPILER_TARGET="$TARGET_TRIPLE" \
-        # We're going to link the static libraries we build here into PIC images, so build the static libraries as PIC.
-        -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-        -DCMAKE_SYSROOT="$ROOTFS_DIR" \
-        # Specify linker to use for exes directly for CMake toolchain detection
-        -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld" \
-        # Don't search for tools in the sysroot as we're cross-compiling
-        -DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM="NEVER" \
-        -DLLVM_USE_LINKER=lld \
-        -DLLVM_ENABLE_RUNTIMES="libcxx;compiler-rt" \
-        -DLIBCXX_ENABLE_SHARED=OFF \
-        -DLIBCXXABI_ENABLE_SHARED=OFF \
-        -DLIBCXXABI_USE_LLVM_UNWINDER=OFF \
-        -DLIBCXX_CXX_ABI=libstdc++ \
-        -DLIBCXX_CXX_ABI_INCLUDE_PATHS="$ROOTFS_DIR/usr/include/c++/5.4.0/;$ROOTFS_DIR/usr/include/$TARGET_TRIPLE" \
-        -DCOMPILER_RT_CXX_LIBRARY="libcxx" \
-        -DCOMPILER_RT_STATIC_CXX_LIBRARY=ON \
-        -DCOMPILER_RT_BUILD_SANITIZERS=OFF \
-        -DCOMPILER_RT_BUILD_MEMPROF=OFF \
-        # The libfuzzer build in LLVM doesn't correctly forward the required CMake properties to the "fuzzed libc++" build
-        # so skip it here.
-        -DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
-        -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON \
-        -DCOMPILER_RT_INSTALL_PATH="/usr/local/lib/clang/$CLANG_MAJOR_VERSION" && \
-    cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
-    cmake --install runtimes --prefix "$ROOTFS_DIR/usr" && \
-    # Copy libstdc++'s cxxabi.h header file to libc++'s include directory so that builds that use libc++ can find it.
-    cp "$ROOTFS_DIR/usr/include/c++/5.4.0/cxxabi.h" "$ROOTFS_DIR/usr/include/c++/v1/"
-
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-llvm-net9.0-local
 ARG ROOTFS_DIR=/crossrootfs/x86
 
-COPY --from=builder /usr/local/lib/clang /usr/local/lib/clang
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR
-
-# Compat with dotnet/runtime's custom resource dir override for PGO and sanitizer builds:
-# Once we update dotnet/runtime to not override the resource directory, we can remove this step.
-RUN CLANG_VERSION=$(clang --version | grep -oP "(?<=version )[0-9.]+") &&  \
-    CLANG_MAJOR_VERSION=$(echo $CLANG_VERSION | grep -oP "\d+" | head -1) && \
-    mkdir -p "$ROOTFS_DIR/usr/lib/llvm-$CLANG_VERSION/lib" && \
-    cp -R /usr/local/lib/clang "$ROOTFS_DIR/usr/lib/llvm-$CLANG_VERSION/lib/clang" 

--- a/src/azurelinux/3.0/cross/x86-net9.0/Dockerfile
+++ b/src/azurelinux/3.0/cross/x86-net9.0/Dockerfile
@@ -1,6 +1,8 @@
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-builder-net9.0-local AS builder
 ARG ROOTFS_DIR=/crossrootfs/x86
 
+# We don't ship linux-x86 binaries, so we don't need to make a custom libc++ build for servicing concerns.
+# We don't sanitize or instrument the linux-x64 build (as we don't ship it), so we don't need to build those runtime support libraries either.
 RUN /scripts/eng/common/cross/build-rootfs.sh x86 xenial --skipunmount
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-llvm-net9.0-local

--- a/src/azurelinux/3.0/cross/x86-net9.0/Dockerfile
+++ b/src/azurelinux/3.0/cross/x86-net9.0/Dockerfile
@@ -3,48 +3,53 @@ ARG ROOTFS_DIR=/crossrootfs/x86
 
 RUN /scripts/eng/common/cross/build-rootfs.sh x86 xenial --skipunmount
 
-# Build compiler-rt profile library for PGO instrumentation
-RUN mkdir compiler-rt_build && cd compiler-rt_build && \
-    BUILD_FLAGS="-v --sysroot=$ROOTFS_DIR" \
-    TARGET_TRIPLE="i386-linux-gnu" && \
-    cmake ../llvm-project.src/compiler-rt \
-        -DCOMPILER_RT_BUILD_PROFILE=ON \
-        -DCOMPILER_RT_BUILD_SANITIZERS=ON \
-        -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON \
-        \
-        -DCOMPILER_RT_BUILD_BUILTINS=OFF \
-        -DCOMPILER_RT_BUILD_CRT=OFF \
-        -DCOMPILER_RT_BUILD_GWP_ASAN=OFF \
-        -DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
-        -DCOMPILER_RT_BUILD_MEMPROF=OFF \
-        -DCOMPILER_RT_BUILD_ORC=OFF \
-        -DCOMPILER_RT_BUILD_XRAY=OFF \
-        \
+RUN TARGET_TRIPLE="i386-linux-gnu" && \
+    CLANG_MAJOR_VERSION=$(clang --version | grep -oP "(?<=version )\d+") && \
+    cmake -S llvm-project.src/runtimes -B runtimes \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_ASM_COMPILER=clang \
         -DCMAKE_C_COMPILER=clang \
         -DCMAKE_CXX_COMPILER=clang++ \
-        -DCMAKE_SHARED_LINKER_FLAGS="-fuse-ld=lld" \
+        -DCMAKE_ASM_COMPILER_TARGET="$TARGET_TRIPLE" \
+        -DCMAKE_C_COMPILER_TARGET="$TARGET_TRIPLE" \
+        -DCMAKE_CXX_COMPILER_TARGET="$TARGET_TRIPLE" \
+        # We're going to link the static libraries we build here into PIC images, so build the static libraries as PIC.
+        -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+        -DCMAKE_SYSROOT="$ROOTFS_DIR" \
+        # Specify linker to use for exes directly for CMake toolchain detection
         -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld" \
-        -DCMAKE_ASM_COMPILER_TARGET="${TARGET_TRIPLE}" \
-        -DCMAKE_C_COMPILER_TARGET="${TARGET_TRIPLE}" \
-        -DCMAKE_CXX_COMPILER_TARGET="${TARGET_TRIPLE}" \
-        -DCMAKE_ASM_FLAGS="${BUILD_FLAGS}" \
-        -DCMAKE_C_FLAGS="${BUILD_FLAGS}" \
-        -DCMAKE_CXX_FLAGS="${BUILD_FLAGS}" && \
-    make -j $(getconf _NPROCESSORS_ONLN)
-
-RUN LLVM_VERSION=18.1.4 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTIMES_DIR=/sanitizer-runtimes && \
-    mkdir -p $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
-    cp compiler-rt_build/lib/linux/libclang_rt.profile-i386.a $ROOTFS_DIR/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/clang/${LLVM_VERSION}/lib/linux/ && \
-    mkdir ${SANITIZER_RUNTIMES_DIR} && \
-    cp compiler-rt_build/lib/linux/libclang_rt.*-i386.a $SANITIZER_RUNTIMES_DIR
-
+        # Don't search for tools in the sysroot as we're cross-compiling
+        -DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM="NEVER" \
+        -DLLVM_USE_LINKER=lld \
+        -DLLVM_ENABLE_RUNTIMES="libcxx;compiler-rt" \
+        -DLIBCXX_ENABLE_SHARED=OFF \
+        -DLIBCXXABI_ENABLE_SHARED=OFF \
+        -DLIBCXXABI_USE_LLVM_UNWINDER=OFF \
+        -DLIBCXX_CXX_ABI=libstdc++ \
+        -DLIBCXX_CXX_ABI_INCLUDE_PATHS="$ROOTFS_DIR/usr/include/c++/5.4.0/;$ROOTFS_DIR/usr/include/$TARGET_TRIPLE" \
+        -DCOMPILER_RT_CXX_LIBRARY="libcxx" \
+        -DCOMPILER_RT_STATIC_CXX_LIBRARY=ON \
+        -DCOMPILER_RT_BUILD_SANITIZERS=OFF \
+        -DCOMPILER_RT_BUILD_MEMPROF=OFF \
+        # The libfuzzer build in LLVM doesn't correctly forward the required CMake properties to the "fuzzed libc++" build
+        # so skip it here.
+        -DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
+        -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON \
+        -DCOMPILER_RT_INSTALL_PATH="/usr/local/lib/clang/$CLANG_MAJOR_VERSION" && \
+    cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
+    cmake --install runtimes --prefix "$ROOTFS_DIR/usr" && \
+    # Copy libstdc++'s cxxabi.h header file to libc++'s include directory so that builds that use libc++ can find it.
+    cp "$ROOTFS_DIR/usr/include/c++/5.4.0/cxxabi.h" "$ROOTFS_DIR/usr/include/c++/v1/"
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-llvm-net9.0-local
 ARG ROOTFS_DIR=/crossrootfs/x86
-ARG LLVM_VERSION_MAJOR=18
 
+COPY --from=builder /usr/local/lib/clang /usr/local/lib/clang
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR
-COPY --from=builder /sanitizer-runtimes /usr/local/lib/clang/$LLVM_VERSION_MAJOR/lib/linux/
-COPY --from=builder compiler-rt_build/include/sanitizer /usr/local/lib/clang/$LLVM_VERSION_MAJOR/include/sanitizer/
+
+# Compat with dotnet/runtime's custom resource dir override for PGO and sanitizer builds:
+# Once we update dotnet/runtime to not override the resource directory, we can remove this step.
+RUN CLANG_VERSION=$(clang --version | grep -oP "(?<=version )[0-9.]+") &&  \
+    CLANG_MAJOR_VERSION=$(echo $CLANG_VERSION | grep -oP "\d+" | head -1) && \
+    mkdir -p "$ROOTFS_DIR/usr/lib/llvm-$CLANG_VERSION/lib" && \
+    cp -R /usr/local/lib/clang "$ROOTFS_DIR/usr/lib/llvm-$CLANG_VERSION/lib/clang" 

--- a/src/azurelinux/manifest.json
+++ b/src/azurelinux/manifest.json
@@ -221,13 +221,13 @@
         {
           "platforms": [
             {
-              "dockerfile": "src/azurelinux/3.0/cross/amd64-net9.0-asan",
+              "dockerfile": "src/azurelinux/3.0/cross/amd64-net9.0-sanitizer",
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-cross-amd64-net9.0-asan-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "azurelinux-3.0-cross-amd64-net9.0-asan$(FloatingTagSuffix)": {},
-                "azurelinux-3.0-cross-amd64-net9.0-asan-local": {
+                "azurelinux-3.0-cross-amd64-net9.0-sanitizer-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "azurelinux-3.0-cross-amd64-net9.0-sanitizer$(FloatingTagSuffix)": {},
+                "azurelinux-3.0-cross-amd64-net9.0-sanitizer-local": {
                   "isLocal": true
                 }
               }

--- a/src/azurelinux/manifest.json
+++ b/src/azurelinux/manifest.json
@@ -221,6 +221,22 @@
         {
           "platforms": [
             {
+              "dockerfile": "src/azurelinux/3.0/cross/amd64-net9.0-asan",
+              "os": "linux",
+              "osVersion": "azurelinux3.0",
+              "tags": {
+                "azurelinux-3.0-cross-amd64-net9.0-asan-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "azurelinux-3.0-cross-amd64-net9.0-asan$(FloatingTagSuffix)": {},
+                "azurelinux-3.0-cross-amd64-net9.0-asan-local": {
+                  "isLocal": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
               "dockerfile": "src/azurelinux/3.0/cross/amd64-alpine-net9.0",
               "os": "linux",
               "osVersion": "azurelinux3.0",


### PR DESCRIPTION
Remove the linux-x86 components that we weren't using that were causing problems as we don't ship or even official-build this configuration.

Don't copy the ABI header, instead inline it.

Depends on dotnet/runtime#101997, dotnet/runtime#102001

Related: https://github.com/dotnet/llvm-project/pull/560 (not required as I'd expect this project should continue to build against the .NET 8.0 images for 8.0).