### PR TITLE
Retrigger some helix image builds

### DIFF
--- a/src/debian/12/helix/amd64/Dockerfile
+++ b/src/debian/12/helix/amd64/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
         sudo \
         tzdata \
         unzip \
-    && rm -rf /var/lib/apt/lists/* \ 
+    && rm -rf /var/lib/apt/lists/*  \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
 ENV LANG=en_US.utf8

--- a/src/debian/12/helix/arm64v8/Dockerfile
+++ b/src/debian/12/helix/arm64v8/Dockerfile
@@ -30,8 +30,8 @@ RUN apt-get update && \
         sudo \
         tzdata \
         unzip \
-    && rm -rf /var/lib/apt/lists/* \
-    \ 
+    && rm -rf /var/lib/apt/lists/*  \
+    \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
 ENV LANG=en_US.utf8

--- a/src/ubuntu/22.04/helix/amd64/Dockerfile
+++ b/src/ubuntu/22.04/helix/amd64/Dockerfile
@@ -34,8 +34,8 @@ RUN apt-get update && \
         sudo \
         tzdata \
         unzip \
-    && rm -rf /var/lib/apt/lists/* \
-    \ 
+    && rm -rf /var/lib/apt/lists/*  \
+    \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
 ENV LANG=en_US.utf8

--- a/src/ubuntu/22.04/helix/arm64v8/Dockerfile
+++ b/src/ubuntu/22.04/helix/arm64v8/Dockerfile
@@ -36,8 +36,8 @@ RUN apt-get update && \
         tzdata \
         unzip \
         curl \
-    && rm -rf /var/lib/apt/lists/* \
-    \ 
+    && rm -rf /var/lib/apt/lists/*  \
+    \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
 ENV LANG=en_US.utf8


### PR DESCRIPTION
For testing purposes. I suspect some of these are out of date and broken with the most recent bump to the python-cryptography dependency version.