### PR TITLE
Set break-system-packages in Debian 12 helix image

### DIFF
--- a/src/debian/12/helix/arm32v7/Dockerfile
+++ b/src/debian/12/helix/arm32v7/Dockerfile
@@ -60,6 +60,13 @@ RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bas
     chmod 755 /root && \
     echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
 
+# Debian 12 is set up with its python environment marked as externally managed
+# (https://packaging.python.org/en/latest/specifications/externally-managed-environments/).
+# This causes errors when helix setup (at runtime) does 'sudo pip install'.
+# Work around this by overriding the check for externally managed environments.
+RUN mkdir -p ~/.config/pip && \
+    echo "[global]\nbreak-system-packages = true" > ~/.config/pip/pip.conf
+
 USER helixbot
 
 RUN python -m virtualenv /home/helixbot/.vsts-env


### PR DESCRIPTION
Fixes failures running tests on the new arm32 images in https://github.com/dotnet/runtime/pull/102059:

```
[BEGIN EXECUTION]
+ sudo python -m pip install --disable-pip-version-check -r /root/helix/scripts/runtime_python_requirements.txt
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.11/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```

This fix is only for the arm32 image, which is the only one used in dotnet/runtime.

There are references to debian-12 arm images in aspnetcore, but they seem to be unused. The arm64 and amd64 images have similar errors if I try 'sudo pip install' locally, so they are probably broken as well, but I'm limiting the fix to arm32 images that we know we need for ci.