### PR TITLE
Fix architecture of new Debian images

### DIFF
--- a/src/debian/manifest.json
+++ b/src/debian/manifest.json
@@ -93,7 +93,7 @@
         {
           "platforms": [
             {
-              "architecture": "arm64",
+              "architecture": "arm",
               "dockerfile": "src/debian/12/helix/arm32v7",
               "os": "linux",
               "osVersion": "bookworm",
@@ -101,7 +101,7 @@
                 "debian-12-helix-arm32v7-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
                 "debian-12-helix-arm32v7$(FloatingTagSuffix)": {}
               },
-              "variant": "v8"
+              "variant": "v7"
             }
           ]
         },


### PR DESCRIPTION
Missed this in https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1041. Should fix the latest test failures in https://github.com/dotnet/runtime/pull/102059.