### PR TITLE
Add azure-cli to docker-testrunner

### DIFF
--- a/src/cbl-mariner/2.0/docker-testrunner/Dockerfile
+++ b/src/cbl-mariner/2.0/docker-testrunner/Dockerfile
@@ -10,6 +10,7 @@ RUN tdnf install -y \
         moby-buildx \
         moby-cli \
         # Test dependencies
+        azure-cli \
         git \
         powershell \
     && tdnf clean all

--- a/src/cbl-mariner/2.0/fpm/amd64/Dockerfile
+++ b/src/cbl-mariner/2.0/fpm/amd64/Dockerfile
@@ -1,6 +1,7 @@
 FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
 RUN tdnf install -y \
         awk \
+        build-essential \
         ca-certificates \
         git \
         icu \


### PR DESCRIPTION
This adds `azure-cli` to the docker-testrunner image. This will be used to support the use of service connections for authenticating to an ACR.