### PR TITLE
Add support for Ubuntu 24.04

### DIFF
--- a/src/ubuntu/24.04/Dockerfile
+++ b/src/ubuntu/24.04/Dockerfile
@@ -1,0 +1,80 @@
+FROM ubuntu.azurecr.io/ubuntu:24.04
+
+# Install the base toolchain we need to build anything (clang, cmake, make and the like)
+# this does not include libraries that we need to compile different projects, we'd like
+# them in a different layer.
+RUN apt-get update \
+    && apt-get install -y \
+        cmake \
+        clang-14 \
+        gdb \
+        liblldb-14-dev \
+        lldb-14 \
+        llvm-14 \
+        locales \
+        make \
+        sudo \
+    && rm -rf /var/lib/apt/lists/*
+
+# This link fixes the broken lldb python scripting that the diagnostics tests require
+RUN mkdir -p /usr/lib/local/lib/python3.10/dist-packages/lldb \
+    && ln -s /usr/lib/llvm-14/lib/python3.10/dist-packages/lldb/* /usr/lib/local/lib/python3.10/dist-packages/lldb
+
+# Install tools used by the VSO build automation.
+RUN apt-get update \
+    && apt-get install -y \
+        git \
+        npm \
+        zip \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# .NET SDK MSBuild requires US.UTF-8 locale to execute tasks
+RUN locale-gen en_US.UTF-8
+
+# Runtime dependencies
+RUN apt-get update \
+    && apt-get install -y \
+        autoconf \
+        automake \
+        curl \
+        build-essential \
+        gettext \
+        jq \
+        libgdiplus \
+        libicu-dev \
+        libkrb5-dev \
+        liblttng-ust-dev \
+        libnuma-dev \
+        libssl-dev \
+        libtool \
+        libunwind8 \
+        libunwind8-dev \
+        uuid-dev \
+        zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Dependencies for VMR/source-build tests
+RUN apt-get update \
+    && apt-get install -y \
+        elfutils \
+        file \
+    && rm -rf /var/lib/apt/lists/*
+
+# Remove older version of node & install node 20
+RUN cd /etc/apt/sources.list.d  && \
+    rm -f nodesource.list && \
+    apt --fix-broken install && \
+    apt update && \
+    apt-get remove nodejs -y && \
+    apt-get remove nodejs-doc -y && \
+    apt-get remove libnode-dev -y
+
+RUN cd ~ && \
+    curl -sL https://deb.nodesource.com/setup_20.x -o nodesource_setup.sh && \
+    bash nodesource_setup.sh && \
+    apt-get install nodejs -y && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -f nodesource_setup.sh
+
+ENV NO_UPDATE_NOTIFIER=true

--- a/src/ubuntu/24.04/Dockerfile
+++ b/src/ubuntu/24.04/Dockerfile
@@ -37,8 +37,8 @@ RUN apt-get update \
     && apt-get install -y \
         autoconf \
         automake \
-        curl \
         build-essential \
+        curl \
         gettext \
         jq \
         libgdiplus \

--- a/src/ubuntu/24.04/Dockerfile
+++ b/src/ubuntu/24.04/Dockerfile
@@ -23,10 +23,10 @@ RUN mkdir -p /usr/lib/local/lib/python3.10/dist-packages/lldb \
 # Install tools used by the VSO build automation.
 RUN apt-get update \
     && apt-get install -y \
+        curl \
         git \
         npm \
         zip \
-        curl \
     && rm -rf /var/lib/apt/lists/*
 
 # .NET SDK MSBuild requires US.UTF-8 locale to execute tasks

--- a/src/ubuntu/24.04/Dockerfile
+++ b/src/ubuntu/24.04/Dockerfile
@@ -5,8 +5,8 @@ FROM ubuntu.azurecr.io/ubuntu:24.04
 # them in a different layer.
 RUN apt-get update \
     && apt-get install -y \
-        cmake \
         clang-14 \
+        cmake \
         gdb \
         liblldb-14-dev \
         lldb-14 \

--- a/src/ubuntu/manifest.json
+++ b/src/ubuntu/manifest.json
@@ -458,6 +458,34 @@
               "variant": "v8"
             }
           ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/24.04",
+              "os": "linux",
+              "osVersion": "noble",
+              "tags": {
+                "ubuntu-24.04-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "ubuntu-24.04$(FloatingTagSuffix)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "architecture": "arm64",
+              "dockerfile": "src/ubuntu/24.04",
+              "os": "linux",
+              "osVersion": "noble",
+              "tags": {
+                "ubuntu-24.04-arm64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "ubuntu-24.04-arm64$(FloatingTagSuffix)": {}
+              },
+              "variant": "v8"
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/4399

This is a copy of Ubuntu 22.04 Dockerfile with the exception of the Azure CLI.  I dropped the component because it currently doesn't support noble arm64 installations (https://github.com/Azure/azure-cli/issues/28945).  This is not required for source-build.