### PR TITLE
Fix directory where PGO library gets copied

### DIFF
--- a/src/azurelinux/3.0/net9.0/cross/amd64-sanitizer/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/amd64-sanitizer/Dockerfile
@@ -6,7 +6,7 @@ ARG ROOTFS_DIR=/crossrootfs/x64
 RUN /scripts/eng/common/cross/build-rootfs.sh x64 bionic --skipunmount
 
 RUN TARGET_TRIPLE="x86_64-linux-gnu" && \
-    CLANG_VERSION=$(clang --version | grep -oP "(?<=version )[0-9.]+") && \
+    CLANG_MAJOR_VERSION=$(clang --version | grep -oP "(?<=version )\d+") && \
     cmake -S llvm-project.src/runtimes -B runtimes \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_ASM_COMPILER=clang \
@@ -35,7 +35,7 @@ RUN TARGET_TRIPLE="x86_64-linux-gnu" && \
         # so skip it here.
         -DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
         -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON \
-        -DCOMPILER_RT_INSTALL_PATH="/usr/local/lib/clang/$CLANG_VERSION" && \
+        -DCOMPILER_RT_INSTALL_PATH="/usr/local/lib/clang/$CLANG_MAJOR_VERSION" && \
     cmake --build runtimes -j && \
     cmake --install runtimes --prefix "$ROOTFS_DIR/usr"
 
@@ -47,6 +47,7 @@ COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR
 
 # Compat with dotnet/runtime's custom resource dir override for PGO and sanitizer builds:
 # Once we update dotnet/runtime to not override the resource directory, we can remove this step.
-RUN CLANG_MAJOR_VERSION=$(clang --version | grep -oP "(?<=version )\d+") && \
-    mkdir -p "$ROOTFS_DIR/usr/lib/llvm-$CLANG_MAJOR_VERSION/lib" && \
-    cp -R /usr/local/lib/clang "$ROOTFS_DIR/usr/lib/llvm-$CLANG_MAJOR_VERSION/lib/clang" 
+RUN CLANG_VERSION=$(clang --version | grep -oP "(?<=version )[0-9.]+") &&  \
+    CLANG_MAJOR_VERSION=$(echo $CLANG_VERSION | grep -oP "\d+" | head -1) && \
+    mkdir -p "$ROOTFS_DIR/usr/lib/llvm-$CLANG_MAJOR_VERSION/lib/clang" && \
+    cp -R "/usr/local/lib/clang/$CLANG_MAJOR_VERSION" "$ROOTFS_DIR/usr/lib/llvm-$CLANG_MAJOR_VERSION/lib/clang/$CLANG_VERSION"

--- a/src/azurelinux/3.0/net9.0/cross/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/amd64/Dockerfile
@@ -4,7 +4,7 @@ ARG ROOTFS_DIR=/crossrootfs/x64
 RUN /scripts/eng/common/cross/build-rootfs.sh x64 xenial --skipunmount
 
 RUN TARGET_TRIPLE="x86_64-linux-gnu" && \
-    CLANG_VERSION=$(clang --version | grep -oP "(?<=version )[0-9.]+") && \
+    CLANG_MAJOR_VERSION=$(clang --version | grep -oP "(?<=version )\d+") && \
     cmake -S llvm-project.src/runtimes -B runtimes \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_ASM_COMPILER=clang \
@@ -33,7 +33,7 @@ RUN TARGET_TRIPLE="x86_64-linux-gnu" && \
         # so skip it here.
         -DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
         -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON \
-        -DCOMPILER_RT_INSTALL_PATH="/usr/local/lib/clang/$CLANG_VERSION" && \
+        -DCOMPILER_RT_INSTALL_PATH="/usr/local/lib/clang/$CLANG_MAJOR_VERSION" && \
     cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
     cmake --install runtimes --prefix "$ROOTFS_DIR/usr"
 
@@ -45,6 +45,7 @@ COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR
 
 # Compat with dotnet/runtime's custom resource dir override for PGO and sanitizer builds:
 # Once we update dotnet/runtime to not override the resource directory, we can remove this step.
-RUN CLANG_MAJOR_VERSION=$(clang --version | grep -oP "(?<=version )\d+") && \
-    mkdir -p "$ROOTFS_DIR/usr/lib/llvm-$CLANG_MAJOR_VERSION/lib" && \
-    cp -R /usr/local/lib/clang "$ROOTFS_DIR/usr/lib/llvm-$CLANG_MAJOR_VERSION/lib/clang" 
+RUN CLANG_VERSION=$(clang --version | grep -oP "(?<=version )[0-9.]+") &&  \
+    CLANG_MAJOR_VERSION=$(echo $CLANG_VERSION | grep -oP "\d+" | head -1) && \
+    mkdir -p "$ROOTFS_DIR/usr/lib/llvm-$CLANG_MAJOR_VERSION/lib/clang" && \
+    cp -R "/usr/local/lib/clang/$CLANG_MAJOR_VERSION" "$ROOTFS_DIR/usr/lib/llvm-$CLANG_MAJOR_VERSION/lib/clang/$CLANG_VERSION"

--- a/src/azurelinux/3.0/net9.0/cross/arm/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/arm/Dockerfile
@@ -6,7 +6,7 @@ ARG ROOTFS_DIR=/crossrootfs/arm
 RUN /scripts/eng/common/cross/build-rootfs.sh arm jammy no-lldb --skipunmount
 
 RUN TARGET_TRIPLE="arm-linux-gnueabihf" && \
-    CLANG_VERSION=$(clang --version | grep -oP "(?<=version )[0-9.]+") && \
+    CLANG_MAJOR_VERSION=$(clang --version | grep -oP "(?<=version )\d+") && \
     cmake -S llvm-project.src/runtimes -B runtimes \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_ASM_COMPILER=clang \
@@ -35,7 +35,7 @@ RUN TARGET_TRIPLE="arm-linux-gnueabihf" && \
         # so skip it here.
         -DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
         -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON \
-        -DCOMPILER_RT_INSTALL_PATH="/usr/local/lib/clang/$CLANG_VERSION" && \
+        -DCOMPILER_RT_INSTALL_PATH="/usr/local/lib/clang/$CLANG_MAJOR_VERSION" && \
     cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
     cmake --install runtimes --prefix "$ROOTFS_DIR/usr"
 
@@ -47,6 +47,7 @@ COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR
 
 # Compat with dotnet/runtime's custom resource dir override for PGO and sanitizer builds:
 # Once we update dotnet/runtime to not override the resource directory, we can remove this step.
-RUN CLANG_MAJOR_VERSION=$(clang --version | grep -oP "(?<=version )\d+") && \
-    mkdir -p "$ROOTFS_DIR/usr/lib/llvm-$CLANG_MAJOR_VERSION/lib" && \
-    cp -R /usr/local/lib/clang "$ROOTFS_DIR/usr/lib/llvm-$CLANG_MAJOR_VERSION/lib/clang" 
+RUN CLANG_VERSION=$(clang --version | grep -oP "(?<=version )[0-9.]+") &&  \
+    CLANG_MAJOR_VERSION=$(echo $CLANG_VERSION | grep -oP "\d+" | head -1) && \
+    mkdir -p "$ROOTFS_DIR/usr/lib/llvm-$CLANG_MAJOR_VERSION/lib/clang" && \
+    cp -R "/usr/local/lib/clang/$CLANG_MAJOR_VERSION" "$ROOTFS_DIR/usr/lib/llvm-$CLANG_MAJOR_VERSION/lib/clang/$CLANG_VERSION"

--- a/src/azurelinux/3.0/net9.0/cross/arm64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/arm64/Dockerfile
@@ -4,7 +4,7 @@ ARG ROOTFS_DIR=/crossrootfs/arm64
 RUN /scripts/eng/common/cross/build-rootfs.sh arm64 xenial --skipunmount
 
 RUN TARGET_TRIPLE="aarch64-linux-gnu" && \
-    CLANG_VERSION=$(clang --version | grep -oP "(?<=version )[0-9.]+") && \
+    CLANG_MAJOR_VERSION=$(clang --version | grep -oP "(?<=version )\d+") && \
     cmake -S llvm-project.src/runtimes -B runtimes \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_ASM_COMPILER=clang \
@@ -35,7 +35,7 @@ RUN TARGET_TRIPLE="aarch64-linux-gnu" && \
         # so skip it here.
         -DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
         -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON \
-        -DCOMPILER_RT_INSTALL_PATH="/usr/local/lib/clang/$CLANG_VERSION" && \
+        -DCOMPILER_RT_INSTALL_PATH="/usr/local/lib/clang/$CLANG_MAJOR_VERSION" && \
     cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
     cmake --install runtimes --prefix "$ROOTFS_DIR/usr"
 
@@ -47,6 +47,7 @@ COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR
 
 # Compat with dotnet/runtime's custom resource dir override for PGO and sanitizer builds:
 # Once we update dotnet/runtime to not override the resource directory, we can remove this step.
-RUN CLANG_MAJOR_VERSION=$(clang --version | grep -oP "(?<=version )\d+") && \
-    mkdir -p "$ROOTFS_DIR/usr/lib/llvm-$CLANG_MAJOR_VERSION/lib" && \
-    cp -R /usr/local/lib/clang "$ROOTFS_DIR/usr/lib/llvm-$CLANG_MAJOR_VERSION/lib/clang" 
+RUN CLANG_VERSION=$(clang --version | grep -oP "(?<=version )[0-9.]+") &&  \
+    CLANG_MAJOR_VERSION=$(echo $CLANG_VERSION | grep -oP "\d+" | head -1) && \
+    mkdir -p "$ROOTFS_DIR/usr/lib/llvm-$CLANG_MAJOR_VERSION/lib/clang" && \
+    cp -R "/usr/local/lib/clang/$CLANG_MAJOR_VERSION" "$ROOTFS_DIR/usr/lib/llvm-$CLANG_MAJOR_VERSION/lib/clang/$CLANG_VERSION"


### PR DESCRIPTION
Should fix failures we are seeing in official builds like:
```
  [ 80%] Linking CXX shared library libclrjit.so
  [ 80%] Building CXX object jit/CMakeFiles/clrjit_win_x64_x64.dir/optimizebools.cpp.o
  ld.lld: error: cannot open /crossrootfs/x64/usr/lib/llvm-18/lib/clang/18.1.4/lib/linux/libclang_rt.profile-x86_64.a: No such file or directory
  clang++: error: linker command failed with exit code 1 (use -v to see invocation)
  make[2]: *** [jit/CMakeFiles/clrjit.dir/build.make:1975: jit/libclrjit.so] Error 1
  make[1]: *** [CMakeFiles/Makefile2:3774: jit/CMakeFiles/clrjit.dir/all] Error 2
  make[1]: *** Waiting for unfinished jobs....
```