### PR TITLE
Use XL pools for Mariner/Azure Linux

### DIFF
--- a/eng/pipelines/dotnet-buildtools-prereqs-all-pr.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-all-pr.yml
@@ -18,5 +18,8 @@ stages:
     publicProjectName: ${{ variables.publicProjectName }}
     linuxAmdBuildJobTimeout: 360
     linuxArmBuildJobTimeout: 300
+    linuxAmd64Pool:
+      name: NetCore-Public-XL
+      demands: ImageOverride -equals build.Ubuntu.2204.amd64.open
     customBuildInitSteps:
     - template: /eng/pipelines/steps/install-cross-build-prereqs.yml

--- a/eng/pipelines/dotnet-buildtools-prereqs-all.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-all.yml
@@ -21,6 +21,10 @@ extends:
         publicProjectName: ${{ variables.publicProjectName }}
         linuxAmdBuildJobTimeout: 480
         linuxArmBuildJobTimeout: 300
+        linuxAmd64Pool:
+          name: NetCore1ESPool-Internal-XL
+          image: 1es-ubuntu-2204
+          os: linux
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           customCopyBaseImagesInitSteps:
           - template: /eng/pipelines/steps/set-base-image-override-options.yml@self

--- a/eng/pipelines/dotnet-buildtools-prereqs-azurelinux-pr.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-azurelinux-pr.yml
@@ -25,5 +25,8 @@ stages:
     internalProjectName: ${{ variables.internalProjectName }}
     publicProjectName: ${{ variables.publicProjectName }}
     linuxAmdBuildJobTimeout: 480
+    linuxAmd64Pool:
+      name: NetCore-Public-XL
+      demands: ImageOverride -equals build.Ubuntu.2204.amd64.open
     customBuildInitSteps:
     - template: /eng/pipelines/steps/install-cross-build-prereqs.yml

--- a/eng/pipelines/dotnet-buildtools-prereqs-azurelinux.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-azurelinux.yml
@@ -28,5 +28,9 @@ extends:
         internalProjectName: ${{ variables.internalProjectName }}
         publicProjectName: ${{ variables.publicProjectName }}
         linuxAmdBuildJobTimeout: 480
+        linuxAmd64Pool:
+          name: NetCore1ESPool-Internal-XL
+          image: 1es-ubuntu-2204
+          os: linux
         customBuildInitSteps:
         - template: /eng/pipelines/steps/install-cross-build-prereqs.yml@self

--- a/eng/pipelines/dotnet-buildtools-prereqs-mariner-pr.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-mariner-pr.yml
@@ -25,5 +25,8 @@ stages:
     internalProjectName: ${{ variables.internalProjectName }}
     publicProjectName: ${{ variables.publicProjectName }}
     linuxAmdBuildJobTimeout: 360
+    linuxAmd64Pool:
+      name: NetCore-Public-XL
+      demands: ImageOverride -equals build.Ubuntu.2204.amd64.open
     customBuildInitSteps:
     - template: /eng/pipelines/steps/install-cross-build-prereqs.yml

--- a/eng/pipelines/dotnet-buildtools-prereqs-mariner.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-mariner.yml
@@ -28,5 +28,9 @@ extends:
         internalProjectName: ${{ variables.internalProjectName }}
         publicProjectName: ${{ variables.publicProjectName }}
         linuxAmdBuildJobTimeout: 480
+        linuxAmd64Pool:
+          name: NetCore1ESPool-Internal-XL
+          image: 1es-ubuntu-2204
+          os: linux
         customBuildInitSteps:
         - template: /eng/pipelines/steps/install-cross-build-prereqs.yml@self

--- a/eng/pipelines/stages/build-test-publish-repo.yml
+++ b/eng/pipelines/stages/build-test-publish-repo.yml
@@ -6,6 +6,7 @@ parameters:
   linuxArmBuildJobTimeout: 60
   customBuildInitSteps: []
   customCopyBaseImagesInitSteps: []
+  linuxAmd64Pool: ''
 
 stages:
 - template: /eng/common/templates/stages/dotnet/build-test-publish-repo.yml@self
@@ -14,10 +15,12 @@ stages:
     internalProjectName: ${{ parameters.internalProjectName }}
     publicProjectName: ${{ parameters.publicProjectName }}
 
-    ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
+    ${{ if and(eq(variables['System.TeamProject'], parameters.publicProjectName), eq(parameters.linuxAmd64Pool, ''))}}:
       linuxAmd64Pool:
         name: NetCore-Public
         demands: ImageOverride -equals build.ubuntu.2204.amd64.open
+    ${{ else }}:
+      linuxAmd64Pool: ${{ parameters.linuxAmd64Pool }}
 
     linuxAmdBuildJobTimeout: ${{ parameters.linuxAmdBuildJobTimeout }}
     linuxArmBuildJobTimeout: ${{ parameters.linuxArmBuildJobTimeout }}


### PR DESCRIPTION
Note that the `-all` pipeline has to be configured to run with these as well because it may have to build Mariner/Azure Linux images.

Fixes #1024