### PR TITLE
Build msquic in a separate docker stage

### DIFF
--- a/src/alpine/3.16/helix/amd64/Dockerfile
+++ b/src/alpine/3.16/helix/amd64/Dockerfile
@@ -19,7 +19,7 @@ RUN git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://gith
 
 WORKDIR /tmp/msquic
 
-RUN cmake -B build/linux/x64_openssl \
+RUN cmake -B build/linux/x64_Release_openssl \
        -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/x64_Release_openssl \
        -DCMAKE_BUILD_TYPE=Release \
        -DQUIC_TLS=openssl \

--- a/src/alpine/3.16/helix/amd64/Dockerfile
+++ b/src/alpine/3.16/helix/amd64/Dockerfile
@@ -87,7 +87,7 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
     pip install ./helix_scripts-*-py3-none-any.whl
 
-# Copy msquic from the msquic into our image that will run on Helix
+# Copy msquic from the msquic image into our image that will run on Helix
 COPY --from=msquic /msquic /
 
 # Needed for corefx tests to pass

--- a/src/alpine/3.16/helix/amd64/Dockerfile
+++ b/src/alpine/3.16/helix/amd64/Dockerfile
@@ -1,3 +1,36 @@
+FROM alpine:3.16 as msquic
+
+# build MsQuic as we don't have packages
+RUN apk update && apk add --no-cache && \
+    apk add \
+        cmake \
+        g++ \
+        gcc \
+        git \
+        numactl-dev \
+        linux-headers \
+        lttng-ust-dev \
+        make \
+        musl-dev \
+        openssl-dev \
+        perl
+
+RUN git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://github.com/microsoft/msquic /tmp/msquic
+
+WORKDIR /tmp/msquic
+
+RUN cmake -B build/linux/x64_openssl \
+       -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/x64_Release_openssl \
+       -DCMAKE_BUILD_TYPE=Release \
+       -DQUIC_TLS=openssl \
+       -DQUIC_ENABLE_LOGGING=true \
+       -DQUIC_USE_SYSTEM_LIBCRYPTO=true \
+       -DQUIC_BUILD_TOOLS=off \
+       -DQUIC_BUILD_TEST=off \
+       -DQUIC_BUILD_PERF=off && \
+    cmake --build build/linux/x64_Release_openssl  --config Release && \
+    cmake --install build/linux/x64_Release_openssl --prefix /msquic
+
 FROM alpine:3.16
 
 RUN apk update && \
@@ -54,47 +87,8 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
     pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
     pip install ./helix_scripts-*-py3-none-any.whl
 
-# build MsQuic as we don't have packages
-RUN apk update && apk add --no-cache && \
-    apk add \
-        cmake \
-        g++ \
-        gcc \
-        git \
-        numactl-dev \
-        linux-headers \
-        lttng-ust-dev \
-        make \
-        musl-dev \
-        openssl-dev \
-        perl && \
-    cd /tmp && \
-    git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://github.com/microsoft/msquic && \
-    cd msquic && \
-    cmake -B build/linux/x64_openssl \
-       -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/x64_Release_openssl \
-       -DCMAKE_BUILD_TYPE=Release \
-       -DQUIC_TLS=openssl \
-       -DQUIC_ENABLE_LOGGING=true \
-       -DQUIC_USE_SYSTEM_LIBCRYPTO=true \
-       -DQUIC_BUILD_TOOLS=off \
-       -DQUIC_BUILD_TEST=off \
-       -DQUIC_BUILD_PERF=off && \
-    cmake --build build/linux/x64_openssl  --config Release && \
-    cp artifacts/bin/linux/x64_Release_openssl/libmsquic.so.* artifacts/bin/linux/x64_Release_openssl/libmsquic.lttng.so.* /usr/lib && \
-    ldd artifacts/bin/linux/x64_Release_openssl/libmsquic.so.* && \
-    rm -rf /tmp/msquic && \
-    apk del \
-        cmake \
-        g++ \
-        gcc \
-        git \
-        linux-headers \
-        lttng-ust-dev \
-        make \
-        musl-dev \
-        openssl-dev \
-        perl
+# Copy msquic from the msquic into our image that will run on Helix
+COPY --from=msquic /msquic /
 
 # Needed for corefx tests to pass
 ENV LANG=en-US.UTF-8

--- a/src/alpine/3.16/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.16/helix/arm64v8/Dockerfile
@@ -1,3 +1,37 @@
+FROM arm64v8/alpine:3.16 as msquic
+
+# build MsQuic as we don't have packages
+RUN apk update && apk add --no-cache && \
+    apk add \
+        cmake \
+        g++ \
+        gcc \
+        git \
+        numactl-dev \
+        linux-headers \
+        lttng-ust-dev \
+        make \
+        musl-dev \
+        openssl-dev \
+        perl
+
+RUN git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://github.com/microsoft/msquic /tmp/msquic
+
+WORKDIR /tmp/msquic
+
+RUN cmake -B build/linux/x64_openssl \
+       -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/arm64_Release_openssl \
+       -DCMAKE_BUILD_TYPE=Release \
+       -DCMAKE_TARGET_ARCHITECTURE=arm64 \
+       -DQUIC_TLS=openssl \
+       -DQUIC_ENABLE_LOGGING=true \
+       -DQUIC_USE_SYSTEM_LIBCRYPTO=true \
+       -DQUIC_BUILD_TOOLS=off \
+       -DQUIC_BUILD_TEST=off \
+       -DQUIC_BUILD_PERF=off && \
+    cmake --build build/linux/arm64_Release_openssl  --config Release && \
+    cmake --install build/linux/arm64_Release_openssl --prefix /msquic
+
 FROM arm64v8/alpine:3.16
 # Install .NET and test dependencies
 RUN apk update && apk add --no-cache \
@@ -38,48 +72,8 @@ RUN apk update && apk add --no-cache && \
         python3-dev \
         openssl-dev
 
-# build MsQuic as we don't have Alpine packages (yet)
-RUN apk update && apk add --no-cache && \
-    apk add \
-        cmake \
-        g++ \
-        gcc \
-        git \
-        numactl-dev \
-        linux-headers \
-        lttng-ust-dev \
-        make \
-        musl-dev \
-        openssl-dev \
-        perl && \
-    cd /tmp && \
-    git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://github.com/microsoft/msquic && \
-    cd msquic && \
-    cmake -B build/linux/arm64_openssl \
-       -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/arm64_Release_openssl \
-       -DCMAKE_BUILD_TYPE=Release \
-       -DCMAKE_TARGET_ARCHITECTURE=arm64 \
-       -DQUIC_TLS=openssl \
-       -DQUIC_ENABLE_LOGGING=true \
-       -DQUIC_USE_SYSTEM_LIBCRYPTO=true \
-       -DQUIC_BUILD_TOOLS=off \
-       -DQUIC_BUILD_TEST=off \
-       -DQUIC_BUILD_PERF=off && \
-    cmake --build build/linux/arm64_openssl  --config Release && \
-    cp artifacts/bin/linux/arm64_Release_openssl/libmsquic.so.* artifacts/bin/linux/arm64_Release_openssl/libmsquic.lttng.so.* /usr/lib && \
-    ldd artifacts/bin/linux/arm64_Release_openssl/libmsquic.so.* && \
-    rm -rf /tmp/msquic && \
-    apk del \
-        cmake \
-        g++ \
-        gcc \
-        git \
-        linux-headers \
-        lttng-ust-dev \
-        make \
-        musl-dev \
-        openssl-dev \
-        perl
+# Copy msquic from the msquic into our image that will run on Helix
+COPY --from=msquic /msquic /
 
 # Needed for runtime tests to pass
 ENV LANG=en-US.UTF-8

--- a/src/alpine/3.16/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.16/helix/arm64v8/Dockerfile
@@ -72,7 +72,7 @@ RUN apk update && apk add --no-cache && \
         python3-dev \
         openssl-dev
 
-# Copy msquic from the msquic into our image that will run on Helix
+# Copy msquic from the msquic image into our image that will run on Helix
 COPY --from=msquic /msquic /
 
 # Needed for runtime tests to pass

--- a/src/alpine/3.16/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.16/helix/arm64v8/Dockerfile
@@ -19,7 +19,7 @@ RUN git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://gith
 
 WORKDIR /tmp/msquic
 
-RUN cmake -B build/linux/x64_openssl \
+RUN cmake -B build/linux/arm64_Release_openssl \
        -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/arm64_Release_openssl \
        -DCMAKE_BUILD_TYPE=Release \
        -DCMAKE_TARGET_ARCHITECTURE=arm64 \

--- a/src/alpine/3.17/helix/amd64/Dockerfile
+++ b/src/alpine/3.17/helix/amd64/Dockerfile
@@ -1,3 +1,36 @@
+FROM alpine:3.17 as msquic
+
+# build MsQuic as we don't have packages
+RUN apk update && apk add --no-cache && \
+    apk add \
+        cmake \
+        g++ \
+        gcc \
+        git \
+        numactl-dev \
+        linux-headers \
+        lttng-ust-dev \
+        make \
+        musl-dev \
+        openssl-dev \
+        perl
+
+RUN git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://github.com/microsoft/msquic /tmp/msquic
+
+WORKDIR /tmp/msquic
+
+RUN cmake -B build/linux/x64_openssl \
+       -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/x64_Release_openssl \
+       -DCMAKE_BUILD_TYPE=Release \
+       -DQUIC_TLS=openssl \
+       -DQUIC_ENABLE_LOGGING=true \
+       -DQUIC_USE_SYSTEM_LIBCRYPTO=true \
+       -DQUIC_BUILD_TOOLS=off \
+       -DQUIC_BUILD_TEST=off \
+       -DQUIC_BUILD_PERF=off && \
+    cmake --build build/linux/x64_Release_openssl  --config Release && \
+    cmake --install build/linux/x64_Release_openssl --prefix /msquic
+
 FROM alpine:3.17
 # Install .NET and test dependencies
 RUN apk update && apk add --no-cache \
@@ -39,46 +72,8 @@ RUN apk update && apk add --no-cache && \
         python3-dev \
         openssl-dev
 
-# build MsQuic as we don't have Alpine packages (yet)
-RUN apk update && apk add --no-cache && \
-    apk add \
-        cmake \
-        g++ \
-        gcc \
-        git \
-        numactl-dev \
-        linux-headers \
-        lttng-ust-dev \
-        make \
-        musl-dev \
-        openssl-dev \
-        perl && \
-    cd /tmp && \
-    git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://github.com/microsoft/msquic && \
-    cd msquic && \
-    cmake -B build/linux/x64_openssl3 \
-       -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/x64_Release_openssl3 \
-       -DCMAKE_BUILD_TYPE=Release \
-       -DQUIC_TLS=openssl3 \
-       -DQUIC_ENABLE_LOGGING=true \
-       -DQUIC_USE_SYSTEM_LIBCRYPTO=true \
-       -DQUIC_BUILD_TOOLS=off \
-       -DQUIC_BUILD_TEST=off \
-       -DQUIC_BUILD_PERF=off && \
-    cmake --build build/linux/x64_openssl3  --config Release && \
-    cp artifacts/bin/linux/x64_Release_openssl3/libmsquic.so.* artifacts/bin/linux/x64_Release_openssl3/libmsquic.lttng.so.* /usr/lib && \
-    rm -rf /tmp/msquic && \
-    apk del \
-        cmake \
-        g++ \
-        gcc \
-        git \
-        linux-headers \
-        lttng-ust-dev \
-        make \
-        musl-dev \
-        openssl-dev \
-        perl
+# Copy msquic from the msquic image into our image that will run on Helix
+COPY --from=msquic /msquic /
 
 # Needed for runtime tests to pass
 ENV LANG=en-US.UTF-8

--- a/src/alpine/3.17/helix/amd64/Dockerfile
+++ b/src/alpine/3.17/helix/amd64/Dockerfile
@@ -19,7 +19,7 @@ RUN git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://gith
 
 WORKDIR /tmp/msquic
 
-RUN cmake -B build/linux/x64_openssl \
+RUN cmake -B build/linux/x64_Release_openssl \
        -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/x64_Release_openssl \
        -DCMAKE_BUILD_TYPE=Release \
        -DQUIC_TLS=openssl \

--- a/src/alpine/3.17/helix/amd64/Dockerfile
+++ b/src/alpine/3.17/helix/amd64/Dockerfile
@@ -19,17 +19,17 @@ RUN git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://gith
 
 WORKDIR /tmp/msquic
 
-RUN cmake -B build/linux/x64_Release_openssl \
-       -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/x64_Release_openssl \
+RUN cmake -B build/linux/x64_Release_openssl3 \
+       -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/x64_Release_openssl3 \
        -DCMAKE_BUILD_TYPE=Release \
-       -DQUIC_TLS=openssl \
+       -DQUIC_TLS=openssl3 \
        -DQUIC_ENABLE_LOGGING=true \
        -DQUIC_USE_SYSTEM_LIBCRYPTO=true \
        -DQUIC_BUILD_TOOLS=off \
        -DQUIC_BUILD_TEST=off \
        -DQUIC_BUILD_PERF=off && \
-    cmake --build build/linux/x64_Release_openssl  --config Release && \
-    cmake --install build/linux/x64_Release_openssl --prefix /msquic
+    cmake --build build/linux/x64_Release_openssl3  --config Release && \
+    cmake --install build/linux/x64_Release_openssl3 --prefix /msquic
 
 FROM alpine:3.17
 # Install .NET and test dependencies

--- a/src/alpine/3.17/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.17/helix/arm32v7/Dockerfile
@@ -19,11 +19,11 @@ RUN git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://gith
 
 WORKDIR /tmp/msquic
 
-RUN cmake -B build/linux/arm_Release_openssl \
+RUN cmake -B build/linux/arm_Release_openssl3 \
        -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/arm_Release_openssl3 \
        -DCMAKE_BUILD_TYPE=Release \
        -DCMAKE_TARGET_ARCHITECTURE=arm64 \
-       -DQUIC_TLS=openssl \
+       -DQUIC_TLS=openssl3 \
        -DQUIC_ENABLE_LOGGING=true \
        -DQUIC_USE_SYSTEM_LIBCRYPTO=true \
        -DQUIC_BUILD_TOOLS=off \

--- a/src/alpine/3.17/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.17/helix/arm32v7/Dockerfile
@@ -1,3 +1,37 @@
+FROM arm32v7/alpine:3.17 as msquic
+
+# build MsQuic as we don't have packages
+RUN apk update && apk add --no-cache && \
+    apk add \
+        cmake \
+        g++ \
+        gcc \
+        git \
+        numactl-dev \
+        linux-headers \
+        lttng-ust-dev \
+        make \
+        musl-dev \
+        openssl-dev \
+        perl
+
+RUN git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://github.com/microsoft/msquic /tmp/msquic
+
+WORKDIR /tmp/msquic
+
+RUN cmake -B build/linux/x64_openssl \
+       -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/arm_Release_openssl3 \
+       -DCMAKE_BUILD_TYPE=Release \
+       -DCMAKE_TARGET_ARCHITECTURE=arm64 \
+       -DQUIC_TLS=openssl \
+       -DQUIC_ENABLE_LOGGING=true \
+       -DQUIC_USE_SYSTEM_LIBCRYPTO=true \
+       -DQUIC_BUILD_TOOLS=off \
+       -DQUIC_BUILD_TEST=off \
+       -DQUIC_BUILD_PERF=off && \
+    cmake --build build/linux/arm_Release_openssl3  --config Release && \
+    cmake --install build/linux/arm_Release_openssl3 --prefix /msquic
+
 FROM arm32v7/alpine:3.17
 # Install .NET and test dependencies
 RUN apk update && apk add --no-cache \
@@ -39,47 +73,8 @@ RUN apk update && apk add --no-cache && \
         python3-dev \
         openssl-dev
 
-# build MsQuic as we don't have Alpine packages (yet)
-RUN apk update && apk add --no-cache && \
-    apk add \
-        cmake \
-        g++ \
-        gcc \
-        git \
-        numactl-dev \
-        linux-headers \
-        lttng-ust-dev \
-        make \
-        musl-dev \
-        openssl-dev \
-        perl && \
-    cd /tmp && \
-    git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://github.com/microsoft/msquic && \
-    cd msquic && \
-    cmake -B build/linux/arm_openssl3 \
-       -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/arm_Release_openssl3 \
-       -DCMAKE_BUILD_TYPE=Release \
-       -DCMAKE_TARGET_ARCHITECTURE=arm \
-       -DQUIC_TLS=openssl3 \
-       -DQUIC_ENABLE_LOGGING=true \
-       -DQUIC_USE_SYSTEM_LIBCRYPTO=true \
-       -DQUIC_BUILD_TOOLS=off \
-       -DQUIC_BUILD_TEST=off \
-       -DQUIC_BUILD_PERF=off && \
-    cmake --build build/linux/arm_openssl3  --config Release && \
-    cp artifacts/bin/linux/arm_Release_openssl3/libmsquic.so.* artifacts/bin/linux/arm_Release_openssl3/libmsquic.lttng.so.* /usr/lib && \
-    rm -rf /tmp/msquic && \
-    apk del \
-        cmake \
-        g++ \
-        gcc \
-        git \
-        linux-headers \
-        lttng-ust-dev \
-        make \
-        musl-dev \
-        openssl-dev \
-        perl
+# Copy msquic from the msquic image into our image that will run on Helix
+COPY --from=msquic /msquic /
 
 # Needed for runtime tests to pass
 ENV LANG=en-US.UTF-8

--- a/src/alpine/3.17/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.17/helix/arm32v7/Dockerfile
@@ -19,7 +19,7 @@ RUN git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://gith
 
 WORKDIR /tmp/msquic
 
-RUN cmake -B build/linux/x64_openssl \
+RUN cmake -B build/linux/arm_Release_openssl \
        -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/arm_Release_openssl3 \
        -DCMAKE_BUILD_TYPE=Release \
        -DCMAKE_TARGET_ARCHITECTURE=arm64 \

--- a/src/alpine/3.17/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.17/helix/arm32v7/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /tmp/msquic
 RUN cmake -B build/linux/arm_Release_openssl3 \
        -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/arm_Release_openssl3 \
        -DCMAKE_BUILD_TYPE=Release \
-       -DCMAKE_TARGET_ARCHITECTURE=arm64 \
+       -DCMAKE_TARGET_ARCHITECTURE=arm \
        -DQUIC_TLS=openssl3 \
        -DQUIC_ENABLE_LOGGING=true \
        -DQUIC_USE_SYSTEM_LIBCRYPTO=true \

--- a/src/alpine/3.17/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.17/helix/arm64v8/Dockerfile
@@ -1,3 +1,37 @@
+FROM arm64v8/alpine:3.17 as msquic
+
+# build MsQuic as we don't have packages
+RUN apk update && apk add --no-cache && \
+    apk add \
+        cmake \
+        g++ \
+        gcc \
+        git \
+        numactl-dev \
+        linux-headers \
+        lttng-ust-dev \
+        make \
+        musl-dev \
+        openssl-dev \
+        perl
+
+RUN git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://github.com/microsoft/msquic /tmp/msquic
+
+WORKDIR /tmp/msquic
+
+RUN cmake -B build/linux/x64_openssl \
+       -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/arm64_Release_openssl \
+       -DCMAKE_BUILD_TYPE=Release \
+       -DCMAKE_TARGET_ARCHITECTURE=arm64 \
+       -DQUIC_TLS=openssl \
+       -DQUIC_ENABLE_LOGGING=true \
+       -DQUIC_USE_SYSTEM_LIBCRYPTO=true \
+       -DQUIC_BUILD_TOOLS=off \
+       -DQUIC_BUILD_TEST=off \
+       -DQUIC_BUILD_PERF=off && \
+    cmake --build build/linux/arm64_Release_openssl  --config Release && \
+    cmake --install build/linux/arm64_Release_openssl --prefix /msquic
+
 FROM arm64v8/alpine:3.17
 # Install .NET and test dependencies
 RUN apk update && apk add --no-cache \
@@ -38,47 +72,8 @@ RUN apk update && apk add --no-cache && \
         python3-dev \
         openssl-dev
 
-# build MsQuic as we don't have Alpine packages (yet)
-RUN apk update && apk add --no-cache && \
-    apk add \
-        cmake \
-        g++ \
-        gcc \
-        git \
-        numactl-dev \
-        linux-headers \
-        lttng-ust-dev \
-        make \
-        musl-dev \
-        openssl-dev \
-        perl && \
-    cd /tmp && \
-    git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://github.com/microsoft/msquic && \
-    cd msquic && \
-    cmake -B build/linux/arm64_openssl3 \
-       -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/arm64_Release_openssl3 \
-       -DCMAKE_BUILD_TYPE=Release \
-       -DCMAKE_TARGET_ARCHITECTURE=arm64 \
-       -DQUIC_TLS=openssl3 \
-       -DQUIC_ENABLE_LOGGING=true \
-       -DQUIC_USE_SYSTEM_LIBCRYPTO=true \
-       -DQUIC_BUILD_TOOLS=off \
-       -DQUIC_BUILD_TEST=off \
-       -DQUIC_BUILD_PERF=off && \
-    cmake --build build/linux/arm64_openssl3  --config Release && \
-    cp artifacts/bin/linux/arm64_Release_openssl3/libmsquic.so.* artifacts/bin/linux/arm64_Release_openssl3/libmsquic.lttng.so.* /usr/lib && \
-    rm -rf /tmp/msquic && \
-    apk del \
-        cmake \
-        g++ \
-        gcc \
-        git \
-        linux-headers \
-        lttng-ust-dev \
-        make \
-        musl-dev \
-        openssl-dev \
-        perl
+# Copy msquic from the msquic image into our image that will run on Helix
+COPY --from=msquic /msquic /
 
 # Needed for runtime tests to pass
 ENV LANG=en-US.UTF-8

--- a/src/alpine/3.17/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.17/helix/arm64v8/Dockerfile
@@ -19,18 +19,18 @@ RUN git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://gith
 
 WORKDIR /tmp/msquic
 
-RUN cmake -B build/linux/arm64_Release_openssl \
-       -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/arm64_Release_openssl \
+RUN cmake -B build/linux/arm64_Release_openssl3 \
+       -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/arm64_Release_openssl3 \
        -DCMAKE_BUILD_TYPE=Release \
        -DCMAKE_TARGET_ARCHITECTURE=arm64 \
-       -DQUIC_TLS=openssl \
+       -DQUIC_TLS=openssl3 \
        -DQUIC_ENABLE_LOGGING=true \
        -DQUIC_USE_SYSTEM_LIBCRYPTO=true \
        -DQUIC_BUILD_TOOLS=off \
        -DQUIC_BUILD_TEST=off \
        -DQUIC_BUILD_PERF=off && \
-    cmake --build build/linux/arm64_Release_openssl  --config Release && \
-    cmake --install build/linux/arm64_Release_openssl --prefix /msquic
+    cmake --build build/linux/arm64_Release_openssl3  --config Release && \
+    cmake --install build/linux/arm64_Release_openssl3 --prefix /msquic
 
 FROM arm64v8/alpine:3.17
 # Install .NET and test dependencies

--- a/src/alpine/3.17/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.17/helix/arm64v8/Dockerfile
@@ -19,7 +19,7 @@ RUN git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://gith
 
 WORKDIR /tmp/msquic
 
-RUN cmake -B build/linux/x64_openssl \
+RUN cmake -B build/linux/arm64_Release_openssl \
        -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/arm64_Release_openssl \
        -DCMAKE_BUILD_TYPE=Release \
        -DCMAKE_TARGET_ARCHITECTURE=arm64 \

--- a/src/alpine/3.18/helix/amd64/Dockerfile
+++ b/src/alpine/3.18/helix/amd64/Dockerfile
@@ -19,7 +19,7 @@ RUN git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://gith
 
 WORKDIR /tmp/msquic
 
-RUN cmake -B build/linux/x64_openssl \
+RUN cmake -B build/linux/x64_Release_openssl \
        -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/x64_Release_openssl \
        -DCMAKE_BUILD_TYPE=Release \
        -DQUIC_TLS=openssl \

--- a/src/alpine/3.18/helix/amd64/Dockerfile
+++ b/src/alpine/3.18/helix/amd64/Dockerfile
@@ -1,3 +1,36 @@
+FROM alpine:3.18 as msquic
+
+# build MsQuic as we don't have packages
+RUN apk update && apk add --no-cache && \
+    apk add \
+        cmake \
+        g++ \
+        gcc \
+        git \
+        numactl-dev \
+        linux-headers \
+        lttng-ust-dev \
+        make \
+        musl-dev \
+        openssl-dev \
+        perl
+
+RUN git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://github.com/microsoft/msquic /tmp/msquic
+
+WORKDIR /tmp/msquic
+
+RUN cmake -B build/linux/x64_openssl \
+       -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/x64_Release_openssl \
+       -DCMAKE_BUILD_TYPE=Release \
+       -DQUIC_TLS=openssl \
+       -DQUIC_ENABLE_LOGGING=true \
+       -DQUIC_USE_SYSTEM_LIBCRYPTO=true \
+       -DQUIC_BUILD_TOOLS=off \
+       -DQUIC_BUILD_TEST=off \
+       -DQUIC_BUILD_PERF=off && \
+    cmake --build build/linux/x64_Release_openssl  --config Release && \
+    cmake --install build/linux/x64_Release_openssl --prefix /msquic
+
 FROM alpine:3.18
 # Install .NET and test dependencies
 RUN apk update && apk add --no-cache \
@@ -39,46 +72,8 @@ RUN apk update && apk add --no-cache && \
         python3-dev \
         openssl-dev
 
-# build MsQuic as we don't have Alpine packages (yet)
-RUN apk update && apk add --no-cache && \
-    apk add \
-        cmake \
-        g++ \
-        gcc \
-        git \
-        numactl-dev \
-        linux-headers \
-        lttng-ust-dev \
-        make \
-        musl-dev \
-        openssl-dev \
-        perl && \
-    cd /tmp && \
-    git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://github.com/microsoft/msquic && \
-    cd msquic && \
-    cmake -B build/linux/x64_openssl3 \
-       -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/x64_Release_openssl3 \
-       -DCMAKE_BUILD_TYPE=Release \
-       -DQUIC_TLS=openssl3 \
-       -DQUIC_ENABLE_LOGGING=true \
-       -DQUIC_USE_SYSTEM_LIBCRYPTO=true \
-       -DQUIC_BUILD_TOOLS=off \
-       -DQUIC_BUILD_TEST=off \
-       -DQUIC_BUILD_PERF=off && \
-    cmake --build build/linux/x64_openssl3  --config Release && \
-    cp artifacts/bin/linux/x64_Release_openssl3/libmsquic.so.* artifacts/bin/linux/x64_Release_openssl3/libmsquic.lttng.so.* /usr/lib && \
-    rm -rf /tmp/msquic && \
-    apk del \
-        cmake \
-        g++ \
-        gcc \
-        git \
-        linux-headers \
-        lttng-ust-dev \
-        make \
-        musl-dev \
-        openssl-dev \
-        perl
+# Copy msquic from the msquic image into our image that will run on Helix
+COPY --from=msquic /msquic /
 
 # Needed for runtime tests to pass
 ENV LANG=en-US.UTF-8

--- a/src/alpine/3.18/helix/amd64/Dockerfile
+++ b/src/alpine/3.18/helix/amd64/Dockerfile
@@ -19,17 +19,17 @@ RUN git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://gith
 
 WORKDIR /tmp/msquic
 
-RUN cmake -B build/linux/x64_Release_openssl \
-       -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/x64_Release_openssl \
+RUN cmake -B build/linux/x64_Release_openssl3 \
+       -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/x64_Release_openssl3 \
        -DCMAKE_BUILD_TYPE=Release \
-       -DQUIC_TLS=openssl \
+       -DQUIC_TLS=openssl3 \
        -DQUIC_ENABLE_LOGGING=true \
        -DQUIC_USE_SYSTEM_LIBCRYPTO=true \
        -DQUIC_BUILD_TOOLS=off \
        -DQUIC_BUILD_TEST=off \
        -DQUIC_BUILD_PERF=off && \
-    cmake --build build/linux/x64_Release_openssl  --config Release && \
-    cmake --install build/linux/x64_Release_openssl --prefix /msquic
+    cmake --build build/linux/x64_Release_openssl3  --config Release && \
+    cmake --install build/linux/x64_Release_openssl3 --prefix /msquic
 
 FROM alpine:3.18
 # Install .NET and test dependencies

--- a/src/alpine/3.18/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.18/helix/arm32v7/Dockerfile
@@ -19,11 +19,11 @@ RUN git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://gith
 
 WORKDIR /tmp/msquic
 
-RUN cmake -B build/linux/arm_Release_openssl \
+RUN cmake -B build/linux/arm_Release_openssl3 \
        -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/arm_Release_openssl3 \
        -DCMAKE_BUILD_TYPE=Release \
        -DCMAKE_TARGET_ARCHITECTURE=arm64 \
-       -DQUIC_TLS=openssl \
+       -DQUIC_TLS=openssl3 \
        -DQUIC_ENABLE_LOGGING=true \
        -DQUIC_USE_SYSTEM_LIBCRYPTO=true \
        -DQUIC_BUILD_TOOLS=off \

--- a/src/alpine/3.18/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.18/helix/arm32v7/Dockerfile
@@ -19,7 +19,7 @@ RUN git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://gith
 
 WORKDIR /tmp/msquic
 
-RUN cmake -B build/linux/x64_openssl \
+RUN cmake -B build/linux/arm_Release_openssl \
        -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/arm_Release_openssl3 \
        -DCMAKE_BUILD_TYPE=Release \
        -DCMAKE_TARGET_ARCHITECTURE=arm64 \

--- a/src/alpine/3.18/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.18/helix/arm32v7/Dockerfile
@@ -1,3 +1,37 @@
+FROM arm32v7/alpine:3.18 as msquic
+
+# build MsQuic as we don't have packages
+RUN apk update && apk add --no-cache && \
+    apk add \
+        cmake \
+        g++ \
+        gcc \
+        git \
+        numactl-dev \
+        linux-headers \
+        lttng-ust-dev \
+        make \
+        musl-dev \
+        openssl-dev \
+        perl
+
+RUN git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://github.com/microsoft/msquic /tmp/msquic
+
+WORKDIR /tmp/msquic
+
+RUN cmake -B build/linux/x64_openssl \
+       -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/arm_Release_openssl3 \
+       -DCMAKE_BUILD_TYPE=Release \
+       -DCMAKE_TARGET_ARCHITECTURE=arm64 \
+       -DQUIC_TLS=openssl \
+       -DQUIC_ENABLE_LOGGING=true \
+       -DQUIC_USE_SYSTEM_LIBCRYPTO=true \
+       -DQUIC_BUILD_TOOLS=off \
+       -DQUIC_BUILD_TEST=off \
+       -DQUIC_BUILD_PERF=off && \
+    cmake --build build/linux/arm_Release_openssl3  --config Release && \
+    cmake --install build/linux/arm_Release_openssl3 --prefix /msquic
+
 FROM arm32v7/alpine:3.18
 # Install .NET and test dependencies
 RUN apk update && apk add --no-cache \
@@ -39,47 +73,8 @@ RUN apk update && apk add --no-cache && \
         python3-dev \
         openssl-dev
 
-# build MsQuic as we don't have Alpine packages (yet)
-RUN apk update && apk add --no-cache && \
-    apk add \
-        cmake \
-        g++ \
-        gcc \
-        git \
-        numactl-dev \
-        linux-headers \
-        lttng-ust-dev \
-        make \
-        musl-dev \
-        openssl-dev \
-        perl && \
-    cd /tmp && \
-    git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://github.com/microsoft/msquic && \
-    cd msquic && \
-    cmake -B build/linux/arm_openssl3 \
-       -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/arm_Release_openssl3 \
-       -DCMAKE_BUILD_TYPE=Release \
-       -DCMAKE_TARGET_ARCHITECTURE=arm \
-       -DQUIC_TLS=openssl3 \
-       -DQUIC_ENABLE_LOGGING=true \
-       -DQUIC_USE_SYSTEM_LIBCRYPTO=true \
-       -DQUIC_BUILD_TOOLS=off \
-       -DQUIC_BUILD_TEST=off \
-       -DQUIC_BUILD_PERF=off && \
-    cmake --build build/linux/arm_openssl3  --config Release && \
-    cp artifacts/bin/linux/arm_Release_openssl3/libmsquic.so.* artifacts/bin/linux/arm_Release_openssl3/libmsquic.lttng.so.* /usr/lib && \
-    rm -rf /tmp/msquic && \
-    apk del \
-        cmake \
-        g++ \
-        gcc \
-        git \
-        linux-headers \
-        lttng-ust-dev \
-        make \
-        musl-dev \
-        openssl-dev \
-        perl
+# Copy msquic from the msquic image into our image that will run on Helix
+COPY --from=msquic /msquic /
 
 # Needed for runtime tests to pass
 ENV LANG=en-US.UTF-8

--- a/src/alpine/3.18/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.18/helix/arm32v7/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /tmp/msquic
 RUN cmake -B build/linux/arm_Release_openssl3 \
        -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/arm_Release_openssl3 \
        -DCMAKE_BUILD_TYPE=Release \
-       -DCMAKE_TARGET_ARCHITECTURE=arm64 \
+       -DCMAKE_TARGET_ARCHITECTURE=arm \
        -DQUIC_TLS=openssl3 \
        -DQUIC_ENABLE_LOGGING=true \
        -DQUIC_USE_SYSTEM_LIBCRYPTO=true \

--- a/src/alpine/3.18/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.18/helix/arm64v8/Dockerfile
@@ -19,18 +19,18 @@ RUN git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://gith
 
 WORKDIR /tmp/msquic
 
-RUN cmake -B build/linux/arm64_Release_openssl \
-       -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/arm64_Release_openssl \
+RUN cmake -B build/linux/arm64_Release_openssl3 \
+       -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/arm64_Release_openssl3 \
        -DCMAKE_BUILD_TYPE=Release \
        -DCMAKE_TARGET_ARCHITECTURE=arm64 \
-       -DQUIC_TLS=openssl \
+       -DQUIC_TLS=openssl3 \
        -DQUIC_ENABLE_LOGGING=true \
        -DQUIC_USE_SYSTEM_LIBCRYPTO=true \
        -DQUIC_BUILD_TOOLS=off \
        -DQUIC_BUILD_TEST=off \
        -DQUIC_BUILD_PERF=off && \
-    cmake --build build/linux/arm64_Release_openssl  --config Release && \
-    cmake --install build/linux/arm64_Release_openssl --prefix /msquic
+    cmake --build build/linux/arm64_Release_openssl3  --config Release && \
+    cmake --install build/linux/arm64_Release_openssl3 --prefix /msquic
 
 FROM arm64v8/alpine:3.18
 # Install .NET and test dependencies

--- a/src/alpine/3.18/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.18/helix/arm64v8/Dockerfile
@@ -1,3 +1,37 @@
+FROM arm64v8/alpine:3.18 as msquic
+
+# build MsQuic as we don't have packages
+RUN apk update && apk add --no-cache && \
+    apk add \
+        cmake \
+        g++ \
+        gcc \
+        git \
+        numactl-dev \
+        linux-headers \
+        lttng-ust-dev \
+        make \
+        musl-dev \
+        openssl-dev \
+        perl
+
+RUN git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://github.com/microsoft/msquic /tmp/msquic
+
+WORKDIR /tmp/msquic
+
+RUN cmake -B build/linux/x64_openssl \
+       -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/arm64_Release_openssl \
+       -DCMAKE_BUILD_TYPE=Release \
+       -DCMAKE_TARGET_ARCHITECTURE=arm64 \
+       -DQUIC_TLS=openssl \
+       -DQUIC_ENABLE_LOGGING=true \
+       -DQUIC_USE_SYSTEM_LIBCRYPTO=true \
+       -DQUIC_BUILD_TOOLS=off \
+       -DQUIC_BUILD_TEST=off \
+       -DQUIC_BUILD_PERF=off && \
+    cmake --build build/linux/arm64_Release_openssl  --config Release && \
+    cmake --install build/linux/arm64_Release_openssl --prefix /msquic
+
 FROM arm64v8/alpine:3.18
 # Install .NET and test dependencies
 RUN apk update && apk add --no-cache \
@@ -38,47 +72,8 @@ RUN apk update && apk add --no-cache && \
         python3-dev \
         openssl-dev
 
-# build MsQuic as we don't have Alpine packages (yet)
-RUN apk update && apk add --no-cache && \
-    apk add \
-        cmake \
-        g++ \
-        gcc \
-        git \
-        numactl-dev \
-        linux-headers \
-        lttng-ust-dev \
-        make \
-        musl-dev \
-        openssl-dev \
-        perl && \
-    cd /tmp && \
-    git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://github.com/microsoft/msquic && \
-    cd msquic && \
-    cmake -B build/linux/arm64_openssl3 \
-       -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/arm64_Release_openssl3 \
-       -DCMAKE_BUILD_TYPE=Release \
-       -DCMAKE_TARGET_ARCHITECTURE=arm64 \
-       -DQUIC_TLS=openssl3 \
-       -DQUIC_ENABLE_LOGGING=true \
-       -DQUIC_USE_SYSTEM_LIBCRYPTO=true \
-       -DQUIC_BUILD_TOOLS=off \
-       -DQUIC_BUILD_TEST=off \
-       -DQUIC_BUILD_PERF=off && \
-    cmake --build build/linux/arm64_openssl3  --config Release && \
-    cp artifacts/bin/linux/arm64_Release_openssl3/libmsquic.so.* artifacts/bin/linux/arm64_Release_openssl3/libmsquic.lttng.so.* /usr/lib && \
-    rm -rf /tmp/msquic && \
-    apk del \
-        cmake \
-        g++ \
-        gcc \
-        git \
-        linux-headers \
-        lttng-ust-dev \
-        make \
-        musl-dev \
-        openssl-dev \
-        perl
+# Copy msquic from the msquic image into our image that will run on Helix
+COPY --from=msquic /msquic /
 
 # Needed for runtime tests to pass
 ENV LANG=en-US.UTF-8

--- a/src/alpine/3.18/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.18/helix/arm64v8/Dockerfile
@@ -19,7 +19,7 @@ RUN git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://gith
 
 WORKDIR /tmp/msquic
 
-RUN cmake -B build/linux/x64_openssl \
+RUN cmake -B build/linux/arm64_Release_openssl \
        -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/arm64_Release_openssl \
        -DCMAKE_BUILD_TYPE=Release \
        -DCMAKE_TARGET_ARCHITECTURE=arm64 \


### PR DESCRIPTION
This allows us to avoid leaking anything from the msquic build into the alpine image, promotes better caching while iterating on docker images, and provides better clarity.

It also means that we don't need to carefully remove files/packages that are only needed for the msquic build.