### PR TITLE
Remove step that copies clang resources

### DIFF
--- a/src/azurelinux/3.0/net9.0/cross/amd64-sanitizer/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/amd64-sanitizer/Dockerfile
@@ -44,10 +44,3 @@ ARG ROOTFS_DIR=/crossrootfs/x64
 
 COPY --from=builder /usr/local/lib/clang /usr/local/lib/clang
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR
-
-# Compat with dotnet/runtime's custom resource dir override for PGO and sanitizer builds:
-# Once we update dotnet/runtime to not override the resource directory, we can remove this step.
-RUN CLANG_VERSION=$(clang --version | grep -oP "(?<=version )[0-9.]+") &&  \
-    CLANG_MAJOR_VERSION=$(echo $CLANG_VERSION | grep -oP "\d+" | head -1) && \
-    mkdir -p "$ROOTFS_DIR/usr/lib/llvm-$CLANG_VERSION/lib" && \
-    cp -R /usr/local/lib/clang "$ROOTFS_DIR/usr/lib/llvm-$CLANG_VERSION/lib/clang" 

--- a/src/azurelinux/3.0/net9.0/cross/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/amd64/Dockerfile
@@ -42,10 +42,3 @@ ARG ROOTFS_DIR=/crossrootfs/x64
 
 COPY --from=builder /usr/local/lib/clang /usr/local/lib/clang/
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR
-
-# Compat with dotnet/runtime's custom resource dir override for PGO and sanitizer builds:
-# Once we update dotnet/runtime to not override the resource directory, we can remove this step.
-RUN CLANG_VERSION=$(clang --version | grep -oP "(?<=version )[0-9.]+") &&  \
-    CLANG_MAJOR_VERSION=$(echo $CLANG_VERSION | grep -oP "\d+" | head -1) && \
-    mkdir -p "$ROOTFS_DIR/usr/lib/llvm-$CLANG_VERSION/lib" && \
-    cp -R /usr/local/lib/clang "$ROOTFS_DIR/usr/lib/llvm-$CLANG_VERSION/lib/clang" 

--- a/src/azurelinux/3.0/net9.0/cross/arm/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/arm/Dockerfile
@@ -44,10 +44,3 @@ ARG ROOTFS_DIR=/crossrootfs/arm
 
 COPY --from=builder /usr/local/lib/clang /usr/local/lib/clang/
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR
-
-# Compat with dotnet/runtime's custom resource dir override for PGO and sanitizer builds:
-# Once we update dotnet/runtime to not override the resource directory, we can remove this step.
-RUN CLANG_VERSION=$(clang --version | grep -oP "(?<=version )[0-9.]+") &&  \
-    CLANG_MAJOR_VERSION=$(echo $CLANG_VERSION | grep -oP "\d+" | head -1) && \
-    mkdir -p "$ROOTFS_DIR/usr/lib/llvm-$CLANG_VERSION/lib" && \
-    cp -R /usr/local/lib/clang "$ROOTFS_DIR/usr/lib/llvm-$CLANG_VERSION/lib/clang" 

--- a/src/azurelinux/3.0/net9.0/cross/arm64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/arm64/Dockerfile
@@ -44,10 +44,3 @@ ARG ROOTFS_DIR=/crossrootfs/arm64
 
 COPY --from=builder /usr/local/lib/clang /usr/local/lib/clang/
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR
-
-# Compat with dotnet/runtime's custom resource dir override for PGO and sanitizer builds:
-# Once we update dotnet/runtime to not override the resource directory, we can remove this step.
-RUN CLANG_VERSION=$(clang --version | grep -oP "(?<=version )[0-9.]+") &&  \
-    CLANG_MAJOR_VERSION=$(echo $CLANG_VERSION | grep -oP "\d+" | head -1) && \
-    mkdir -p "$ROOTFS_DIR/usr/lib/llvm-$CLANG_VERSION/lib" && \
-    cp -R /usr/local/lib/clang "$ROOTFS_DIR/usr/lib/llvm-$CLANG_VERSION/lib/clang" 


### PR DESCRIPTION
We should be able to remove this now that runtime no longer uses this resource dir with https://github.com/dotnet/runtime/pull/102390.