### PR TITLE
Remove symcrypt-openssl in the android-docker image

### DIFF
--- a/src/azurelinux/3.0/net9.0/android/docker/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/android/docker/Dockerfile
@@ -3,4 +3,7 @@ FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-android-net9.0-l
 RUN tdnf update -y \
     && tdnf install -y \
         moby-engine \
-        moby-cli
+        moby-cli && \
+    # Temporary workaround
+    tdnf remove -y \
+        symcrypt-openssl


### PR DESCRIPTION
Remove symcrypt-openssl in the android-docker image to fix failures when trying to use it in https://github.com/dotnet/runtime/pull/102775