### PR TITLE
Add an image with the x64 openssl inserted into the NDK enough that CMake can find it

### DIFF
--- a/src/azurelinux/3.0/net9.0/cross/android/openssl/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/android/openssl/amd64/Dockerfile
@@ -1,0 +1,10 @@
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-cross-android-amd64-net9.0-local
+
+# Copy the OpenSSL headers and libs from the x64 rootfs into the Anroid NDK so dotnet/runtime's
+# OpenSSL headers hack can find them for the linux-bionic build.
+RUN mkdir -p /usr/local/android-ndk/usr/local/include && \
+    mkdir /usr/local/android-ndk/usr/local/lib && \
+    cp -r /crossrootfs/x64/usr/include/openssl  /usr/local/android-ndk/usr/local/include/openssl && \
+    cp -r /crossrootfs/x64/usr/include/x86_64-linux-gnu/openssl  /usr/local/android-ndk/usr/local/include && \
+    cp -r $(readlink -f /crossrootfs/x64/usr/lib/x86_64-linux-gnu/libssl.so)  /usr/local/android-ndk/usr/local/lib/libssl.so && \
+    cp -r $(readlink -f /crossrootfs/x64/usr/lib/x86_64-linux-gnu/libcrypto.so)  /usr/local/android-ndk/usr/local/lib/libcrypto.so

--- a/src/azurelinux/manifest.json
+++ b/src/azurelinux/manifest.json
@@ -371,7 +371,10 @@
               "osVersion": "azurelinux3.0",
               "tags": {
                 "azurelinux-3.0-cross-android-amd64-net9.0-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "azurelinux-3.0-cross-android-amd64-net9.0$(FloatingTagSuffix)": {}
+                "azurelinux-3.0-cross-android-amd64-net9.0$(FloatingTagSuffix)": {},
+                "azurelinux-3.0-cross-android-amd64-net9.0-local": {
+                  "isLocal": true
+                }
               }
             }
           ]
@@ -385,6 +388,19 @@
               "tags": {
                 "azurelinux-3.0-android-docker-net9.0-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
                 "azurelinux-3.0-android-docker-net9.0$(FloatingTagSuffix)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/azurelinux/3.0/net9.0/cross/android/openssl/amd64",
+              "os": "linux",
+              "osVersion": "azurelinux3.0",
+              "tags": {
+                "azurelinux-3.0-android-openssl-net9.0-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "azurelinux-3.0-android-openssl-net9.0$(FloatingTagSuffix)": {}
               }
             }
           ]


### PR DESCRIPTION
This (along with an upcoming PR into dotnet/runtime) will enable our linux-bionic builds on AzureLinux 3.0