### PR TITLE
Fix armv6 image rootfs

### DIFF
--- a/src/azurelinux/3.0/net9.0/cross/armv6/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/armv6/Dockerfile
@@ -8,7 +8,7 @@ RUN wget http://raspbian.raspberrypi.org/raspbian/pool/main/r/raspbian-archive-k
     mv raspbian-archive-keyring-20120528.2/keyrings/raspbian-archive-keyring.gpg /usr/share/keyrings/ && \
     rm -r raspbian-archive-keyring_20120528.2.tar.gz raspbian-archive-keyring-20120528.2
 
-RUN /scripts/eng/common/cross/build-rootfs.sh armv6 bookworm
+RUN /scripts/eng/common/cross/build-rootfs.sh armv6 bookworm lldb13
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-llvm-net9.0-local
 ARG ROOTFS_DIR=/crossrootfs/armv6

--- a/src/azurelinux/manifest.json
+++ b/src/azurelinux/manifest.json
@@ -435,8 +435,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-cross-armv6-respbian-10-net9.0-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "azurelinux-3.0-cross-armv6-respbian-10-net9.0$(FloatingTagSuffix)": {}
+                "azurelinux-3.0-cross-armv6-net9.0-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "azurelinux-3.0-cross-armv6-net9.0$(FloatingTagSuffix)": {}
               }
             }
           ]


### PR DESCRIPTION
This image didn't have a bookworm rootfs because build-rootfs.sh didn't support bookworm.
Also fixes the naming scheme to match the one used for cbl-mariner armv6 images.
Depends on https://github.com/dotnet/arcade/pull/14803