### PR TITLE
Add Alpine 3.20 Helix images

### DIFF
--- a/src/alpine/3.20/helix/amd64/Dockerfile
+++ b/src/alpine/3.20/helix/amd64/Dockerfile
@@ -48,30 +48,10 @@ RUN apk update && apk add --no-cache \
     numactl \
     openssl \
     python3 \
+    python3-dev \
+    py3-pip \
     sudo \
     tzdata
-
-# Install Helix Dependencies
-RUN apk update && apk add --no-cache && \
-    apk add \
-        cargo \
-        libffi-dev \
-        linux-headers \
-        python3-dev \
-        openssl-dev && \
-    ln -sf /usr/bin/python3 /usr/bin/python && \
-    curl https://bootstrap.pypa.io/get-pip.py -o ./get-pip.py --fail --silent --show-error && \
-    python3 ./get-pip.py && rm ./get-pip.py && \
-    python3 -m pip install --upgrade pip==22.2.2 && \
-    python3 -m pip install virtualenv==20.16.5 && \
-    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    pip install ./helix_scripts-*-py3-none-any.whl && \
-    apk del \
-        cargo \
-        libffi-dev \
-        linux-headers \
-        python3-dev \
-        openssl-dev
 
 # Copy msquic from the msquic image into our image that will run on Helix
 COPY --from=msquic /msquic /usr
@@ -86,6 +66,21 @@ RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
     chmod 755 /root && \
     echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot
 
-USER helixbot
+# Install Helix Dependencies
+RUN apk update && apk add --no-cache \
+    build-base \
+    gcc \
+    linux-headers && \
+    # Create virtual environment
+    python3 -m venv /home/helixbot/.vsts-env && \
+    source /home/helixbot/.vsts-env/bin/activate && \
+    # Install Helix scripts
+    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    pip install ./helix_scripts-*-py3-none-any.whl && \
+    # Delete unnecessary dependencies
+    apk del \
+    build-base \
+    gcc \
+    linux-headers
 
-RUN python3 -m virtualenv /home/helixbot/.vsts-env
+USER helixbot

--- a/src/alpine/3.20/helix/amd64/Dockerfile
+++ b/src/alpine/3.20/helix/amd64/Dockerfile
@@ -1,0 +1,91 @@
+FROM amd64/alpine:3.20 as msquic
+
+# build MsQuic as we don't have packages
+RUN apk update && apk add --no-cache && \
+    apk add \
+        cmake \
+        g++ \
+        gcc \
+        git \
+        numactl-dev \
+        linux-headers \
+        lttng-ust-dev \
+        make \
+        musl-dev \
+        openssl-dev \
+        perl
+
+RUN git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://github.com/microsoft/msquic /tmp/msquic
+
+WORKDIR /tmp/msquic
+
+RUN cmake -B build/linux/x64_Release_openssl3 \
+       -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/x64_Release_openssl3 \
+       -DCMAKE_BUILD_TYPE=Release \
+       -DQUIC_TLS=openssl3 \
+       -DQUIC_ENABLE_LOGGING=true \
+       -DQUIC_USE_SYSTEM_LIBCRYPTO=true \
+       -DQUIC_BUILD_TOOLS=off \
+       -DQUIC_BUILD_TEST=off \
+       -DQUIC_BUILD_PERF=off && \
+    cmake --build build/linux/x64_Release_openssl3  --config Release && \
+    cmake --install build/linux/x64_Release_openssl3 --prefix /msquic
+
+FROM alpine:3.20
+# Install .NET and test dependencies
+RUN apk update && apk add --no-cache \
+    bash \
+    coreutils \
+    curl \
+    icu-data-full \
+    icu-libs \
+    iputils \
+    krb5-libs \
+    lldb \
+    llvm \
+    lttng-ust \
+    musl-locales \
+    numactl \
+    openssl \
+    python3 \
+    sudo \
+    tzdata
+
+# Install Helix Dependencies
+RUN apk update && apk add --no-cache && \
+    apk add \
+        cargo \
+        libffi-dev \
+        linux-headers \
+        python3-dev \
+        openssl-dev && \
+    ln -sf /usr/bin/python3 /usr/bin/python && \
+    curl https://bootstrap.pypa.io/get-pip.py -o ./get-pip.py --fail --silent --show-error && \
+    python3 ./get-pip.py && rm ./get-pip.py && \
+    python3 -m pip install --upgrade pip==22.2.2 && \
+    python3 -m pip install virtualenv==20.16.5 && \
+    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    pip install ./helix_scripts-*-py3-none-any.whl && \
+    apk del \
+        cargo \
+        libffi-dev \
+        linux-headers \
+        python3-dev \
+        openssl-dev
+
+# Copy msquic from the msquic image into our image that will run on Helix
+COPY --from=msquic /msquic /usr
+
+# Needed for runtime tests to pass
+ENV LANG=en-US.UTF-8
+RUN echo export LANG=${LANG}  >> /etc/profile.d/locale.sh
+
+# create helixbot user and give rights to sudo without password
+# Alpine does not support long options
+RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
+    chmod 755 /root && \
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot
+
+USER helixbot
+
+RUN python3 -m virtualenv /home/helixbot/.vsts-env

--- a/src/alpine/3.20/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.20/helix/arm32v7/Dockerfile
@@ -35,32 +35,25 @@ RUN cmake -B build/linux/arm_Release_openssl3 \
 FROM arm32v7/alpine:3.20
 # Install .NET and test dependencies
 RUN apk update && apk add --no-cache \
-    bash \
-    coreutils \
-    curl \
-    icu-data-full \
-    icu-libs \
-    iputils \
-    krb5-libs \
-    lldb \
-    llvm \
-    lttng-ust \
-    musl-locales \
-    numactl \
-    openssl \
-    python3 \
-    python3-dev \
-    py3-cryptography \
-    py3-pip \
-    sudo \
-    tzdata
-
-# Copy msquic from the msquic image into our image that will run on Helix
-COPY --from=msquic /msquic /usr
-
-# Needed for runtime tests to pass
-ENV LANG=en-US.UTF-8
-RUN echo export LANG=${LANG}  >> /etc/profile.d/locale.sh
+        bash \
+        coreutils \
+        curl \
+        icu-data-full \
+        icu-libs \
+        iputils \
+        krb5-libs \
+        lldb \
+        llvm \
+        lttng-ust \
+        musl-locales \
+        numactl \
+        openssl \
+        python3 \
+        python3-dev \
+        py3-cryptography \
+        py3-pip \
+        sudo \
+        tzdata
 
 # create helixbot user and give rights to sudo without password
 # Alpine does not support long options
@@ -70,23 +63,30 @@ RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
 
 # Install Helix Dependencies
 RUN apk update && apk add --no-cache \
-    build-base \
-    cargo \
-    libffi-dev \
-    gcc \
-    linux-headers && \
-    # Create virtual environment
-    python3 -m venv /home/helixbot/.vsts-env && \
+        build-base \
+        cargo \
+        libffi-dev \
+        gcc \
+        linux-headers & \
+        # Create virtual environment
+    python3 -m venv --system-site-packages /home/helixbot/.vsts-env && \
     source /home/helixbot/.vsts-env/bin/activate && \
     # Install Helix scripts
     pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
     pip install ./helix_scripts-*-py3-none-any.whl && \
     # Delete unnecessary dependencies
     apk del \
-    build-base \
-    cargo \
-    libffi-dev \
-    gcc \
-    linux-headers
+        build-base \
+        cargo \
+        libffi-dev \
+        gcc \
+        linux-headers
+
+# Copy msquic from the msquic image into our image that will run on Helix
+COPY --from=msquic /msquic /usr
+
+# Needed for runtime tests to pass
+ENV LANG=en-US.UTF-8
+RUN echo export LANG=${LANG}  >> /etc/profile.d/locale.sh
 
 USER helixbot

--- a/src/alpine/3.20/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.20/helix/arm32v7/Dockerfile
@@ -1,0 +1,95 @@
+FROM arm32v7/alpine:3.20 as msquic
+
+# build MsQuic as we don't have packages
+RUN apk update && apk add --no-cache && \
+    apk add \
+        cmake \
+        g++ \
+        gcc \
+        git \
+        numactl-dev \
+        linux-headers \
+        lttng-ust-dev \
+        make \
+        musl-dev \
+        openssl-dev \
+        perl
+
+RUN git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://github.com/microsoft/msquic /tmp/msquic
+
+WORKDIR /tmp/msquic
+
+RUN cmake -B build/linux/arm_Release_openssl3 \
+       -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/arm_Release_openssl3 \
+       -DCMAKE_BUILD_TYPE=Release \
+       -DCMAKE_TARGET_ARCHITECTURE=arm \
+       -DQUIC_TLS=openssl3 \
+       -DQUIC_ENABLE_LOGGING=true \
+       -DQUIC_USE_SYSTEM_LIBCRYPTO=true \
+       -DQUIC_BUILD_TOOLS=off \
+       -DQUIC_BUILD_TEST=off \
+       -DQUIC_BUILD_PERF=off && \
+    cmake --build build/linux/arm_Release_openssl3  --config Release && \
+    cmake --install build/linux/arm_Release_openssl3 --prefix /msquic
+
+FROM arm32v7/alpine:3.20
+# Install .NET and test dependencies
+RUN apk update && apk add --no-cache \
+    bash \
+    coreutils \
+    curl \
+    icu-data-full \
+    icu-libs \
+    iputils \
+    krb5-libs \
+    lldb \
+    llvm \
+    lttng-ust \
+    musl-locales \
+    numactl \
+    openssl \
+    python3 \
+    sudo \
+    tzdata
+
+# Install Helix Dependencies
+RUN apk update && apk add --no-cache && \
+    apk add \
+        cargo \
+        libffi-dev \
+        linux-headers \
+        python3-dev \
+        openssl-dev && \
+    ln -sf /usr/bin/python3 /usr/bin/python && \
+    curl https://bootstrap.pypa.io/get-pip.py -o ./get-pip.py --fail --silent --show-error && \
+    python3 ./get-pip.py && rm ./get-pip.py && \
+    python3 -m pip install --upgrade pip==22.2.2 && \
+    python3 -m pip install virtualenv==20.16.5 && \
+    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    pip install ./helix_scripts-*-py3-none-any.whl && \
+    apk del \
+        cargo \
+        libffi-dev \
+        linux-headers \
+        python3-dev \
+        openssl-dev
+
+# Copy msquic from the msquic image into our image that will run on Helix
+COPY --from=msquic /msquic /usr
+
+# Needed for runtime tests to pass
+ENV LANG=en-US.UTF-8
+RUN echo export LANG=${LANG}  >> /etc/profile.d/locale.sh
+
+# create helixbot user and give rights to sudo without password
+# Alpine does not support long options
+RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1001 helixbot && \
+    /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot2 && \
+    chmod 755 /root && \
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot && \
+    echo "helixbot2 ALL=(ALL)      NOPASSWD: ALL" > /etc/sudoers.d/helixbot2
+
+
+USER helixbot
+
+RUN python3 -m virtualenv /home/helixbot/.vsts-env

--- a/src/alpine/3.20/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.20/helix/arm32v7/Dockerfile
@@ -70,6 +70,7 @@ RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
 # Install Helix Dependencies
 RUN apk update && apk add --no-cache \
     build-base \
+    cargo \
     libffi-dev \
     gcc \
     linux-headers && \
@@ -82,6 +83,7 @@ RUN apk update && apk add --no-cache \
     # Delete unnecessary dependencies
     apk del \
     build-base \
+    cargo \
     libffi-dev \
     gcc \
     linux-headers

--- a/src/alpine/3.20/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.20/helix/arm32v7/Dockerfile
@@ -50,6 +50,7 @@ RUN apk update && apk add --no-cache \
     openssl \
     python3 \
     python3-dev \
+    py3-cryptography \
     py3-pip \
     sudo \
     tzdata

--- a/src/alpine/3.20/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.20/helix/arm32v7/Dockerfile
@@ -70,6 +70,7 @@ RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
 # Install Helix Dependencies
 RUN apk update && apk add --no-cache \
     build-base \
+    libffi-dev \
     gcc \
     linux-headers && \
     # Create virtual environment
@@ -81,6 +82,7 @@ RUN apk update && apk add --no-cache \
     # Delete unnecessary dependencies
     apk del \
     build-base \
+    libffi-dev \
     gcc \
     linux-headers
 

--- a/src/alpine/3.20/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.20/helix/arm32v7/Dockerfile
@@ -64,7 +64,6 @@ RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
 # Install Helix Dependencies
 RUN apk update && apk add --no-cache \
         build-base \
-        cargo \
         libffi-dev \
         gcc \
         linux-headers & \
@@ -77,7 +76,6 @@ RUN apk update && apk add --no-cache \
     # Delete unnecessary dependencies
     apk del \
         build-base \
-        cargo \
         libffi-dev \
         gcc \
         linux-headers

--- a/src/alpine/3.20/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.20/helix/arm32v7/Dockerfile
@@ -49,30 +49,10 @@ RUN apk update && apk add --no-cache \
     numactl \
     openssl \
     python3 \
+    python3-dev \
+    py3-pip \
     sudo \
     tzdata
-
-# Install Helix Dependencies
-RUN apk update && apk add --no-cache && \
-    apk add \
-        cargo \
-        libffi-dev \
-        linux-headers \
-        python3-dev \
-        openssl-dev && \
-    ln -sf /usr/bin/python3 /usr/bin/python && \
-    curl https://bootstrap.pypa.io/get-pip.py -o ./get-pip.py --fail --silent --show-error && \
-    python3 ./get-pip.py && rm ./get-pip.py && \
-    python3 -m pip install --upgrade pip==22.2.2 && \
-    python3 -m pip install virtualenv==20.16.5 && \
-    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    pip install ./helix_scripts-*-py3-none-any.whl && \
-    apk del \
-        cargo \
-        libffi-dev \
-        linux-headers \
-        python3-dev \
-        openssl-dev
 
 # Copy msquic from the msquic image into our image that will run on Helix
 COPY --from=msquic /msquic /usr
@@ -83,13 +63,25 @@ RUN echo export LANG=${LANG}  >> /etc/profile.d/locale.sh
 
 # create helixbot user and give rights to sudo without password
 # Alpine does not support long options
-RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1001 helixbot && \
-    /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot2 && \
+RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
     chmod 755 /root && \
-    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot && \
-    echo "helixbot2 ALL=(ALL)      NOPASSWD: ALL" > /etc/sudoers.d/helixbot2
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot
 
+# Install Helix Dependencies
+RUN apk update && apk add --no-cache \
+    build-base \
+    gcc \
+    linux-headers && \
+    # Create virtual environment
+    python3 -m venv /home/helixbot/.vsts-env && \
+    source /home/helixbot/.vsts-env/bin/activate && \
+    # Install Helix scripts
+    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    pip install ./helix_scripts-*-py3-none-any.whl && \
+    # Delete unnecessary dependencies
+    apk del \
+    build-base \
+    gcc \
+    linux-headers
 
 USER helixbot
-
-RUN python3 -m virtualenv /home/helixbot/.vsts-env

--- a/src/alpine/3.20/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.20/helix/arm64v8/Dockerfile
@@ -49,29 +49,10 @@ RUN apk update && apk add --no-cache \
     numactl \
     openssl \
     python3 \
+    python3-dev \
+    py3-pip \
     sudo \
     tzdata
-
-RUN apk update && apk add --no-cache && \
-    apk add \
-        cargo \
-        libffi-dev \
-        linux-headers \
-        python3-dev \
-        openssl-dev && \
-    ln -sf /usr/bin/python3 /usr/bin/python && \
-    curl https://bootstrap.pypa.io/get-pip.py -o ./get-pip.py --fail --silent --show-error && \
-    python3 ./get-pip.py && rm ./get-pip.py && \
-    python3 -m pip install --upgrade pip==22.2.2 && \
-    python3 -m pip install virtualenv==20.16.5 && \
-    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    pip install ./helix_scripts-*-py3-none-any.whl && \
-    apk del \
-        cargo \
-        libffi-dev \
-        linux-headers \
-        python3-dev \
-        openssl-dev
 
 # Copy msquic from the msquic image into our image that will run on Helix
 COPY --from=msquic /msquic /usr
@@ -82,12 +63,25 @@ RUN echo export LANG=${LANG}  >> /etc/profile.d/locale.sh
 
 # create helixbot user and give rights to sudo without password
 # Alpine does not support long options
-RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1001 helixbot && \
-    /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot2 && \
+RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
     chmod 755 /root && \
-    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot && \
-    echo "helixbot2 ALL=(ALL)      NOPASSWD: ALL" > /etc/sudoers.d/helixbot2
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot
+
+# Install Helix Dependencies
+RUN apk update && apk add --no-cache \
+    build-base \
+    gcc \
+    linux-headers && \
+    # Create virtual environment
+    python3 -m venv /home/helixbot/.vsts-env && \
+    source /home/helixbot/.vsts-env/bin/activate && \
+    # Install Helix scripts
+    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    pip install ./helix_scripts-*-py3-none-any.whl && \
+    # Delete unnecessary dependencies
+    apk del \
+    build-base \
+    gcc \
+    linux-headers
 
 USER helixbot
-
-RUN python3 -m virtualenv /home/helixbot/.vsts-env

--- a/src/alpine/3.20/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.20/helix/arm64v8/Dockerfile
@@ -1,0 +1,93 @@
+FROM arm64v8/alpine:3.20 as msquic
+
+# build MsQuic as we don't have packages
+RUN apk update && apk add --no-cache && \
+    apk add \
+        cmake \
+        g++ \
+        gcc \
+        git \
+        numactl-dev \
+        linux-headers \
+        lttng-ust-dev \
+        make \
+        musl-dev \
+        openssl-dev \
+        perl
+
+RUN git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://github.com/microsoft/msquic /tmp/msquic
+
+WORKDIR /tmp/msquic
+
+RUN cmake -B build/linux/arm64_Release_openssl3 \
+       -DQUIC_OUTPUT_DIR=/tmp/msquic/artifacts/bin/linux/arm64_Release_openssl3 \
+       -DCMAKE_BUILD_TYPE=Release \
+       -DCMAKE_TARGET_ARCHITECTURE=arm64 \
+       -DQUIC_TLS=openssl3 \
+       -DQUIC_ENABLE_LOGGING=true \
+       -DQUIC_USE_SYSTEM_LIBCRYPTO=true \
+       -DQUIC_BUILD_TOOLS=off \
+       -DQUIC_BUILD_TEST=off \
+       -DQUIC_BUILD_PERF=off && \
+    cmake --build build/linux/arm64_Release_openssl3  --config Release && \
+    cmake --install build/linux/arm64_Release_openssl3 --prefix /msquic
+
+FROM arm64v8/alpine:3.20
+# Install .NET and test dependencies
+RUN apk update && apk add --no-cache \
+    bash \
+    coreutils \
+    curl \
+    icu-data-full \
+    icu-libs \
+    iputils \
+    krb5-libs \
+    lldb \
+    llvm \
+    lttng-ust \
+    musl-locales \
+    numactl \
+    openssl \
+    python3 \
+    sudo \
+    tzdata
+
+RUN apk update && apk add --no-cache && \
+    apk add \
+        cargo \
+        libffi-dev \
+        linux-headers \
+        python3-dev \
+        openssl-dev && \
+    ln -sf /usr/bin/python3 /usr/bin/python && \
+    curl https://bootstrap.pypa.io/get-pip.py -o ./get-pip.py --fail --silent --show-error && \
+    python3 ./get-pip.py && rm ./get-pip.py && \
+    python3 -m pip install --upgrade pip==22.2.2 && \
+    python3 -m pip install virtualenv==20.16.5 && \
+    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    pip install ./helix_scripts-*-py3-none-any.whl && \
+    apk del \
+        cargo \
+        libffi-dev \
+        linux-headers \
+        python3-dev \
+        openssl-dev
+
+# Copy msquic from the msquic image into our image that will run on Helix
+COPY --from=msquic /msquic /usr
+
+# Needed for runtime tests to pass
+ENV LANG=en-US.UTF-8
+RUN echo export LANG=${LANG}  >> /etc/profile.d/locale.sh
+
+# create helixbot user and give rights to sudo without password
+# Alpine does not support long options
+RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1001 helixbot && \
+    /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot2 && \
+    chmod 755 /root && \
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot && \
+    echo "helixbot2 ALL=(ALL)      NOPASSWD: ALL" > /etc/sudoers.d/helixbot2
+
+USER helixbot
+
+RUN python3 -m virtualenv /home/helixbot/.vsts-env

--- a/src/alpine/3.20/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.20/helix/arm64v8/Dockerfile
@@ -70,6 +70,7 @@ RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
 # Install Helix Dependencies
 RUN apk update && apk add --no-cache \
     build-base \
+    libffi-dev \
     gcc \
     linux-headers && \
     # Create virtual environment
@@ -81,6 +82,7 @@ RUN apk update && apk add --no-cache \
     # Delete unnecessary dependencies
     apk del \
     build-base \
+    libffi-dev \
     gcc \
     linux-headers
 

--- a/src/alpine/manifest.json
+++ b/src/alpine/manifest.json
@@ -166,6 +166,49 @@
         {
           "platforms": [
             {
+              "dockerfile": "src/alpine/3.20/helix/amd64",
+              "os": "linux",
+              "osVersion": "alpine3.20",
+              "tags": {
+                "alpine-3.20-helix-amd64-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "alpine-3.20-helix-amd64$(FloatingTagSuffix)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "architecture": "arm",
+              "dockerfile": "src/alpine/3.20/helix/arm32v7",
+              "os": "linux",
+              "osVersion": "alpine3.20",
+              "tags": {
+                "alpine-3.20-helix-arm32v7-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "alpine-3.20-helix-arm32v7$(FloatingTagSuffix)": {}
+              },
+              "variant": "v7"
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "architecture": "arm64",
+              "dockerfile": "src/alpine/3.20/helix/arm64v8",
+              "os": "linux",
+              "osVersion": "alpine3.20",
+              "tags": {
+                "alpine-3.20-helix-arm64v8-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "alpine-3.20-helix-arm64v8$(FloatingTagSuffix)": {}
+              },
+              "variant": "v8"
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
               "dockerfile": "src/alpine/3.20/amd64",
               "os": "linux",
               "osVersion": "alpine3.20",


### PR DESCRIPTION
Fixes #1093.

I tried to use `py3-psutil` from Alpine but was unable to do so due to the way dependencies are specified in the helix wheel we install. Instead, the `psutil` is built from source (with `gcc`). Explained in more detail at #1092.

I switched to `venv` from `virtualenv` since the former comes with Python3 distributions. AFAICT, `virtualenv` is more a legacy Python 2-ism.

The way we install `pip` and `virtualenv` is anti-pattern as I've written before. In some Dockerfiles I've seen, we install `pip` three times in a row. "Gotta be sure!"

I've tried to address these problems, however, there is a quite possible chance that we're either need to change the way these images are launched or go back to `--break-system-packages`, like we do in Debian. I really want to get away from that, since it is a clear demonstration that we're unable to use Python as it is designed.

Due to what is discussed in #1093, I actually used the virtual environment for what it is intended for, which is 