### PR TITLE
Pin debootstrap to tag 1.0.134 and fix azurelinux 3.0 build

### DIFF
--- a/src/azurelinux/3.0/net8.0/crossdeps-builder/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/crossdeps-builder/amd64/Dockerfile
@@ -9,6 +9,7 @@ RUN tdnf install -y \
         # LLVM build dependencies
         binutils \
         clang \
+        make \
         cmake \
         diffutils \
         glibc-devel \

--- a/src/azurelinux/3.0/net8.0/crossdeps-builder/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/crossdeps-builder/amd64/Dockerfile
@@ -9,6 +9,7 @@ RUN tdnf install -y \
         # LLVM build dependencies
         binutils \
         clang \
+        gcc \
         make \
         cmake \
         diffutils \

--- a/src/azurelinux/3.0/net8.0/crossdeps/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/crossdeps/amd64/Dockerfile
@@ -9,6 +9,7 @@ RUN tdnf update -y && \
         wget \
         # Common runtime build dependencies
         awk \
+        make \
         cmake \
         diffutils \
         icu \

--- a/src/azurelinux/3.0/net8.0/crossdeps/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/crossdeps/amd64/Dockerfile
@@ -23,4 +23,5 @@ RUN tdnf update -y && \
         # Jit rolling build dependency
         python3-pip \
         # aspnetcore build dependencies
-        nodejs
+        nodejs \
+        npm

--- a/src/azurelinux/3.0/net8.0/crossdeps/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/crossdeps/amd64/Dockerfile
@@ -9,6 +9,7 @@ RUN tdnf update -y && \
         wget \
         # Common runtime build dependencies
         awk \
+        gcc \
         make \
         cmake \
         diffutils \

--- a/src/azurelinux/3.0/net9.0/cross/riscv64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/riscv64/Dockerfile
@@ -3,8 +3,11 @@ ARG ROOTFS_DIR=/crossrootfs/riscv64
 
 # Install the latest debootstrap
 RUN tdnf remove -y debootstrap && \
-    curl -sSL https://deb.debian.org/debian/pool/main/d/debootstrap/debootstrap_1.0.134.tar.gz | tar xzf - -C / && \
-    ln -s /debootstrap/debootstrap -t /usr/local/bin
+    curl -sSLO https://deb.debian.org/debian/pool/main/d/debootstrap/debootstrap_1.0.134.tar.gz && \
+    echo "03c1dfbff2f9936acea3954b9c92e348e7e216f706c202744f80c9f1302329b4 debootstrap_1.0.134.tar.gz" | sha256sum -c - && \
+    tar xzf debootstrap_1.0.134.tar.gz -C / && \
+    ln -s /debootstrap/debootstrap -t /usr/local/bin && \
+    rm -f debootstrap_1.0.134.tar.gz
 
 RUN /scripts/eng/common/cross/build-rootfs.sh riscv64 noble --skipunmount
 

--- a/src/azurelinux/3.0/net9.0/cross/riscv64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/riscv64/Dockerfile
@@ -3,8 +3,7 @@ ARG ROOTFS_DIR=/crossrootfs/riscv64
 
 # Install the latest debootstrap
 RUN tdnf remove -y debootstrap && \
-    git clone --depth 1 "https://git.launchpad.net/ubuntu/+source/debootstrap" /debootstrap && \
-    chmod a+x /debootstrap/debootstrap && \
+    curl -sSL https://deb.debian.org/debian/pool/main/d/debootstrap/debootstrap_1.0.134.tar.gz | tar xzf - -C / && \
     ln -s /debootstrap/debootstrap -t /usr/local/bin
 
 RUN /scripts/eng/common/cross/build-rootfs.sh riscv64 noble --skipunmount

--- a/src/azurelinux/3.0/net9.0/crossdeps-builder/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/crossdeps-builder/amd64/Dockerfile
@@ -9,6 +9,7 @@ RUN tdnf install -y \
         # LLVM build dependencies
         binutils \
         clang \
+        make \
         cmake \
         diffutils \
         glibc-devel \

--- a/src/azurelinux/3.0/net9.0/crossdeps-builder/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/crossdeps-builder/amd64/Dockerfile
@@ -9,6 +9,7 @@ RUN tdnf install -y \
         # LLVM build dependencies
         binutils \
         clang \
+        gcc \
         make \
         cmake \
         diffutils \

--- a/src/azurelinux/3.0/net9.0/crossdeps/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/crossdeps/amd64/Dockerfile
@@ -9,6 +9,7 @@ RUN tdnf update -y && \
         wget \
         # Common runtime build dependencies
         awk \
+        make \
         cmake \
         diffutils \
         icu \

--- a/src/azurelinux/3.0/net9.0/crossdeps/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/crossdeps/amd64/Dockerfile
@@ -23,4 +23,5 @@ RUN tdnf update -y && \
         # Jit rolling build dependency
         python3-pip \
         # aspnetcore build dependencies
-        nodejs
+        nodejs \
+        npm

--- a/src/azurelinux/3.0/net9.0/crossdeps/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/crossdeps/amd64/Dockerfile
@@ -9,6 +9,7 @@ RUN tdnf update -y && \
         wget \
         # Common runtime build dependencies
         awk \
+        gcc \
         make \
         cmake \
         diffutils \

--- a/src/azurelinux/3.0/net9.0/webassembly/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/webassembly/amd64/Dockerfile
@@ -6,6 +6,7 @@ RUN tdnf update -y \
         # WebAssembly build dependencies
         which \
         nodejs \
+        npm \
         python3 \
         libxml2 \
         unzip

--- a/src/cbl-mariner/2.0/webassembly/amd64/Dockerfile
+++ b/src/cbl-mariner/2.0/webassembly/amd64/Dockerfile
@@ -6,7 +6,6 @@ RUN tdnf update -y \
         # WebAssembly build dependencies
         which \
         nodejs \
-        npm \
         python3 \
         libxml2 \
         unzip

--- a/src/cbl-mariner/2.0/webassembly/amd64/Dockerfile
+++ b/src/cbl-mariner/2.0/webassembly/amd64/Dockerfile
@@ -6,6 +6,7 @@ RUN tdnf update -y \
         # WebAssembly build dependencies
         which \
         nodejs \
+        npm \
         python3 \
         libxml2 \
         unzip


### PR DESCRIPTION
While https://github.com/microsoft/azurelinux/pull/9422 is under review, we can pin it to ubuntu1 release tag.

We also need to add some more dependencies since azurelinux 3.0 rebuilt their packages and now doesn't install some transitive dependencies anymore.