### PR TITLE
Fix Arm emulation for Ubuntu 22.04

### DIFF
--- a/src/ubuntu/22.04/cross/arm/Dockerfile
+++ b/src/ubuntu/22.04/cross/arm/Dockerfile
@@ -5,6 +5,12 @@ ARG ROOTFS_DIR=/crossrootfs/arm
 RUN git config --global user.email builder@dotnet-buildtools-prereqs-docker && \
     git clone --depth 1 --single-branch https://github.com/dotnet/arcade /scripts
 
+RUN apt-get update \
+    && apt-get install -y \
+        qemu \
+        qemu-user-static \
+    && rm -rf /var/lib/apt/lists/*
+
 # Build the rootfs
 RUN /scripts/eng/common/cross/build-rootfs.sh arm jammy lldb14 --skipunmount
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/1067