### PR TITLE
Install azure cli via script and update depkg image derive from core

### DIFF
--- a/src/ubuntu/22.04/coredeps/Dockerfile
+++ b/src/ubuntu/22.04/coredeps/Dockerfile
@@ -8,9 +8,8 @@ RUN apt-get update \
         npm \
         tar \
         zip \
-    && rm -rf /var/lib/apt/lists/* \
-    && npm install -g azure-cli@0.9.20 \
-    && npm cache clean --force
+    && curl -sL https://aka.ms/InstallAzureCLIDeb | bash \
+    && rm -rf /var/lib/apt/lists/*
 
 # Runtime dependencies
 RUN apt-get update \

--- a/src/ubuntu/22.04/debpkg/amd64/Dockerfile
+++ b/src/ubuntu/22.04/debpkg/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-coredeps-local
 
 # Install the deb packaging toolchain we need to build debs
 RUN apt-get update \


### PR DESCRIPTION
- Stop using the npm installation of azure-cli (very old)
- Base depkg on coredeps to get powershell