### PR TITLE
Install Powershell on Alpine 3.20

### DIFF
--- a/src/alpine/3.20/amd64/Dockerfile
+++ b/src/alpine/3.20/amd64/Dockerfile
@@ -6,6 +6,7 @@ RUN apk update && apk add --no-cache \
         automake \
         bash \
         build-base \
+        ca-certificates \
         clang \
         clang-dev \
         cmake \
@@ -18,15 +19,22 @@ RUN apk update && apk add --no-cache \
         git \
         icu-data-full \
         icu-dev \
+        icu-libs \
         jq \
         krb5-dev \
         libtool \
+        less \
+        libgcc \
+        libintl \
+        libssl3 \
+        libstdc++ \
         libunwind-dev \
         linux-headers \
         lld \
         lldb-dev \
         llvm \
         lttng-ust-dev \
+        ncurses-terminfo-base \
         make \
         numactl-dev \
         openssl \
@@ -37,6 +45,26 @@ RUN apk update && apk add --no-cache \
         shadow \
         sudo \
         tzdata \
+        userspace-rcu \
         util-linux-dev \
         which \
         zlib-dev
+
+# Install the latest non-preview powershell release.
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust \
+    && LATEST_TAG=$(curl -L https://api.github.com/repos/powershell/powershell/releases/latest | jq -r '.tag_name') \
+    # Verify that it's a 7.x release
+    && [[ $LATEST_TAG == v7.* ]] \
+    && curl -L https://github.com/PowerShell/PowerShell/releases/download/$LATEST_TAG/powershell-${LATEST_TAG#*v}-linux-musl-x64.tar.gz -o /tmp/powershell.tar.gz \
+    && mkdir -p /opt/microsoft/powershell/7 \
+    && tar zxf /tmp/powershell.tar.gz -C /opt/microsoft/powershell/7 \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh \
+    && rm -f /tmp/powershell.tar.gz
+
+# Install azurecli from PIP
+RUN azureEnv="/usr/local/share/azure-cli-env" && \
+    python3 -m venv "$azureEnv" && \
+    "$azureEnv/bin/python" -m pip install --upgrade setuptools && \
+    "$azureEnv/bin/python" -m pip install azure-cli && \
+    ln -s "$azureEnv/bin/az" /usr/local/bin/az


### PR DESCRIPTION
Port changes from https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1100 to 3.20