### PR TITLE
Move illumos to Ubuntu 22.04

### DIFF
--- a/src/ubuntu/22.04/cross/illumos/Dockerfile
+++ b/src/ubuntu/22.04/cross/illumos/Dockerfile
@@ -1,0 +1,16 @@
+ARG ROOTFS_DIR=/crossrootfs/x64
+
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps-local AS builder
+ARG ROOTFS_DIR
+
+# Obtain arcade scripts used to build rootfs
+RUN git config --global user.email builder@dotnet-buildtools-prereqs-docker && \
+    git clone --depth 1 --single-branch https://github.com/dotnet/arcade /scripts
+
+# Build the rootfs
+RUN /scripts/eng/common/cross/build-rootfs.sh x64 illumos --skipunmount
+
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps-local
+ARG ROOTFS_DIR
+
+COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR

--- a/src/ubuntu/manifest.json
+++ b/src/ubuntu/manifest.json
@@ -333,6 +333,19 @@
         {
           "platforms": [
             {
+              "dockerfile": "src/ubuntu/22.04/cross/illumos",
+              "os": "linux",
+              "osVersion": "jammy",
+              "tags": {
+                "ubuntu-22.04-cross-illumos-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "ubuntu-22.04-cross-illumos$(FloatingTagSuffix)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
               "architecture": "amd64",
               "dockerfile": "src/ubuntu/22.04/helix/amd64",
               "os": "linux",


### PR DESCRIPTION
It was accidentally dropped in https://github.com/dotnet/dotnet-buildtools-prereqs-docker/commit/fd83c7a43e15e40343d7c47903e0b5b7ed3ac702.