### PR TITLE
Fix up debpkg image

### DIFF
--- a/src/ubuntu/22.04/Dockerfile
+++ b/src/ubuntu/22.04/Dockerfile
@@ -94,9 +94,11 @@ RUN cd ~ && \
     rm -f nodesource_setup.sh
 
 # Install powershell
-RUN apt-get install -y \
+RUN apt-get update && \
+    apt-get install -y \
     apt-transport-https \
-    software-properties-common && \
+    software-properties-common \
+    curl && \
     source /etc/os-release && \
     curl -sL https://packages.microsoft.com/config/ubuntu/$VERSION_ID/packages-microsoft-prod.deb -o packages-microsoft-prod.deb && \
     dpkg -i packages-microsoft-prod.deb && \

--- a/src/ubuntu/22.04/Dockerfile
+++ b/src/ubuntu/22.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu.azurecr.io/ubuntu:22.04
+FROM mcr.microsoft.com/powershell:7.2-ubuntu-22.04
 
 # Install the base toolchain we need to build anything (clang, cmake, make and the like)
 # this does not include libraries that we need to compile different projects, we'd like

--- a/src/ubuntu/22.04/Dockerfile
+++ b/src/ubuntu/22.04/Dockerfile
@@ -99,11 +99,11 @@ RUN apt-get update && \
     apt-transport-https \
     software-properties-common \
     curl && \
-    source /etc/os-release && \
-    curl -sL https://packages.microsoft.com/config/ubuntu/$VERSION_ID/packages-microsoft-prod.deb -o packages-microsoft-prod.deb && \
+    curl -sL https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -o packages-microsoft-prod.deb && \
     dpkg -i packages-microsoft-prod.deb && \
     rm packages-microsoft-prod.deb && \
     apt-get update && \
-    apt-get install -y powershell
+    apt-get install -y powershell && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV NO_UPDATE_NOTIFIER=true

--- a/src/ubuntu/22.04/Dockerfile
+++ b/src/ubuntu/22.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/powershell:7.2-ubuntu-22.04
+FROM ubuntu.azurecr.io/ubuntu:22.04
 
 # Install the base toolchain we need to build anything (clang, cmake, make and the like)
 # this does not include libraries that we need to compile different projects, we'd like
@@ -92,5 +92,16 @@ RUN cd ~ && \
     apt-get install nodejs -y && \
     rm -rf /var/lib/apt/lists/* && \
     rm -f nodesource_setup.sh
+
+# Install powershell
+RUN apt-get install -y \
+    apt-transport-https \
+    software-properties-common && \
+    source /etc/os-release && \
+    curl -sL https://packages.microsoft.com/config/ubuntu/$VERSION_ID/packages-microsoft-prod.deb -o packages-microsoft-prod.deb && \
+    dpkg -i packages-microsoft-prod.deb && \
+    rm packages-microsoft-prod.deb && \
+    apt-get update && \
+    apt-get install -y powershell
 
 ENV NO_UPDATE_NOTIFIER=true

--- a/src/ubuntu/22.04/Dockerfile
+++ b/src/ubuntu/22.04/Dockerfile
@@ -93,7 +93,6 @@ RUN cd ~ && \
     rm -rf /var/lib/apt/lists/* && \
     rm -f nodesource_setup.sh
 
-<<<<<<< HEAD
 # Install powershell
 RUN apt-get install -y \
     apt-transport-https \
@@ -106,6 +105,3 @@ RUN apt-get install -y \
     apt-get install -y powershell
 
 ENV NO_UPDATE_NOTIFIER=true
-=======
-ENV NO_UPDATE_NOTIFIER=true
->>>>>>> origin/fixup-debpkg-image

--- a/src/ubuntu/22.04/Dockerfile
+++ b/src/ubuntu/22.04/Dockerfile
@@ -93,17 +93,4 @@ RUN cd ~ && \
     rm -rf /var/lib/apt/lists/* && \
     rm -f nodesource_setup.sh
 
-# Install powershell
-RUN apt-get update && \
-    apt-get install -y \
-    apt-transport-https \
-    software-properties-common \
-    curl && \
-    curl -sL https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -o packages-microsoft-prod.deb && \
-    dpkg -i packages-microsoft-prod.deb && \
-    rm packages-microsoft-prod.deb && \
-    apt-get update && \
-    apt-get install -y powershell && \
-    rm -rf /var/lib/apt/lists/*
-
 ENV NO_UPDATE_NOTIFIER=true

--- a/src/ubuntu/22.04/debpkg/amd64/Dockerfile
+++ b/src/ubuntu/22.04/debpkg/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-coredeps-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-local
 
 # Install the deb packaging toolchain we need to build debs
 RUN apt-get update \

--- a/src/ubuntu/22.04/debpkg/amd64/Dockerfile
+++ b/src/ubuntu/22.04/debpkg/amd64/Dockerfile
@@ -8,3 +8,17 @@ RUN apt-get update \
         devscripts \
         liblldb-14 \
     && rm -rf /var/lib/apt/lists/*
+
+# Install powershell. This is in the debpkg/amd64 docker file as it may not be required in the arm64
+# images, and is not actually supported over there.
+RUN apt-get update && \
+    apt-get install -y \
+    apt-transport-https \
+    software-properties-common \
+    curl && \
+    curl -sL https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -o packages-microsoft-prod.deb && \
+    dpkg -i packages-microsoft-prod.deb && \
+    rm packages-microsoft-prod.deb && \
+    apt-get update && \
+    apt-get install -y powershell && \
+    rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
- Go back to building from the base ubuntu image rather than coredeps
- Derive base image from powershell ubuntu 2204 image.