### PR TITLE
Remove `zlib-devel` dependency from azurelinux for .NET 9.0

### DIFF
--- a/src/azurelinux/3.0/net9.0/crossdeps-builder/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/crossdeps-builder/amd64/Dockerfile
@@ -16,7 +16,6 @@ RUN tdnf install -y \
         glibc-devel \
         kernel-headers \
         texinfo \
-        zlib-devel \
         # Rootfs build dependencies
         bzip2-devel \
         debootstrap \

--- a/src/azurelinux/3.0/net9.0/crossdeps-builder/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/crossdeps-builder/amd64/Dockerfile
@@ -16,6 +16,7 @@ RUN tdnf install -y \
         glibc-devel \
         kernel-headers \
         texinfo \
+        zlib-devel \
         # Rootfs build dependencies
         bzip2-devel \
         debootstrap \

--- a/src/azurelinux/3.0/net9.0/crossdeps/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/crossdeps/amd64/Dockerfile
@@ -15,7 +15,6 @@ RUN tdnf update -y && \
         diffutils \
         icu \
         tar \
-        zlib-devel \
         # Crosscomponents build dependencies
         glibc-devel \
         kernel-headers \


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/101465

For .NET 9.0, we brought a copy of zlib-ng into dotnet/runtime that will be used by all platforms, except for the mobile ones (android, ios, tvos, maccatalyst) and armv6: https://github.com/dotnet/runtime/pull/102403

For that reason, and as suggested in [this comment](https://github.com/dotnet/runtime/pull/104399#issuecomment-2207009080), the azurelinux docker images that target .NET 9.0 won't need to install `zlib-devel` as a dependency anymore.
