### PR TITLE
Add alpine 3.20 withnode image

### DIFF
--- a/src/alpine/3.20/withnode/amd64/Dockerfile
+++ b/src/alpine/3.20/withnode/amd64/Dockerfile
@@ -1,0 +1,14 @@
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.20-local
+
+RUN apk update \
+    && apk add --no-cache \
+        nodejs \
+        npm
+
+# Add label for bring your own node in azure devops
+LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/bin/node"
+
+ENV NO_UPDATE_NOTIFIER=true
+
+# Set node as a default command
+CMD [ "node" ]

--- a/src/alpine/manifest.json
+++ b/src/alpine/manifest.json
@@ -214,7 +214,23 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "alpine-3.20-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "alpine-3.20$(FloatingTagSuffix)": {}
+                "alpine-3.20$(FloatingTagSuffix)": {},
+                "alpine-3.20-local": {
+                  "isLocal": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/alpine/3.20/withnode/amd64",
+              "os": "linux",
+              "osVersion": "alpine3.20",
+              "tags": {
+                "alpine-3.20-withnode-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "alpine-3.20-withnode$(FloatingTagSuffix)": {}
               }
             }
           ]


### PR DESCRIPTION
This is a copy of 3.19 with a couple formatting changes and then I lowercased WithNode everywhere (tags and directory) to match the convention used elsewhere.