### PR TITLE
Refactor Apline Dockerfiles to use a consist and efficient apk pattern

### DIFF
--- a/src/alpine/3.17/amd64/Dockerfile
+++ b/src/alpine/3.17/amd64/Dockerfile
@@ -1,7 +1,6 @@
 FROM amd64/alpine:3.17
 
-RUN apk update && \
-    apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         autoconf \
         automake \
         bash \

--- a/src/alpine/3.17/helix/amd64/Dockerfile
+++ b/src/alpine/3.17/helix/amd64/Dockerfile
@@ -1,7 +1,7 @@
 FROM amd64/alpine:3.17 as msquic
 
 # build MsQuic as we don't have packages
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         cmake \
         g++ \
         gcc \
@@ -34,7 +34,7 @@ RUN cmake -B build/linux/x64_Release_openssl3 \
 FROM amd64/alpine:3.17
 
 # Install .NET and test dependencies
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         bash \
         coreutils \
         curl \
@@ -54,7 +54,7 @@ RUN apk add --no-cache \
         tzdata
 
 # Install Helix Dependencies
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         cargo \
         libffi-dev \
         linux-headers \

--- a/src/alpine/3.17/helix/amd64/Dockerfile
+++ b/src/alpine/3.17/helix/amd64/Dockerfile
@@ -1,8 +1,7 @@
 FROM amd64/alpine:3.17 as msquic
 
 # build MsQuic as we don't have packages
-RUN apk update && apk add --no-cache && \
-    apk add \
+RUN apk add --no-cache \
         cmake \
         g++ \
         gcc \
@@ -31,30 +30,31 @@ RUN cmake -B build/linux/x64_Release_openssl3 \
     cmake --build build/linux/x64_Release_openssl3  --config Release && \
     cmake --install build/linux/x64_Release_openssl3 --prefix /msquic
 
+
 FROM amd64/alpine:3.17
+
 # Install .NET and test dependencies
-RUN apk update && apk add --no-cache \
-    bash \
-    coreutils \
-    curl \
-    icu-data-full \
-    icu-libs \
-    iputils \
-    krb5-libs \
-    lldb \
-    llvm \
-    lttng-ust \
-    musl-locales \
-    numactl \
-    openssl \
-    python3 \
-    py3-pip \
-    sudo \
-    tzdata
+RUN apk add --no-cache \
+        bash \
+        coreutils \
+        curl \
+        icu-data-full \
+        icu-libs \
+        iputils \
+        krb5-libs \
+        lldb \
+        llvm \
+        lttng-ust \
+        musl-locales \
+        numactl \
+        openssl \
+        python3 \
+        py3-pip \
+        sudo \
+        tzdata
 
 # Install Helix Dependencies
-RUN apk update && apk add --no-cache && \
-    apk add \
+RUN apk add --no-cache \
         cargo \
         libffi-dev \
         linux-headers \

--- a/src/alpine/3.17/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.17/helix/arm32v7/Dockerfile
@@ -1,8 +1,7 @@
 FROM arm32v7/alpine:3.17 as msquic
 
 # build MsQuic as we don't have packages
-RUN apk update && apk add --no-cache && \
-    apk add \
+RUN apk add --no-cache \
         cmake \
         g++ \
         gcc \
@@ -32,30 +31,31 @@ RUN cmake -B build/linux/arm_Release_openssl3 \
     cmake --build build/linux/arm_Release_openssl3  --config Release && \
     cmake --install build/linux/arm_Release_openssl3 --prefix /msquic
 
+
 FROM arm32v7/alpine:3.17
+
 # Install .NET and test dependencies
-RUN apk update && apk add --no-cache \
-    bash \
-    coreutils \
-    curl \
-    icu-data-full \
-    icu-libs \
-    iputils \
-    krb5-libs \
-    lldb \
-    llvm \
-    lttng-ust \
-    musl-locales \
-    numactl \
-    openssl \
-    python3 \
-    py3-pip \
-    sudo \
-    tzdata
+RUN apk add --no-cache \
+        bash \
+        coreutils \
+        curl \
+        icu-data-full \
+        icu-libs \
+        iputils \
+        krb5-libs \
+        lldb \
+        llvm \
+        lttng-ust \
+        musl-locales \
+        numactl \
+        openssl \
+        python3 \
+        py3-pip \
+        sudo \
+        tzdata
 
 # Install Helix Dependencies
-RUN apk update && apk add --no-cache && \
-    apk add \
+RUN apk add --no-cache \
         cargo \
         libffi-dev \
         linux-headers \

--- a/src/alpine/3.17/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.17/helix/arm32v7/Dockerfile
@@ -1,7 +1,7 @@
 FROM arm32v7/alpine:3.17 as msquic
 
 # build MsQuic as we don't have packages
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         cmake \
         g++ \
         gcc \
@@ -35,7 +35,7 @@ RUN cmake -B build/linux/arm_Release_openssl3 \
 FROM arm32v7/alpine:3.17
 
 # Install .NET and test dependencies
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         bash \
         coreutils \
         curl \
@@ -55,7 +55,7 @@ RUN apk add --no-cache \
         tzdata
 
 # Install Helix Dependencies
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         cargo \
         libffi-dev \
         linux-headers \

--- a/src/alpine/3.17/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.17/helix/arm64v8/Dockerfile
@@ -1,7 +1,7 @@
 FROM arm64v8/alpine:3.17 as msquic
 
 # build MsQuic as we don't have packages
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         cmake \
         g++ \
         gcc \
@@ -35,7 +35,7 @@ RUN cmake -B build/linux/arm64_Release_openssl3 \
 FROM arm64v8/alpine:3.17
 
 # Install .NET and test dependencies
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         bash \
         coreutils \
         curl \
@@ -55,7 +55,7 @@ RUN apk add --no-cache \
         tzdata
 
 # Install Helix Dependencies
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         cargo \
         libffi-dev \
         linux-headers \

--- a/src/alpine/3.17/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.17/helix/arm64v8/Dockerfile
@@ -1,8 +1,7 @@
 FROM arm64v8/alpine:3.17 as msquic
 
 # build MsQuic as we don't have packages
-RUN apk update && apk add --no-cache && \
-    apk add \
+RUN apk add --no-cache \
         cmake \
         g++ \
         gcc \
@@ -32,30 +31,31 @@ RUN cmake -B build/linux/arm64_Release_openssl3 \
     cmake --build build/linux/arm64_Release_openssl3  --config Release && \
     cmake --install build/linux/arm64_Release_openssl3 --prefix /msquic
 
+
 FROM arm64v8/alpine:3.17
+
 # Install .NET and test dependencies
-RUN apk update && apk add --no-cache \
-    bash \
-    coreutils \
-    curl \
-    icu-data-full \
-    icu-libs \
-    iputils \
-    krb5-libs \
-    lldb \
-    llvm \
-    lttng-ust \
-    musl-locales \
-    numactl \
-    openssl \
-    python3 \
-    py3-pip \
-    sudo \
-    tzdata
+RUN apk add --no-cache \
+        bash \
+        coreutils \
+        curl \
+        icu-data-full \
+        icu-libs \
+        iputils \
+        krb5-libs \
+        lldb \
+        llvm \
+        lttng-ust \
+        musl-locales \
+        numactl \
+        openssl \
+        python3 \
+        py3-pip \
+        sudo \
+        tzdata
 
 # Install Helix Dependencies
-RUN apk update && apk add --no-cache && \
-    apk add \
+RUN apk add --no-cache \
         cargo \
         libffi-dev \
         linux-headers \

--- a/src/alpine/3.18/WithNode/amd64/Dockerfile
+++ b/src/alpine/3.18/WithNode/amd64/Dockerfile
@@ -1,6 +1,8 @@
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.18-local
 
-RUN apk update && apk add --no-cache nodejs npm
+RUN apk add --no-cache \
+        nodejs \
+        npm
 
 # Add label for bring your own node in azure devops
 LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/bin/node"

--- a/src/alpine/3.18/WithNode/amd64/Dockerfile
+++ b/src/alpine/3.18/WithNode/amd64/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.18-local
 
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         nodejs \
         npm
 

--- a/src/alpine/3.18/amd64/Dockerfile
+++ b/src/alpine/3.18/amd64/Dockerfile
@@ -1,7 +1,7 @@
 FROM amd64/alpine:3.18
 
 # Install .NET and test dependencies
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         autoconf \
         automake \
         bash \

--- a/src/alpine/3.18/amd64/Dockerfile
+++ b/src/alpine/3.18/amd64/Dockerfile
@@ -1,7 +1,7 @@
 FROM amd64/alpine:3.18
 
 # Install .NET and test dependencies
-RUN apk update && apk add --no-cache \
+RUN apk add --no-cache \
         autoconf \
         automake \
         bash \

--- a/src/alpine/3.18/helix/amd64/Dockerfile
+++ b/src/alpine/3.18/helix/amd64/Dockerfile
@@ -1,7 +1,7 @@
 FROM amd64/alpine:3.18 as msquic
 
 # build MsQuic as we don't have packages
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         cmake \
         g++ \
         gcc \
@@ -34,7 +34,7 @@ RUN cmake -B build/linux/x64_Release_openssl3 \
 FROM amd64/alpine:3.18
 
 # Install .NET and test dependencies
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         bash \
         coreutils \
         curl \
@@ -54,7 +54,7 @@ RUN apk add --no-cache \
         tzdata
 
 # Install Helix Dependencies
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         cargo \
         libffi-dev \
         linux-headers \

--- a/src/alpine/3.18/helix/amd64/Dockerfile
+++ b/src/alpine/3.18/helix/amd64/Dockerfile
@@ -1,8 +1,7 @@
 FROM amd64/alpine:3.18 as msquic
 
 # build MsQuic as we don't have packages
-RUN apk update && apk add --no-cache && \
-    apk add \
+RUN apk add --no-cache \
         cmake \
         g++ \
         gcc \
@@ -31,30 +30,31 @@ RUN cmake -B build/linux/x64_Release_openssl3 \
     cmake --build build/linux/x64_Release_openssl3  --config Release && \
     cmake --install build/linux/x64_Release_openssl3 --prefix /msquic
 
+
 FROM amd64/alpine:3.18
+
 # Install .NET and test dependencies
-RUN apk update && apk add --no-cache \
-    bash \
-    coreutils \
-    curl \
-    icu-data-full \
-    icu-libs \
-    iputils \
-    krb5-libs \
-    lldb \
-    llvm \
-    lttng-ust \
-    musl-locales \
-    numactl \
-    openssl \
-    python3 \
-    py3-pip \
-    sudo \
-    tzdata
+RUN apk add --no-cache \
+        bash \
+        coreutils \
+        curl \
+        icu-data-full \
+        icu-libs \
+        iputils \
+        krb5-libs \
+        lldb \
+        llvm \
+        lttng-ust \
+        musl-locales \
+        numactl \
+        openssl \
+        python3 \
+        py3-pip \
+        sudo \
+        tzdata
 
 # Install Helix Dependencies
-RUN apk update && apk add --no-cache && \
-    apk add \
+RUN apk add --no-cache \
         cargo \
         libffi-dev \
         linux-headers \

--- a/src/alpine/3.18/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.18/helix/arm32v7/Dockerfile
@@ -1,8 +1,7 @@
 FROM arm32v7/alpine:3.18 as msquic
 
 # build MsQuic as we don't have packages
-RUN apk update && apk add --no-cache && \
-    apk add \
+RUN apk add --no-cache \
         cmake \
         g++ \
         gcc \
@@ -32,30 +31,31 @@ RUN cmake -B build/linux/arm_Release_openssl3 \
     cmake --build build/linux/arm_Release_openssl3  --config Release && \
     cmake --install build/linux/arm_Release_openssl3 --prefix /msquic
 
+
 FROM arm32v7/alpine:3.18
+
 # Install .NET and test dependencies
-RUN apk update && apk add --no-cache \
-    bash \
-    coreutils \
-    curl \
-    icu-data-full \
-    icu-libs \
-    iputils \
-    krb5-libs \
-    lldb \
-    llvm \
-    lttng-ust \
-    musl-locales \
-    numactl \
-    openssl \
-    python3 \
-    py3-pip \
-    sudo \
-    tzdata
+RUN apk add --no-cache \
+        bash \
+        coreutils \
+        curl \
+        icu-data-full \
+        icu-libs \
+        iputils \
+        krb5-libs \
+        lldb \
+        llvm \
+        lttng-ust \
+        musl-locales \
+        numactl \
+        openssl \
+        python3 \
+        py3-pip \
+        sudo \
+        tzdata
 
 # Install Helix Dependencies
-RUN apk update && apk add --no-cache && \
-    apk add \
+RUN apk add --no-cache \
         cargo \
         libffi-dev \
         linux-headers \

--- a/src/alpine/3.18/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.18/helix/arm32v7/Dockerfile
@@ -1,7 +1,7 @@
 FROM arm32v7/alpine:3.18 as msquic
 
 # build MsQuic as we don't have packages
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         cmake \
         g++ \
         gcc \
@@ -35,7 +35,7 @@ RUN cmake -B build/linux/arm_Release_openssl3 \
 FROM arm32v7/alpine:3.18
 
 # Install .NET and test dependencies
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         bash \
         coreutils \
         curl \
@@ -55,7 +55,7 @@ RUN apk add --no-cache \
         tzdata
 
 # Install Helix Dependencies
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         cargo \
         libffi-dev \
         linux-headers \

--- a/src/alpine/3.18/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.18/helix/arm64v8/Dockerfile
@@ -1,7 +1,7 @@
 FROM arm64v8/alpine:3.18 as msquic
 
 # build MsQuic as we don't have packages
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         cmake \
         g++ \
         gcc \
@@ -35,7 +35,7 @@ RUN cmake -B build/linux/arm64_Release_openssl3 \
 FROM arm64v8/alpine:3.18
 
 # Install .NET and test dependencies
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         bash \
         coreutils \
         curl \
@@ -55,7 +55,7 @@ RUN apk add --no-cache \
         tzdata
 
 # Install Helix Dependencies
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         cargo \
         libffi-dev \
         linux-headers \

--- a/src/alpine/3.18/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.18/helix/arm64v8/Dockerfile
@@ -1,8 +1,7 @@
 FROM arm64v8/alpine:3.18 as msquic
 
 # build MsQuic as we don't have packages
-RUN apk update && apk add --no-cache && \
-    apk add \
+RUN apk add --no-cache \
         cmake \
         g++ \
         gcc \
@@ -32,30 +31,31 @@ RUN cmake -B build/linux/arm64_Release_openssl3 \
     cmake --build build/linux/arm64_Release_openssl3  --config Release && \
     cmake --install build/linux/arm64_Release_openssl3 --prefix /msquic
 
+
 FROM arm64v8/alpine:3.18
+
 # Install .NET and test dependencies
-RUN apk update && apk add --no-cache \
-    bash \
-    coreutils \
-    curl \
-    icu-data-full \
-    icu-libs \
-    iputils \
-    krb5-libs \
-    lldb \
-    llvm \
-    lttng-ust \
-    musl-locales \
-    numactl \
-    openssl \
-    python3 \
-    py3-pip \
-    sudo \
-    tzdata
+RUN apk add --no-cache \
+        bash \
+        coreutils \
+        curl \
+        icu-data-full \
+        icu-libs \
+        iputils \
+        krb5-libs \
+        lldb \
+        llvm \
+        lttng-ust \
+        musl-locales \
+        numactl \
+        openssl \
+        python3 \
+        py3-pip \
+        sudo \
+        tzdata
 
 # Install Helix Dependencies
-RUN apk update && apk add --no-cache && \
-    apk add \
+RUN apk add --no-cache \
         cargo \
         libffi-dev \
         linux-headers \

--- a/src/alpine/3.19/WithNode/amd64/Dockerfile
+++ b/src/alpine/3.19/WithNode/amd64/Dockerfile
@@ -1,6 +1,8 @@
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-local
 
-RUN apk update && apk add --no-cache nodejs npm
+RUN apk add --no-cache \
+        nodejs \
+        npm
 
 # Add label for bring your own node in azure devops
 LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/bin/node"

--- a/src/alpine/3.19/WithNode/amd64/Dockerfile
+++ b/src/alpine/3.19/WithNode/amd64/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-local
 
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         nodejs \
         npm
 

--- a/src/alpine/3.19/amd64/Dockerfile
+++ b/src/alpine/3.19/amd64/Dockerfile
@@ -1,7 +1,7 @@
 FROM amd64/alpine:3.19
 
 # Install .NET and test dependencies
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         autoconf \
         automake \
         bash \

--- a/src/alpine/3.19/amd64/Dockerfile
+++ b/src/alpine/3.19/amd64/Dockerfile
@@ -1,7 +1,7 @@
 FROM amd64/alpine:3.19
 
 # Install .NET and test dependencies
-RUN apk update && apk add --no-cache \
+RUN apk add --no-cache \
         autoconf \
         automake \
         bash \

--- a/src/alpine/3.20/amd64/Dockerfile
+++ b/src/alpine/3.20/amd64/Dockerfile
@@ -1,7 +1,7 @@
 FROM amd64/alpine:3.20
 
 # Install .NET and test dependencies
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         autoconf \
         automake \
         bash \

--- a/src/alpine/3.20/amd64/Dockerfile
+++ b/src/alpine/3.20/amd64/Dockerfile
@@ -1,7 +1,7 @@
 FROM amd64/alpine:3.20
 
 # Install .NET and test dependencies
-RUN apk update && apk add --no-cache \
+RUN apk add --no-cache \
         autoconf \
         automake \
         bash \

--- a/src/alpine/3.20/helix/amd64/Dockerfile
+++ b/src/alpine/3.20/helix/amd64/Dockerfile
@@ -30,29 +30,29 @@ RUN cmake -B build/linux/x64_Release_openssl3 \
     cmake --build build/linux/x64_Release_openssl3  --config Release && \
     cmake --install build/linux/x64_Release_openssl3 --prefix /msquic
 
-    
+
 FROM amd64/alpine:3.20
 
 # Install .NET and test dependencies
 RUN apk add --no-cache \
-    bash \
-    coreutils \
-    curl \
-    icu-data-full \
-    icu-libs \
-    iputils \
-    krb5-libs \
-    lldb \
-    llvm \
-    lttng-ust \
-    musl-locales \
-    numactl \
-    openssl \
-    python3 \
-    python3-dev \
-    py3-pip \
-    sudo \
-    tzdata
+        bash \
+        coreutils \
+        curl \
+        icu-data-full \
+        icu-libs \
+        iputils \
+        krb5-libs \
+        lldb \
+        llvm \
+        lttng-ust \
+        musl-locales \
+        numactl \
+        openssl \
+        python3 \
+        python3-dev \
+        py3-pip \
+        sudo \
+        tzdata
 
 # Copy msquic from the msquic image into our image that will run on Helix
 COPY --from=msquic /msquic /usr

--- a/src/alpine/3.20/helix/amd64/Dockerfile
+++ b/src/alpine/3.20/helix/amd64/Dockerfile
@@ -1,8 +1,7 @@
 FROM amd64/alpine:3.20 as msquic
 
 # build MsQuic as we don't have packages
-RUN apk update && apk add --no-cache && \
-    apk add \
+RUN apk add --no-cache \
         cmake \
         g++ \
         gcc \
@@ -31,9 +30,11 @@ RUN cmake -B build/linux/x64_Release_openssl3 \
     cmake --build build/linux/x64_Release_openssl3  --config Release && \
     cmake --install build/linux/x64_Release_openssl3 --prefix /msquic
 
+    
 FROM amd64/alpine:3.20
+
 # Install .NET and test dependencies
-RUN apk update && apk add --no-cache \
+RUN apk add --no-cache \
     bash \
     coreutils \
     curl \
@@ -67,10 +68,10 @@ RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
     echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot
 
 # Install Helix Dependencies
-RUN apk update && apk add --no-cache \
-    build-base \
-    gcc \
-    linux-headers && \
+RUN apk add --no-cache \
+        build-base \
+        gcc \
+        linux-headers && \
     # Create virtual environment
     python3 -m venv /home/helixbot/.vsts-env && \
     source /home/helixbot/.vsts-env/bin/activate && \
@@ -79,8 +80,8 @@ RUN apk update && apk add --no-cache \
     pip install ./helix_scripts-*-py3-none-any.whl && \
     # Delete unnecessary dependencies
     apk del \
-    build-base \
-    gcc \
-    linux-headers
+        build-base \
+        gcc \
+        linux-headers
 
 USER helixbot

--- a/src/alpine/3.20/helix/amd64/Dockerfile
+++ b/src/alpine/3.20/helix/amd64/Dockerfile
@@ -1,7 +1,7 @@
 FROM amd64/alpine:3.20 as msquic
 
 # build MsQuic as we don't have packages
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         cmake \
         g++ \
         gcc \
@@ -34,7 +34,7 @@ RUN cmake -B build/linux/x64_Release_openssl3 \
 FROM amd64/alpine:3.20
 
 # Install .NET and test dependencies
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         bash \
         coreutils \
         curl \
@@ -68,7 +68,7 @@ RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
     echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot
 
 # Install Helix Dependencies
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         build-base \
         gcc \
         linux-headers && \

--- a/src/alpine/3.20/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.20/helix/arm32v7/Dockerfile
@@ -1,7 +1,7 @@
 FROM arm32v7/alpine:3.20 as msquic
 
 # build MsQuic as we don't have packages
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         cmake \
         g++ \
         gcc \
@@ -35,7 +35,7 @@ RUN cmake -B build/linux/arm_Release_openssl3 \
 FROM arm32v7/alpine:3.20
 
 # Install .NET and test dependencies
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         bash \
         coreutils \
         curl \
@@ -63,7 +63,7 @@ RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
     echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot
 
 # Install Helix Dependencies
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         build-base \
         libffi-dev \
         gcc \

--- a/src/alpine/3.20/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.20/helix/arm32v7/Dockerfile
@@ -1,8 +1,7 @@
 FROM arm32v7/alpine:3.20 as msquic
 
 # build MsQuic as we don't have packages
-RUN apk update && apk add --no-cache && \
-    apk add \
+RUN apk add --no-cache \
         cmake \
         g++ \
         gcc \
@@ -32,9 +31,11 @@ RUN cmake -B build/linux/arm_Release_openssl3 \
     cmake --build build/linux/arm_Release_openssl3  --config Release && \
     cmake --install build/linux/arm_Release_openssl3 --prefix /msquic
 
+
 FROM arm32v7/alpine:3.20
+
 # Install .NET and test dependencies
-RUN apk update && apk add --no-cache \
+RUN apk add --no-cache \
         bash \
         coreutils \
         curl \
@@ -62,7 +63,7 @@ RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
     echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot
 
 # Install Helix Dependencies
-RUN apk update && apk add --no-cache \
+RUN apk add --no-cache \
         build-base \
         libffi-dev \
         gcc \

--- a/src/alpine/3.20/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.20/helix/arm64v8/Dockerfile
@@ -1,8 +1,7 @@
 FROM arm64v8/alpine:3.20 as msquic
 
 # build MsQuic as we don't have packages
-RUN apk update && apk add --no-cache && \
-    apk add \
+RUN apk add --no-cache \
         cmake \
         g++ \
         gcc \
@@ -32,27 +31,29 @@ RUN cmake -B build/linux/arm64_Release_openssl3 \
     cmake --build build/linux/arm64_Release_openssl3  --config Release && \
     cmake --install build/linux/arm64_Release_openssl3 --prefix /msquic
 
+
 FROM arm64v8/alpine:3.20
+
 # Install .NET and test dependencies
-RUN apk update && apk add --no-cache \
-    bash \
-    coreutils \
-    curl \
-    icu-data-full \
-    icu-libs \
-    iputils \
-    krb5-libs \
-    lldb \
-    llvm \
-    lttng-ust \
-    musl-locales \
-    numactl \
-    openssl \
-    python3 \
-    python3-dev \
-    py3-pip \
-    sudo \
-    tzdata
+RUN apk add --no-cache \
+        bash \
+        coreutils \
+        curl \
+        icu-data-full \
+        icu-libs \
+        iputils \
+        krb5-libs \
+        lldb \
+        llvm \
+        lttng-ust \
+        musl-locales \
+        numactl \
+        openssl \
+        python3 \
+        python3-dev \
+        py3-pip \
+        sudo \
+        tzdata
 
 # Copy msquic from the msquic image into our image that will run on Helix
 COPY --from=msquic /msquic /usr
@@ -68,11 +69,11 @@ RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
     echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot
 
 # Install Helix Dependencies
-RUN apk update && apk add --no-cache \
-    build-base \
-    libffi-dev \
-    gcc \
-    linux-headers && \
+RUN apk add --no-cache \
+        build-base \
+        libffi-dev \
+        gcc \
+        linux-headers && \
     # Create virtual environment
     python3 -m venv /home/helixbot/.vsts-env && \
     source /home/helixbot/.vsts-env/bin/activate && \
@@ -81,9 +82,9 @@ RUN apk update && apk add --no-cache \
     pip install ./helix_scripts-*-py3-none-any.whl && \
     # Delete unnecessary dependencies
     apk del \
-    build-base \
-    libffi-dev \
-    gcc \
-    linux-headers
+        build-base \
+        libffi-dev \
+        gcc \
+        linux-headers
 
 USER helixbot

--- a/src/alpine/3.20/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.20/helix/arm64v8/Dockerfile
@@ -1,7 +1,7 @@
 FROM arm64v8/alpine:3.20 as msquic
 
 # build MsQuic as we don't have packages
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         cmake \
         g++ \
         gcc \
@@ -35,7 +35,7 @@ RUN cmake -B build/linux/arm64_Release_openssl3 \
 FROM arm64v8/alpine:3.20
 
 # Install .NET and test dependencies
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         bash \
         coreutils \
         curl \
@@ -69,7 +69,7 @@ RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
     echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot
 
 # Install Helix Dependencies
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         build-base \
         libffi-dev \
         gcc \

--- a/src/alpine/3.20/withnode/amd64/Dockerfile
+++ b/src/alpine/3.20/withnode/amd64/Dockerfile
@@ -1,7 +1,6 @@
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.20-local
 
-RUN apk update \
-    && apk add --no-cache \
+RUN apk add --no-cache \
         nodejs \
         npm
 

--- a/src/alpine/3.20/withnode/amd64/Dockerfile
+++ b/src/alpine/3.20/withnode/amd64/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.20-local
 
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         nodejs \
         npm
 


### PR DESCRIPTION
The motivation for this PR was the following bad `apk` usage pattern:

```
RUN apk update && apk add --no-cache && \
    apk add \
```

This was causing the package cache to be populated and not cleaned up which introduces image bloat.  Additionally with `apk`, there is no need to make an explicit `apk update` call as `apk add` command will automatically update the package index.  As a result, all Alpine Dockerfiles were updated to use the following simple pattern:

```
RUN apk add --no-cache \
```