### PR TITLE
Update llvm.sh arguments

### DIFF
--- a/src/ubuntu/22.04/crossdeps/Dockerfile
+++ b/src/ubuntu/22.04/crossdeps/Dockerfile
@@ -40,12 +40,5 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # install llvm-toolchain using official script
-RUN wget -O- https://apt.llvm.org/llvm.sh | bash -s -- 18 \
-        clang \
-        clang-tools \
-        liblldb-dev \
-        lld \
-        lldb \
-        llvm \
-        python3-lldb \
+RUN wget -O- https://apt.llvm.org/llvm.sh | bash -s -- 18 all
     && rm -rf /var/lib/apt/lists/*

--- a/src/ubuntu/22.04/crossdeps/Dockerfile
+++ b/src/ubuntu/22.04/crossdeps/Dockerfile
@@ -40,5 +40,5 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # install llvm-toolchain using official script
-RUN wget -O- https://apt.llvm.org/llvm.sh | bash -s -- 18 all
+RUN wget -O- https://apt.llvm.org/llvm.sh | bash -s -- 18 all \
     && rm -rf /var/lib/apt/lists/*

--- a/src/ubuntu/22.04/crossdeps/Dockerfile
+++ b/src/ubuntu/22.04/crossdeps/Dockerfile
@@ -40,5 +40,9 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # install llvm-toolchain using official script
-RUN wget -O- https://apt.llvm.org/llvm.sh | bash -s -- 18 all \
+RUN wget -O- https://apt.llvm.org/llvm.sh | bash -s -- 18 \
+    && apt-get install -y \
+        clang-tools-18 \
+        liblldb-18-dev \
+        llvm-18 \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Recent changes in this script have stopped accepting individual package names. It's either default set or `all`, and we need all for stuff like llvm-ar.

Runtime builds started failing after https://github.com/dotnet/versions/commit/e470ef258ceb1ca28703c21e18792bf51ddd975f.

cc @jakobbotsch
Fixes https://github.com/dotnet/runtime/issues/105176.