### PR TITLE
Install Helix Python packages into a venv in a separate docker stage

### DIFF
--- a/src/alpine/3.17/helix/amd64/Dockerfile
+++ b/src/alpine/3.17/helix/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM amd64/alpine:3.17 as msquic
+FROM amd64/alpine:3.17 AS msquic
 
 # build MsQuic as we don't have packages
 RUN apk add --upgrade --no-cache \
@@ -30,6 +30,19 @@ RUN cmake -B build/linux/x64_Release_openssl3 \
     cmake --build build/linux/x64_Release_openssl3  --config Release && \
     cmake --install build/linux/x64_Release_openssl3 --prefix /msquic
 
+FROM amd64/alpine:3.17 AS venv
+
+RUN apk add --upgrade --no-cache \
+        cargo \
+        libffi-dev \
+        linux-headers \
+        python3-dev \
+        openssl-dev
+
+RUN python3 -m venv /venv && \
+        source /venv/bin/activate && \
+        pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+        pip install ./helix_scripts-*-py3-none-any.whl
 
 FROM amd64/alpine:3.17
 
@@ -53,23 +66,6 @@ RUN apk add --upgrade --no-cache \
         sudo \
         tzdata
 
-# Install Helix Dependencies
-RUN apk add --upgrade --no-cache \
-        cargo \
-        libffi-dev \
-        linux-headers \
-        python3-dev \
-        openssl-dev && \
-    ln -sf /usr/bin/python3 /usr/bin/python && \
-    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    pip install ./helix_scripts-*-py3-none-any.whl && \
-    apk del \
-        cargo \
-        libffi-dev \
-        linux-headers \
-        python3-dev \
-        openssl-dev
-
 # Copy msquic from the msquic image into our image that will run on Helix
 COPY --from=msquic /msquic /usr
 
@@ -85,4 +81,9 @@ RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
 
 USER helixbot
 
-RUN python3 -m venv /home/helixbot/.vsts-env
+# Install Helix Dependencies
+
+ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+COPY --from=venv /venv /home/helixbot/.vsts-env

--- a/src/alpine/3.17/helix/amd64/Dockerfile
+++ b/src/alpine/3.17/helix/amd64/Dockerfile
@@ -86,4 +86,4 @@ USER helixbot
 ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-COPY --from=venv /venv /home/helixbot/.vsts-env
+COPY --from=venv /venv $VIRTUAL_ENV

--- a/src/alpine/3.17/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.17/helix/arm32v7/Dockerfile
@@ -31,6 +31,19 @@ RUN cmake -B build/linux/arm_Release_openssl3 \
     cmake --build build/linux/arm_Release_openssl3  --config Release && \
     cmake --install build/linux/arm_Release_openssl3 --prefix /msquic
 
+FROM arm32v7/alpine:3.17 as venv
+
+RUN apk add --upgrade --no-cache \
+        cargo \
+        libffi-dev \
+        linux-headers \
+        python3-dev \
+        openssl-dev
+
+RUN python3 -m venv /venv && \
+        source /venv/bin/activate && \
+        pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+        pip install ./helix_scripts-*-py3-none-any.whl
 
 FROM arm32v7/alpine:3.17
 
@@ -54,23 +67,6 @@ RUN apk add --upgrade --no-cache \
         sudo \
         tzdata
 
-# Install Helix Dependencies
-RUN apk add --upgrade --no-cache \
-        cargo \
-        libffi-dev \
-        linux-headers \
-        python3-dev \
-        openssl-dev && \
-    ln -sf /usr/bin/python3 /usr/bin/python && \
-    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    pip install ./helix_scripts-*-py3-none-any.whl && \
-    apk del \
-        cargo \
-        libffi-dev \
-        linux-headers \
-        python3-dev \
-        openssl-dev
-
 # Copy msquic from the msquic image into our image that will run on Helix
 COPY --from=msquic /msquic /usr
 
@@ -86,4 +82,9 @@ RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
 
 USER helixbot
 
-RUN python3 -m venv /home/helixbot/.vsts-env
+# Install Helix Dependencies
+
+ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+COPY --from=venv /venv /home/helixbot/.vsts-env

--- a/src/alpine/3.17/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.17/helix/arm32v7/Dockerfile
@@ -34,11 +34,16 @@ RUN cmake -B build/linux/arm_Release_openssl3 \
 FROM arm32v7/alpine:3.17 as venv
 
 RUN apk add --upgrade --no-cache \
-        cargo \
         libffi-dev \
         linux-headers \
         python3-dev \
         openssl-dev
+
+RUN echo "https://dl-cdn.alpinelinux.org/alpine/v3.18/main" >> /etc/apk/repositories && \
+        echo "https://dl-cdn.alpinelinux.org/alpine/v3.18/community" >> /etc/apk/repositories && \
+        apk update && \
+        apk add --no-cache \
+        cargo
 
 RUN python3 -m venv /venv && \
         source /venv/bin/activate && \

--- a/src/alpine/3.17/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.17/helix/arm32v7/Dockerfile
@@ -87,4 +87,4 @@ USER helixbot
 ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-COPY --from=venv /venv /home/helixbot/.vsts-env
+COPY --from=venv /venv $VIRTUAL_ENV

--- a/src/alpine/3.17/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.17/helix/arm64v8/Dockerfile
@@ -31,6 +31,19 @@ RUN cmake -B build/linux/arm64_Release_openssl3 \
     cmake --build build/linux/arm64_Release_openssl3  --config Release && \
     cmake --install build/linux/arm64_Release_openssl3 --prefix /msquic
 
+FROM arm64v8/alpine:3.17 as venv
+
+RUN apk add --upgrade --no-cache \
+        cargo \
+        libffi-dev \
+        linux-headers \
+        python3-dev \
+        openssl-dev
+
+RUN python3 -m venv /venv && \
+        source /venv/bin/activate && \
+        pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+        pip install ./helix_scripts-*-py3-none-any.whl
 
 FROM arm64v8/alpine:3.17
 
@@ -54,23 +67,6 @@ RUN apk add --upgrade --no-cache \
         sudo \
         tzdata
 
-# Install Helix Dependencies
-RUN apk add --upgrade --no-cache \
-        cargo \
-        libffi-dev \
-        linux-headers \
-        python3-dev \
-        openssl-dev && \
-    ln -sf /usr/bin/python3 /usr/bin/python && \
-    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    pip install ./helix_scripts-*-py3-none-any.whl && \
-    apk del \
-        cargo \
-        libffi-dev \
-        linux-headers \
-        python3-dev \
-        openssl-dev
-
 # Copy msquic from the msquic image into our image that will run on Helix
 COPY --from=msquic /msquic /usr
 
@@ -86,4 +82,9 @@ RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
 
 USER helixbot
 
-RUN python3 -m venv /home/helixbot/.vsts-env
+# Install Helix Dependencies
+
+ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+COPY --from=venv /venv /home/helixbot/.vsts-env

--- a/src/alpine/3.17/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.17/helix/arm64v8/Dockerfile
@@ -87,4 +87,4 @@ USER helixbot
 ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-COPY --from=venv /venv /home/helixbot/.vsts-env
+COPY --from=venv /venv $VIRTUAL_ENV

--- a/src/alpine/3.18/helix/amd64/Dockerfile
+++ b/src/alpine/3.18/helix/amd64/Dockerfile
@@ -30,6 +30,20 @@ RUN cmake -B build/linux/x64_Release_openssl3 \
     cmake --build build/linux/x64_Release_openssl3  --config Release && \
     cmake --install build/linux/x64_Release_openssl3 --prefix /msquic
 
+FROM amd64/alpine:3.18 AS venv
+
+RUN apk add --upgrade --no-cache \
+        cargo \
+        libffi-dev \
+        linux-headers \
+        python3-dev \
+        openssl-dev
+
+RUN python3 -m venv /venv && \
+        source /venv/bin/activate && \
+        pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+        pip install ./helix_scripts-*-py3-none-any.whl
+
 
 FROM amd64/alpine:3.18
 
@@ -53,23 +67,6 @@ RUN apk add --upgrade --no-cache \
         sudo \
         tzdata
 
-# Install Helix Dependencies
-RUN apk add --upgrade --no-cache \
-        cargo \
-        libffi-dev \
-        linux-headers \
-        python3-dev \
-        openssl-dev && \
-    ln -sf /usr/bin/python3 /usr/bin/python && \
-    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    pip install ./helix_scripts-*-py3-none-any.whl && \
-    apk del \
-        cargo \
-        libffi-dev \
-        linux-headers \
-        python3-dev \
-        openssl-dev
-
 # Copy msquic from the msquic image into our image that will run on Helix
 COPY --from=msquic /msquic /usr
 
@@ -85,4 +82,9 @@ RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
 
 USER helixbot
 
-RUN python3 -m venv /home/helixbot/.vsts-env
+# Install Helix Dependencies
+
+ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+COPY --from=venv /venv /home/helixbot/.vsts-env

--- a/src/alpine/3.18/helix/amd64/Dockerfile
+++ b/src/alpine/3.18/helix/amd64/Dockerfile
@@ -87,4 +87,4 @@ USER helixbot
 ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-COPY --from=venv /venv /home/helixbot/.vsts-env
+COPY --from=venv /venv $VIRTUAL_ENV

--- a/src/alpine/3.18/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.18/helix/arm32v7/Dockerfile
@@ -87,4 +87,4 @@ USER helixbot
 ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-COPY --from=venv /venv /home/helixbot/.vsts-env
+COPY --from=venv /venv $VIRTUAL_ENV

--- a/src/alpine/3.18/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.18/helix/arm32v7/Dockerfile
@@ -31,6 +31,19 @@ RUN cmake -B build/linux/arm_Release_openssl3 \
     cmake --build build/linux/arm_Release_openssl3  --config Release && \
     cmake --install build/linux/arm_Release_openssl3 --prefix /msquic
 
+FROM arm32v7/alpine:3.18 as venv
+
+RUN apk add --upgrade --no-cache \
+        cargo \
+        libffi-dev \
+        linux-headers \
+        python3-dev \
+        openssl-dev
+
+RUN python3 -m venv /venv && \
+        source /venv/bin/activate && \
+        pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+        pip install ./helix_scripts-*-py3-none-any.whl
 
 FROM arm32v7/alpine:3.18
 
@@ -54,23 +67,6 @@ RUN apk add --upgrade --no-cache \
         sudo \
         tzdata
 
-# Install Helix Dependencies
-RUN apk add --upgrade --no-cache \
-        cargo \
-        libffi-dev \
-        linux-headers \
-        python3-dev \
-        openssl-dev && \
-    ln -sf /usr/bin/python3 /usr/bin/python && \
-    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    pip install ./helix_scripts-*-py3-none-any.whl && \
-    apk del \
-        cargo \
-        libffi-dev \
-        linux-headers \
-        python3-dev \
-        openssl-dev
-
 # Copy msquic from the msquic image into our image that will run on Helix
 COPY --from=msquic /msquic /usr
 
@@ -86,4 +82,9 @@ RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
 
 USER helixbot
 
-RUN python3 -m venv /home/helixbot/.vsts-env
+# Install Helix Dependencies
+
+ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+COPY --from=venv /venv /home/helixbot/.vsts-env

--- a/src/alpine/3.18/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.18/helix/arm64v8/Dockerfile
@@ -31,6 +31,20 @@ RUN cmake -B build/linux/arm64_Release_openssl3 \
     cmake --build build/linux/arm64_Release_openssl3  --config Release && \
     cmake --install build/linux/arm64_Release_openssl3 --prefix /msquic
 
+FROM arm64v8/alpine:3.18 as venv
+
+RUN apk add --upgrade --no-cache \
+        cargo \
+        libffi-dev \
+        linux-headers \
+        python3-dev \
+        openssl-dev
+
+RUN python3 -m venv /venv && \
+        source /venv/bin/activate && \
+        pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+        pip install ./helix_scripts-*-py3-none-any.whl
+
 
 FROM arm64v8/alpine:3.18
 
@@ -54,23 +68,6 @@ RUN apk add --upgrade --no-cache \
         sudo \
         tzdata
 
-# Install Helix Dependencies
-RUN apk add --upgrade --no-cache \
-        cargo \
-        libffi-dev \
-        linux-headers \
-        python3-dev \
-        openssl-dev && \
-    ln -sf /usr/bin/python3 /usr/bin/python && \
-    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    pip install ./helix_scripts-*-py3-none-any.whl && \
-    apk del \
-        cargo \
-        libffi-dev \
-        linux-headers \
-        python3-dev \
-        openssl-dev
-
 # Copy msquic from the msquic image into our image that will run on Helix
 COPY --from=msquic /msquic /usr
 
@@ -86,4 +83,9 @@ RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
 
 USER helixbot
 
-RUN python3 -m venv /home/helixbot/.vsts-env
+# Install Helix Dependencies
+
+ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+COPY --from=venv /venv /home/helixbot/.vsts-env

--- a/src/alpine/3.18/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.18/helix/arm64v8/Dockerfile
@@ -88,4 +88,4 @@ USER helixbot
 ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-COPY --from=venv /venv /home/helixbot/.vsts-env
+COPY --from=venv /venv $VIRTUAL_ENV

--- a/src/alpine/3.20/helix/amd64/Dockerfile
+++ b/src/alpine/3.20/helix/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM amd64/alpine:3.20 as msquic
+FROM amd64/alpine:3.20 AS msquic
 
 # build MsQuic as we don't have packages
 RUN apk add --upgrade --no-cache \
@@ -33,7 +33,9 @@ RUN cmake -B build/linux/x64_Release_openssl3 \
 FROM amd64/alpine:3.20 AS venv
 
 RUN apk add --upgrade --no-cache \
+        python3-dev \
         build-base \
+        libffi-dev \
         gcc \
         linux-headers
 

--- a/src/alpine/3.20/helix/amd64/Dockerfile
+++ b/src/alpine/3.20/helix/amd64/Dockerfile
@@ -30,6 +30,17 @@ RUN cmake -B build/linux/x64_Release_openssl3 \
     cmake --build build/linux/x64_Release_openssl3  --config Release && \
     cmake --install build/linux/x64_Release_openssl3 --prefix /msquic
 
+FROM amd64/alpine:3.20 AS venv
+
+RUN apk add --upgrade --no-cache \
+        build-base \
+        gcc \
+        linux-headers
+
+RUN python3 -m venv /venv && \
+        source /venv/bin/activate && \
+        pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+        pip install ./helix_scripts-*-py3-none-any.whl
 
 FROM amd64/alpine:3.20
 
@@ -67,21 +78,11 @@ RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
     chmod 755 /root && \
     echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot
 
-# Install Helix Dependencies
-RUN apk add --upgrade --no-cache \
-        build-base \
-        gcc \
-        linux-headers && \
-    # Create virtual environment
-    python3 -m venv /home/helixbot/.vsts-env && \
-    source /home/helixbot/.vsts-env/bin/activate && \
-    # Install Helix scripts
-    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    pip install ./helix_scripts-*-py3-none-any.whl && \
-    # Delete unnecessary dependencies
-    apk del \
-        build-base \
-        gcc \
-        linux-headers
-
 USER helixbot
+
+# Install Helix Dependencies
+
+ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+COPY --from=venv /venv /home/helixbot/.vsts-env

--- a/src/alpine/3.20/helix/amd64/Dockerfile
+++ b/src/alpine/3.20/helix/amd64/Dockerfile
@@ -87,4 +87,4 @@ USER helixbot
 ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-COPY --from=venv /venv /home/helixbot/.vsts-env
+COPY --from=venv /venv $VIRTUAL_ENV

--- a/src/alpine/3.20/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.20/helix/arm32v7/Dockerfile
@@ -34,6 +34,7 @@ RUN cmake -B build/linux/arm_Release_openssl3 \
 FROM arm32v7/alpine:3.20 AS venv
 
 RUN apk add --upgrade --no-cache \
+        cargo \
         python3-dev \
         build-base \
         libffi-dev \

--- a/src/alpine/3.20/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.20/helix/arm32v7/Dockerfile
@@ -89,4 +89,4 @@ USER helixbot
 ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-COPY --from=venv /venv /home/helixbot/.vsts-env
+COPY --from=venv /venv $VIRTUAL_ENV

--- a/src/alpine/3.20/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.20/helix/arm32v7/Dockerfile
@@ -39,6 +39,7 @@ RUN apk add --upgrade --no-cache \
         build-base \
         libffi-dev \
         gcc \
+        openssl-dev \
         linux-headers
 
 RUN python3 -m venv /venv && \

--- a/src/alpine/3.20/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.20/helix/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/alpine:3.20 as msquic
+FROM arm32v7/alpine:3.20 AS msquic
 
 # build MsQuic as we don't have packages
 RUN apk add --upgrade --no-cache \
@@ -31,6 +31,19 @@ RUN cmake -B build/linux/arm_Release_openssl3 \
     cmake --build build/linux/arm_Release_openssl3  --config Release && \
     cmake --install build/linux/arm_Release_openssl3 --prefix /msquic
 
+FROM arm32v7/alpine:3.20 AS venv
+
+RUN apk add --upgrade --no-cache \
+        python3-dev \
+        build-base \
+        libffi-dev \
+        gcc \
+        linux-headers
+
+RUN python3 -m venv /venv && \
+        source /venv/bin/activate && \
+        pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+        pip install ./helix_scripts-*-py3-none-any.whl
 
 FROM arm32v7/alpine:3.20
 
@@ -62,25 +75,6 @@ RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
     chmod 755 /root && \
     echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot
 
-# Install Helix Dependencies
-RUN apk add --upgrade --no-cache \
-        build-base \
-        libffi-dev \
-        gcc \
-        linux-headers & \
-        # Create virtual environment
-    python3 -m venv --system-site-packages /home/helixbot/.vsts-env && \
-    source /home/helixbot/.vsts-env/bin/activate && \
-    # Install Helix scripts
-    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    pip install ./helix_scripts-*-py3-none-any.whl && \
-    # Delete unnecessary dependencies
-    apk del \
-        build-base \
-        libffi-dev \
-        gcc \
-        linux-headers
-
 # Copy msquic from the msquic image into our image that will run on Helix
 COPY --from=msquic /msquic /usr
 
@@ -89,3 +83,10 @@ ENV LANG=en-US.UTF-8
 RUN echo export LANG=${LANG}  >> /etc/profile.d/locale.sh
 
 USER helixbot
+
+# Install Helix Dependencies
+
+ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+COPY --from=venv /venv /home/helixbot/.vsts-env

--- a/src/alpine/3.20/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.20/helix/arm64v8/Dockerfile
@@ -31,6 +31,19 @@ RUN cmake -B build/linux/arm64_Release_openssl3 \
     cmake --build build/linux/arm64_Release_openssl3  --config Release && \
     cmake --install build/linux/arm64_Release_openssl3 --prefix /msquic
 
+FROM arm64v8/alpine:3.20 AS venv
+
+RUN apk add --upgrade --no-cache \
+        build-base \
+        libffi-dev \
+        gcc \
+        linux-headers
+
+RUN python3 -m venv /venv && \
+        source /venv/bin/activate && \
+        pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+        pip install ./helix_scripts-*-py3-none-any.whl
+
 
 FROM arm64v8/alpine:3.20
 
@@ -68,23 +81,11 @@ RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
     chmod 755 /root && \
     echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot
 
-# Install Helix Dependencies
-RUN apk add --upgrade --no-cache \
-        build-base \
-        libffi-dev \
-        gcc \
-        linux-headers && \
-    # Create virtual environment
-    python3 -m venv /home/helixbot/.vsts-env && \
-    source /home/helixbot/.vsts-env/bin/activate && \
-    # Install Helix scripts
-    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    pip install ./helix_scripts-*-py3-none-any.whl && \
-    # Delete unnecessary dependencies
-    apk del \
-        build-base \
-        libffi-dev \
-        gcc \
-        linux-headers
-
 USER helixbot
+
+# Install Helix Dependencies
+
+ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+COPY --from=venv /venv /home/helixbot/.vsts-env

--- a/src/alpine/3.20/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.20/helix/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/alpine:3.20 as msquic
+FROM arm64v8/alpine:3.20 AS msquic
 
 # build MsQuic as we don't have packages
 RUN apk add --upgrade --no-cache \
@@ -34,9 +34,11 @@ RUN cmake -B build/linux/arm64_Release_openssl3 \
 FROM arm64v8/alpine:3.20 AS venv
 
 RUN apk add --upgrade --no-cache \
+        python3-dev \
         build-base \
         libffi-dev \
         gcc \
+        libffi-dev \
         linux-headers
 
 RUN python3 -m venv /venv && \

--- a/src/alpine/3.20/helix/arm64v8/Dockerfile
+++ b/src/alpine/3.20/helix/arm64v8/Dockerfile
@@ -90,4 +90,4 @@ USER helixbot
 ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-COPY --from=venv /venv /home/helixbot/.vsts-env
+COPY --from=venv /venv $VIRTUAL_ENV

--- a/src/debian/12/helix/amd64/Dockerfile
+++ b/src/debian/12/helix/amd64/Dockerfile
@@ -72,4 +72,4 @@ USER helixbot
 ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-COPY --from=venv /venv /home/helixbot/.vsts-env
+COPY --from=venv /venv $VIRTUAL_ENV

--- a/src/debian/12/helix/amd64/Dockerfile
+++ b/src/debian/12/helix/amd64/Dockerfile
@@ -1,3 +1,18 @@
+FROM library/debian:bookworm AS venv
+
+RUN apt-get update && \
+    apt-get install -y \
+        coreutils \
+        python3-dev \
+        python3-pip \
+        python3-venv \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m venv /venv && \
+    . /venv/bin/activate && \
+    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    pip install ./helix_scripts-*-py3-none-any.whl
+
 FROM library/debian:bookworm
 
 # Install Helix Dependencies
@@ -34,10 +49,6 @@ RUN apt-get update && \
 
 ENV LANG=en_US.utf8
 
-RUN ln -sf /usr/bin/python3 /usr/bin/python && \
-    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    pip install ./helix_scripts-*-py3-none-any.whl --break-system-packages
-
 # Add MsQuic
 RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
     echo 2cfd20a306b2fa5e25522d78f2ef50a1f429d35fd30bd983e2ebffc2b80944fa microsoft.asc| sha256sum --check - && \
@@ -56,4 +67,9 @@ RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bas
 
 USER helixbot
 
-RUN python3 -m venv /home/helixbot/.vsts-env
+# Install Helix Dependencies
+
+ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+COPY --from=venv /venv /home/helixbot/.vsts-env

--- a/src/debian/12/helix/arm32v7/Dockerfile
+++ b/src/debian/12/helix/arm32v7/Dockerfile
@@ -74,4 +74,4 @@ USER helixbot
 ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-COPY --from=venv /venv /home/helixbot/.vsts-env
+COPY --from=venv /venv $VIRTUAL_ENV

--- a/src/debian/12/helix/arm32v7/Dockerfile
+++ b/src/debian/12/helix/arm32v7/Dockerfile
@@ -2,6 +2,8 @@ FROM library/debian:bookworm AS venv
 
 RUN apt-get update && \
     apt-get install -y \
+        curl \
+        pkg-config \
         coreutils \
         python3-dev \
         python3-pip \
@@ -53,11 +55,6 @@ RUN apt-get update && \
         unzip \
     && rm -rf /var/lib/apt/lists/* \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
-
-# Install latest version of rust because the package version provided by Debian is too old.
-# Need 1.65.0+ to install the Helix scripts due to cryptography-openssl dependency.
-RUN curl -sSf https://sh.rustup.rs | sh -s -- -y
-ENV PATH="/root/.cargo/bin:${PATH}"
 
 ENV LANG=en_US.utf8
 

--- a/src/debian/12/helix/arm32v7/Dockerfile
+++ b/src/debian/12/helix/arm32v7/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && \
         python3-pip \
         python3-venv \
         libffi-dev \
+        libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Install latest version of rust because the package version provided by Debian is too old.

--- a/src/debian/12/helix/arm32v7/Dockerfile
+++ b/src/debian/12/helix/arm32v7/Dockerfile
@@ -8,6 +8,11 @@ RUN apt-get update && \
         python3-venv \
     && rm -rf /var/lib/apt/lists/*
 
+# Install latest version of rust because the package version provided by Debian is too old.
+# Need 1.65.0+ to install the Helix scripts due to cryptography-openssl dependency.
+RUN curl -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
 RUN python3 -m venv /venv && \
     . /venv/bin/activate && \
     pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \

--- a/src/debian/12/helix/arm32v7/Dockerfile
+++ b/src/debian/12/helix/arm32v7/Dockerfile
@@ -1,6 +1,20 @@
+FROM library/debian:bookworm AS venv
+
+RUN apt-get update && \
+    apt-get install -y \
+        coreutils \
+        python3-dev \
+        python3-pip \
+        python3-venv \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m venv /venv && \
+    . /venv/bin/activate && \
+    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    pip install ./helix_scripts-*-py3-none-any.whl
+
 FROM library/debian:bookworm
 
-# Install Helix Dependencies
 RUN apt-get update && \
     apt-get install -y \
         autoconf \
@@ -37,10 +51,6 @@ RUN apt-get update && \
 
 ENV LANG=en_US.utf8
 
-RUN ln -sf /usr/bin/python3 /usr/bin/python && \
-    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    pip install ./helix_scripts-*-py3-none-any.whl --break-system-packages
-
 # Add MsQuic
 RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
     echo 2cfd20a306b2fa5e25522d78f2ef50a1f429d35fd30bd983e2ebffc2b80944fa microsoft.asc| sha256sum --check - && \
@@ -57,13 +67,11 @@ RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bas
     chmod 755 /root && \
     echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
 
-# Debian 12 is set up with its python environment marked as externally managed
-# (https://packaging.python.org/en/latest/specifications/externally-managed-environments/).
-# This causes errors when helix setup (at runtime) does 'sudo pip install'.
-# Work around this by overriding the check for externally managed environments.
-RUN mkdir -p ~/.config/pip && \
-    echo "[global]\nbreak-system-packages = true" > ~/.config/pip/pip.conf
-
 USER helixbot
 
-RUN python3 -m venv /home/helixbot/.vsts-env
+# Install Helix Dependencies
+
+ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+COPY --from=venv /venv /home/helixbot/.vsts-env

--- a/src/debian/12/helix/arm32v7/Dockerfile
+++ b/src/debian/12/helix/arm32v7/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && \
         python3-dev \
         python3-pip \
         python3-venv \
+        libffi-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Install latest version of rust because the package version provided by Debian is too old.

--- a/src/debian/12/helix/arm64v8/Dockerfile
+++ b/src/debian/12/helix/arm64v8/Dockerfile
@@ -72,4 +72,4 @@ USER helixbot
 ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-COPY --from=venv /venv /home/helixbot/.vsts-env
+COPY --from=venv /venv $VIRTUAL_ENV

--- a/src/debian/12/helix/arm64v8/Dockerfile
+++ b/src/debian/12/helix/arm64v8/Dockerfile
@@ -1,3 +1,18 @@
+FROM library/debian:bookworm AS venv
+
+RUN apt-get update && \
+    apt-get install -y \
+        coreutils \
+        python3-dev \
+        python3-pip \
+        python3-venv \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m venv /venv && \
+    . /venv/bin/activate && \
+    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    pip install ./helix_scripts-*-py3-none-any.whl
+
 FROM library/debian:bookworm
 
 # Install Helix Dependencies
@@ -34,10 +49,6 @@ RUN apt-get update && \
 
 ENV LANG=en_US.utf8
 
-RUN ln -sf /usr/bin/python3 /usr/bin/python && \
-    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    pip install ./helix_scripts-*-py3-none-any.whl --break-system-packages
-
 # Add MsQuic
 RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
     echo 2cfd20a306b2fa5e25522d78f2ef50a1f429d35fd30bd983e2ebffc2b80944fa microsoft.asc| sha256sum --check - && \
@@ -56,4 +67,9 @@ RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bas
 
 USER helixbot
 
-RUN python3 -m venv /home/helixbot/.vsts-env
+# Install Helix Dependencies
+
+ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+COPY --from=venv /venv /home/helixbot/.vsts-env

--- a/src/ubuntu/24.04/helix/Dockerfile
+++ b/src/ubuntu/24.04/helix/Dockerfile
@@ -4,6 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y \
         cargo \
+        pkg-config \
         libffi-dev \
         coreutils \
         python3-dev \

--- a/src/ubuntu/24.04/helix/Dockerfile
+++ b/src/ubuntu/24.04/helix/Dockerfile
@@ -3,6 +3,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get install -y \
+        cargo \
+        libffi-dev \
         coreutils \
         python3-dev \
         python3-pip \

--- a/src/ubuntu/24.04/helix/Dockerfile
+++ b/src/ubuntu/24.04/helix/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && \
         python3-dev \
         python3-pip \
         python3-venv \
+        libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
 RUN python3 -m venv /venv && \

--- a/src/ubuntu/24.04/helix/Dockerfile
+++ b/src/ubuntu/24.04/helix/Dockerfile
@@ -84,5 +84,5 @@ USER helixbot
 ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-COPY --from=venv /venv /home/helixbot/.vsts-env
+COPY --from=venv /venv $VIRTUAL_ENV
 

--- a/src/ubuntu/24.04/helix/Dockerfile
+++ b/src/ubuntu/24.04/helix/Dockerfile
@@ -1,6 +1,21 @@
+FROM ubuntu.azurecr.io/ubuntu:noble AS venv
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y \
+        coreutils \
+        python3-dev \
+        python3-pip \
+        python3-venv \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m venv /venv && \
+    . /venv/bin/activate && \
+    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    pip install ./helix_scripts-*-py3-none-any.whl
+
 FROM ubuntu.azurecr.io/ubuntu:noble
 ARG TARGETARCH
-# Install Helix Dependencies
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN LIBCURL=libcurl4 && \
@@ -45,10 +60,6 @@ RUN LIBCURL=libcurl4 && \
 
 ENV LANG=en_US.utf8
 
-RUN ln -sf /usr/bin/python3 /usr/bin/python && \
-    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    pip install --break-system-packages ./helix_scripts-*-py3-none-any.whl
-
 # Add MsQuic
 # MsQuic does not yet publish packages for 24.04
 # Manually install 22.04 package for now
@@ -68,4 +79,10 @@ RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1001 --shell /bin/bas
 
 USER helixbot
 
-RUN python -m venv /home/helixbot/.vsts-env
+# Install Helix Dependencies
+
+ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+COPY --from=venv /venv /home/helixbot/.vsts-env
+


### PR DESCRIPTION
Install Helix python packages into a separate docker stage into a venv to avoid installing and uninstalling packages from the final image and to avoid using `--break-system-packages`.