### PR TITLE
Install newer rust version

### DIFF
--- a/src/alpine/3.17/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.17/helix/arm32v7/Dockerfile
@@ -56,12 +56,20 @@ RUN apk add --upgrade --no-cache \
 
 # Install Helix Dependencies
 RUN apk add --upgrade --no-cache \
-        cargo \
         libffi-dev \
         linux-headers \
         python3-dev \
         openssl-dev && \
     ln -sf /usr/bin/python3 /usr/bin/python && \
+    \
+    # We need to install a 1.65.0+ version of rust due to cryptography-openssl dependency. This isn't available from Alpine 3.17 so we'll
+    # configure package install to target 3.18.    
+    echo "https://dl-cdn.alpinelinux.org/alpine/v3.18/main" >> /etc/apk/repositories && \
+    apk update && \
+    apk add --no-cache \
+        cargo && \
+    sed -i '/v3.18/d' /etc/apk/repositories && \
+    \
     pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
     pip install ./helix_scripts-*-py3-none-any.whl && \
     apk del \

--- a/src/alpine/3.17/helix/arm32v7/Dockerfile
+++ b/src/alpine/3.17/helix/arm32v7/Dockerfile
@@ -65,6 +65,7 @@ RUN apk add --upgrade --no-cache \
     # We need to install a 1.65.0+ version of rust due to cryptography-openssl dependency. This isn't available from Alpine 3.17 so we'll
     # configure package install to target 3.18.    
     echo "https://dl-cdn.alpinelinux.org/alpine/v3.18/main" >> /etc/apk/repositories && \
+    echo "https://dl-cdn.alpinelinux.org/alpine/v3.18/community" >> /etc/apk/repositories && \
     apk update && \
     apk add --no-cache \
         cargo && \

--- a/src/debian/12/helix/arm32v7/Dockerfile
+++ b/src/debian/12/helix/arm32v7/Dockerfile
@@ -27,13 +27,17 @@ RUN apt-get update && \
         python3-dev \
         python3-pip \
         python3-venv \
-        rustc \
         software-properties-common \
         sudo \
         tzdata \
         unzip \
     && rm -rf /var/lib/apt/lists/* \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+# Install latest version of rust because the package version provided by Debian is too old.
+# Need 1.65.0+ to install the Helix scripts due to cryptography-openssl dependency.
+RUN curl -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
 
 ENV LANG=en_US.utf8
 


### PR DESCRIPTION
Certain Arm32 Helix builds are broken with the following error:

```
#10 216.6   × Building wheel for cryptography (pyproject.toml) did not run successfully.
#10 216.6   │ exit code: 1
#10 216.6   ╰─> [13 lines of output]
#10 216.6       Running `maturin pep517 build-wheel -i /usr/bin/python3 --compatibility off`
#10 216.6       📦 Including license file "/tmp/pip-install-9tau84p3/cryptography_107648dceb1e46fe97aba4a45136dbe9/LICENSE"
#10 216.6       📦 Including license file "/tmp/pip-install-9tau84p3/cryptography_107648dceb1e46fe97aba4a45136dbe9/LICENSE.APACHE"
#10 216.6       📦 Including license file "/tmp/pip-install-9tau84p3/cryptography_107648dceb1e46fe97aba4a45136dbe9/LICENSE.BSD"
#10 216.6       🍹 Building a mixed python/rust project
#10 216.6       🔗 Found pyo3 bindings with abi3 support for Python ≥ 3.7
#10 216.6       🐍 Not using a specific python interpreter
#10 216.6       📡 Using build options features, locked from pyproject.toml
#10 216.6       error: package `cryptography-x509-verification v0.1.0 (/tmp/pip-install-9tau84p3/cryptography_107648dceb1e46fe97aba4a45136dbe9/src/rust/cryptography-x509-verification)` cannot be built because it requires rustc 1.65.0 or newer, while the currently active rustc version is 1.64.0
#10 216.6       💥 maturin failed
#10 216.6         Caused by: Failed to build a native library through cargo
#10 216.6         Caused by: Cargo build finished with "exit status: 101": `env -u CARGO CARGO_ENCODED_RUSTFLAGS="-C\u{1f}target-feature=-crt-static" PYO3_ENVIRONMENT_SIGNATURE="cpython-3.10-64bit" PYO3_PYTHON="/usr/bin/python3" PYTHON_SYS_EXECUTABLE="/usr/bin/python3" "cargo" "rustc" "--features" "pyo3/abi3-py37" "--message-format" "json-render-diagnostics" "--locked" "--manifest-path" "/tmp/pip-install-9tau84p3/cryptography_107648dceb1e46fe97aba4a45136dbe9/src/rust/Cargo.toml" "--release" "--lib"`
#10 216.6       Error: command ['maturin', 'pep517', 'build-wheel', '-i', '/usr/bin/python3', '--compatibility', 'off'] returned non-zero exit status 1
#10 216.6       [end of output]
```

This is the key bit of info from that: ` requires rustc 1.65.0 or newer, while the currently active rustc version is 1.64.0`.

This only occurs in Arm32 builds because some change must have occurred for the Arm32 version of the cryptography package that requires the wheel to be built and has new dependencies than before. 

@jkoritzinsky - This is somewhat related to your changes in https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1142. The reason for your build failure there is due to missing dependencies because of the need to compile the wheel. Once those are resolved, the build would run into this error so you'll need to incorporate these changes.