### PR TITLE
Update msquic version and configure distros to use latest package again

### DIFF
--- a/src/almalinux/8/helix/amd64/Dockerfile
+++ b/src/almalinux/8/helix/amd64/Dockerfile
@@ -13,8 +13,7 @@ RUN rpm -Uvh https://packages.microsoft.com/config/centos/8/packages-microsoft-p
         # Required for asp.net core test runs
         sudo \
         libicu \
-        # temporarilly fix msquic to 2.3.6 due to https://github.com/dotnet/runtime/issues/105788
-        libmsquic-2.3.6-1
+        libmsquic
 
 RUN python3 -m pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
     python3 -m pip install ./helix_scripts-*-py3-none-any.whl

--- a/src/alpine/3.17/helix/Dockerfile
+++ b/src/alpine/3.17/helix/Dockerfile
@@ -15,7 +15,7 @@ RUN apk add --upgrade --no-cache \
         openssl-dev \
         perl
 
-RUN git clone --depth 1 --single-branch --branch main --recursive https://github.com/microsoft/msquic /tmp/msquic
+RUN git clone --depth 1 --single-branch --branch v2.4.1 --recursive https://github.com/microsoft/msquic /tmp/msquic
 
 WORKDIR /tmp/msquic
 

--- a/src/alpine/3.18/helix/Dockerfile
+++ b/src/alpine/3.18/helix/Dockerfile
@@ -15,7 +15,7 @@ RUN apk add --upgrade --no-cache \
         openssl-dev \
         perl
 
-RUN git clone --depth 1 --single-branch --branch main --recursive https://github.com/microsoft/msquic /tmp/msquic
+RUN git clone --depth 1 --single-branch --branch v2.4.1 --recursive https://github.com/microsoft/msquic /tmp/msquic
 
 WORKDIR /tmp/msquic
 

--- a/src/alpine/3.20/helix/Dockerfile
+++ b/src/alpine/3.20/helix/Dockerfile
@@ -15,7 +15,7 @@ RUN apk add --upgrade --no-cache \
         openssl-dev \
         perl
 
-RUN git clone --depth 1 --single-branch --branch main --recursive https://github.com/microsoft/msquic /tmp/msquic
+RUN git clone --depth 1 --single-branch --branch v2.4.1 --recursive https://github.com/microsoft/msquic /tmp/msquic
 
 WORKDIR /tmp/msquic
 

--- a/src/cbl-mariner/2.0/helix/amd64/Dockerfile
+++ b/src/cbl-mariner/2.0/helix/amd64/Dockerfile
@@ -9,8 +9,7 @@ RUN tdnf install --setopt tsflags=nodocs --refresh -y \
          gcc \
          icu \
          iputils \
-         # temporarilly fix msquic to 2.3.6 due to https://github.com/dotnet/runtime/issues/105788
-         libmsquic-2.3.6-1 \
+         libmsquic \
          llvm \
          python3-pip \
          shadow-utils \

--- a/src/centos/stream9/helix/amd64/Dockerfile
+++ b/src/centos/stream9/helix/amd64/Dockerfile
@@ -21,8 +21,7 @@ RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
         git-core \
         iputils \
         libicu \
-        # temporarilly fix msquic to 2.3.6 due to https://github.com/dotnet/runtime/issues/105788
-        libmsquic-2.3.6-1 \
+        libmsquic \
         libtool \
         llvm \
         make \

--- a/src/debian/11/helix/amd64/Dockerfile
+++ b/src/debian/11/helix/amd64/Dockerfile
@@ -46,8 +46,7 @@ RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
     rm microsoft.asc && \
     apt-add-repository https://packages.microsoft.com/debian/11/prod && \
     apt-get update && \
-    # temporarilly fix msquic to 2.3.6 due to https://github.com/dotnet/runtime/issues/105788
-    apt-get install -y libmsquic=2.3.6 && \
+    apt-get install -y libmsquic && \
     rm -rf /var/lib/apt/lists/*
 
 # Create helixbot user and give rights to sudo without password

--- a/src/debian/11/helix/arm32v7/Dockerfile
+++ b/src/debian/11/helix/arm32v7/Dockerfile
@@ -45,8 +45,7 @@ RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
     rm microsoft.asc && \
     apt-add-repository https://packages.microsoft.com/debian/11/prod && \
     apt-get update && \
-    # temporarilly fix msquic to 2.3.6 due to https://github.com/dotnet/runtime/issues/105788
-    apt-get install -y libmsquic=2.3.6 && \
+    apt-get install -y libmsquic && \
     rm -rf /var/lib/apt/lists/*
 
 ENV LANG=en_US.utf8

--- a/src/debian/11/helix/arm64v8/Dockerfile
+++ b/src/debian/11/helix/arm64v8/Dockerfile
@@ -49,8 +49,7 @@ RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
     rm microsoft.asc && \
     apt-add-repository https://packages.microsoft.com/debian/11/prod && \
     apt-get update && \
-    # temporarilly fix msquic to 2.3.6 due to https://github.com/dotnet/runtime/issues/105788
-    apt-get install -y libmsquic=2.3.6 && \
+    apt-get install -y libmsquic && \
     rm -rf /var/lib/apt/lists/*
 
 # Create helixbot users and give rights to sudo without password
@@ -60,7 +59,7 @@ RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1001 --shell /bin/bas
     /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm helixbot2 && \
     chmod 755 /root && \
     echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers && \
-    echo "helixbot2 ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
+    echo "helixbot2 ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers 
 
 USER helixbot
 

--- a/src/debian/12/helix/amd64/Dockerfile
+++ b/src/debian/12/helix/amd64/Dockerfile
@@ -56,8 +56,7 @@ RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
     rm microsoft.asc && \
     echo deb https://packages.microsoft.com/debian/12/prod bookworm main >> /etc/apt/sources.list.d/microsoft.list && \
     apt-get update && \
-    # temporarilly fix msquic to 2.3.6 due to https://github.com/dotnet/runtime/issues/105788
-    apt-get install -y libmsquic=2.3.6 && \
+    apt-get install -y libmsquic && \
     rm -rf /var/lib/apt/lists/*
 
 # Create helixbot user and give rights to sudo without password

--- a/src/debian/12/helix/arm32v7/Dockerfile
+++ b/src/debian/12/helix/arm32v7/Dockerfile
@@ -66,8 +66,7 @@ RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
     rm microsoft.asc && \
     echo deb https://packages.microsoft.com/debian/12/prod bookworm main >> /etc/apt/sources.list.d/microsoft.list && \
     apt-get update && \
-    # temporarilly fix msquic to 2.3.6 due to https://github.com/dotnet/runtime/issues/105788
-    apt-get install -y libmsquic=2.3.6 && \
+    apt-get install -y libmsquic && \
     rm -rf /var/lib/apt/lists/*
 
 # Create helixbot user and give rights to sudo without password

--- a/src/debian/12/helix/arm64v8/Dockerfile
+++ b/src/debian/12/helix/arm64v8/Dockerfile
@@ -56,8 +56,7 @@ RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
     rm microsoft.asc && \
     echo deb https://packages.microsoft.com/debian/12/prod bookworm main >> /etc/apt/sources.list.d/microsoft.list && \
     apt-get update && \
-    # temporarilly fix msquic to 2.3.6 due to https://github.com/dotnet/runtime/issues/105788
-    apt-get install -y libmsquic=2.3.6 && \
+    apt-get install -y libmsquic && \
     rm -rf /var/lib/apt/lists/*
 
 # Create helixbot user and give rights to sudo without password

--- a/src/opensuse/15.4/helix/amd64/Dockerfile
+++ b/src/opensuse/15.4/helix/amd64/Dockerfile
@@ -42,8 +42,7 @@ RUN wget https://packages.microsoft.com/keys/microsoft.asc && \
     rpm --import microsoft.asc && \
     rm microsoft.asc && \
     zypper addrepo https://packages.microsoft.com/opensuse/15/prod/ "MS Packages" && \
-    # temporarilly fix msquic to 2.3.6 due to https://github.com/dotnet/runtime/issues/105788
-    zypper install -y libmsquic=2.3.6-1 && \
+    zypper install -y libmsquic && \
     zypper clean -a
 
 RUN ln -sf /usr/bin/python3 /usr/bin/python && \

--- a/src/ubuntu/20.04/helix/Dockerfile
+++ b/src/ubuntu/20.04/helix/Dockerfile
@@ -53,8 +53,7 @@ RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
     rm microsoft.asc && \
     apt-add-repository https://packages.microsoft.com/ubuntu/20.04/prod && \
     apt-get update && \
-    # temporarilly fix msquic to 2.3.6 due to https://github.com/dotnet/runtime/issues/105788
-    apt-get install -y libmsquic=2.3.6 && \
+    apt-get install -y libmsquic && \
     rm -rf /var/lib/apt/lists/*
 
 # create helixbot user and give rights to sudo without password

--- a/src/ubuntu/22.04/helix/Dockerfile
+++ b/src/ubuntu/22.04/helix/Dockerfile
@@ -52,8 +52,7 @@ RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
     rm microsoft.asc && \
     apt-add-repository https://packages.microsoft.com/ubuntu/22.04/prod && \
     apt-get update && \
-    # temporarilly fix msquic to 2.3.6 due to https://github.com/dotnet/runtime/issues/105788
-    apt-get install -y libmsquic=2.3.6 && \
+    apt-get install -y libmsquic && \
     rm -rf /var/lib/apt/lists/*
 
 # create helixbot user and give rights to sudo without password

--- a/src/ubuntu/24.04/helix/Dockerfile
+++ b/src/ubuntu/24.04/helix/Dockerfile
@@ -65,6 +65,7 @@ RUN LIBCURL=libcurl4 && \
 ENV LANG=en_US.utf8
 
 # Installing `libxdp1 libnl-3-dev libnl-route-3-dev` packages as a temporary workaround delete them once the issue is fixed
+# For ARM, we need to download the libmsquic package and install it manually because it still depends on libssl3 instead of libssl3t64
 # Add MsQuic
 RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
     echo 2cfd20a306b2fa5e25522d78f2ef50a1f429d35fd30bd983e2ebffc2b80944fa microsoft.asc| sha256sum --check - && \
@@ -72,7 +73,12 @@ RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
     rm microsoft.asc && \
     apt-add-repository https://packages.microsoft.com/ubuntu/24.04/prod && \
     apt-get update && \
-    apt-get install -y libmsquic libxdp1 libnl-3-dev libnl-route-3-dev && \
+    apt-get install -y libxdp1 libnl-3-dev libnl-route-3-dev && \
+    if [ "$TARGETARCH" = "arm" ]; then \
+    apt-get download libmsquic && \
+    dpkg --ignore-depends=libssl3 -i libmsquic_*.deb && \
+    rm -f libmsquic_*.deb ; \
+    else apt-get install -y libmsquic ; fi && \
     rm -rf /var/lib/apt/lists/*
 
 # create helixbot user and give rights to sudo without password

--- a/src/ubuntu/24.04/helix/Dockerfile
+++ b/src/ubuntu/24.04/helix/Dockerfile
@@ -64,17 +64,16 @@ RUN LIBCURL=libcurl4 && \
 
 ENV LANG=en_US.utf8
 
+# Installing `libxdp1 libnl-3-dev libnl-route-3-dev` packages as a temporary workaround delete them once the issue is fixed
 # Add MsQuic
-# MsQuic does not yet publish packages for 24.04
-# Manually install 22.04 package for now
-RUN DEPS= && \
-    ARCH=$TARGETARCH && \
-    if [ "$TARGETARCH" = "arm" ]; then \
-        DEPS=--ignore-depends=libssl3 && \
-        ARCH=armhf ; fi && \
-    curl -LO https://packages.microsoft.com/ubuntu/22.04/prod/pool/main/libm/libmsquic/libmsquic_2.3.6_$ARCH.deb && \
-    dpkg $DEPS -i libmsquic_*.deb && \
-    rm -f libmsquic_*.deb
+RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
+    echo 2cfd20a306b2fa5e25522d78f2ef50a1f429d35fd30bd983e2ebffc2b80944fa microsoft.asc| sha256sum --check - && \
+    apt-key add microsoft.asc && \
+    rm microsoft.asc && \
+    apt-add-repository https://packages.microsoft.com/ubuntu/24.04/prod && \
+    apt-get update && \
+    apt-get install -y libmsquic libxdp1 libnl-3-dev libnl-route-3-dev && \
+    rm -rf /var/lib/apt/lists/*
 
 # create helixbot user and give rights to sudo without password
 RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1001 --shell /bin/bash --ingroup adm helixbot && \


### PR DESCRIPTION
Fixes #1155
Contributes to dotnet/runtime#82077

This PR also converts Alpine msquic branch to v2.4.1 from main

/cc @ManickaP 