### PR TITLE
Update gcc path in alpine-riscv64

### DIFF
--- a/src/azurelinux/3.0/net9.0/cross/riscv64-alpine/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/riscv64-alpine/Dockerfile
@@ -26,7 +26,7 @@ RUN TARGET_TRIPLE="riscv64-alpine-linux-musl" && \
         -DLIBCXX_ENABLE_SHARED=OFF \
         -DLIBCXX_HAS_MUSL_LIBC=ON \
         -DLIBCXX_CXX_ABI=libstdc++ \
-        -DLIBCXX_CXX_ABI_INCLUDE_PATHS="$ROOTFS_DIR/usr/include/c++/13.2.1/;$ROOTFS_DIR/usr/include/c++/13.2.1/$TARGET_TRIPLE" && \
+        -DLIBCXX_CXX_ABI_INCLUDE_PATHS="$ROOTFS_DIR/usr/include/c++/14.2.0/;$ROOTFS_DIR/usr/include/c++/14.2.0/$TARGET_TRIPLE" && \
     cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
     cmake --install runtimes --prefix "$ROOTFS_DIR/usr"
 


### PR DESCRIPTION
For new archs, the triplet path can change as soon as the maintainer will update the gcc. This is rare, because we will eventually pin the alpine riscv64 version to 3.21 as soon as it is out (which has lldb support) and keep it there. (e.g. alpine-arm64 is pinned to 3.13 to maximize compatibility)

Fixes #1160