### PR TITLE
Make `@dotnet/dotnet-docker-reviewers` an owner of every file

### DIFF
--- a/.github/workflows/codeowners-validation.yml
+++ b/.github/workflows/codeowners-validation.yml
@@ -16,6 +16,10 @@ jobs:
         if: always()
         run: ./eng/validate-codeowners.sh ownersAreTeams
 
+      - name: Ensure each path has @dotnet/dotnet-docker-reviewers as a CODEOWNER
+        if: always()
+        run: ./eng/validate-codeowners.sh ownersIncludeDockerReviewers
+
       - name: Check each Dockerfile for a CODEOWNER
         if: always()
         run: ./eng/validate-codeowners.sh dockerfilesHaveOwners

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,49 +2,52 @@
 # See https://help.github.com/articles/about-code-owners/
 
 ### General infra ###
+# '*' is excluded from the CODEOWNERS validation that runs on PRs
 * @dotnet/dotnet-docker-reviewers
 
 ### Dockerfiles ###
 
-# common paths
-src/**/helix/ @dotnet/dnceng
-src/**/cross*/ @dotnet/runtime-infrastructure
-src/**/webassembly*/ @dotnet/runtime-infrastructure
-
 # almalinux
-src/almalinux/**/source-build/ @dotnet/source-build-internal
+src/almalinux/**/source-build/ @dotnet/source-build-internal @dotnet/dotnet-docker-reviewers
 
 # alpine
-src/alpine/**/amd64/ @dotnet/source-build-internal
+src/alpine/**/amd64/ @dotnet/source-build-internal @dotnet/dotnet-docker-reviewers
 
 # azurelinux
-src/azurelinux/**/android/ @dotnet/runtime-infrastructure
-src/azurelinux/**/fpm/ @dotnet/runtime-infrastructure
-src/azurelinux/**/opt/ @dotnet/runtime-infrastructure
+src/azurelinux/**/android/ @dotnet/runtime-infrastructure @dotnet/dotnet-docker-reviewers
+src/azurelinux/**/fpm/ @dotnet/runtime-infrastructure @dotnet/dotnet-docker-reviewers
+src/azurelinux/**/opt/ @dotnet/runtime-infrastructure @dotnet/dotnet-docker-reviewers
 
 # cbl-mariner
-src/cbl-mariner/**/android/ @dotnet/runtime-infrastructure
-src/cbl-mariner/**/fpm/ @dotnet/runtime-infrastructure
-src/cbl-mariner/**/opt/ @dotnet/runtime-infrastructure
-src/cbl-mariner/**/docker-testrunner/ @dotnet/dotnet-docker-reviewers
-src/cbl-mariner/2.0/amd64/ @dotnet/runtime-infrastructure
+src/cbl-mariner/**/android/ @dotnet/runtime-infrastructure @dotnet/dotnet-docker-reviewers
+src/cbl-mariner/**/fpm/ @dotnet/runtime-infrastructure @dotnet/dotnet-docker-reviewers
+src/cbl-mariner/**/opt/ @dotnet/runtime-infrastructure @dotnet/dotnet-docker-reviewers
+src/cbl-mariner/**/docker-testrunner/ @dotnet/dotnet-docker-reviewers @dotnet/dotnet-docker-reviewers
+src/cbl-mariner/2.0/amd64/ @dotnet/runtime-infrastructure @dotnet/dotnet-docker-reviewers
 
 # centos
-src/centos/stream9/amd64/ @dotnet/source-build-internal
+src/centos/stream9/amd64/ @dotnet/source-build-internal @dotnet/dotnet-docker-reviewers
 
 # debian
-src/debian/11/amd64/ @dotnet/source-build-internal
-src/debian/11/opt/arm64v8/ @dotnet/runtime-infrastructure
-src/debian/12/gcc14/amd64/ @dotnet/runtime-infrastructure
+src/debian/11/amd64/ @dotnet/source-build-internal @dotnet/dotnet-docker-reviewers
+src/debian/11/opt/arm64v8/ @dotnet/runtime-infrastructure @dotnet/dotnet-docker-reviewers
+src/debian/12/gcc14/amd64/ @dotnet/runtime-infrastructure @dotnet/dotnet-docker-reviewers
 
 # fedora
-src/fedora/**/amd64/ @dotnet/source-build-internal
+src/fedora/**/amd64/ @dotnet/source-build-internal @dotnet/dotnet-docker-reviewers
 
 # ubuntu
-src/ubuntu/**/debpkg/ @dotnet/runtime-infrastructure
-src/ubuntu/22.04/mlnet/ @dotnet/runtime-infrastructure
-src/ubuntu/22.04/opt/arm64v8/ @dotnet/runtime-infrastructure
-src/ubuntu/common/coredeps/ @dotnet/runtime-infrastructure
-src/ubuntu/20.04/Dockerfile @dotnet/source-build-internal
-src/ubuntu/22.04/Dockerfile @dotnet/source-build-internal
-src/ubuntu/24.04/Dockerfile @dotnet/source-build-internal
+src/ubuntu/**/debpkg/ @dotnet/runtime-infrastructure @dotnet/dotnet-docker-reviewers
+src/ubuntu/22.04/mlnet/ @dotnet/runtime-infrastructure @dotnet/dotnet-docker-reviewers
+src/ubuntu/22.04/opt/arm64v8/ @dotnet/runtime-infrastructure @dotnet/dotnet-docker-reviewers
+src/ubuntu/common/coredeps/ @dotnet/runtime-infrastructure @dotnet/dotnet-docker-reviewers
+src/ubuntu/20.04/Dockerfile @dotnet/source-build-internal @dotnet/dotnet-docker-reviewers
+src/ubuntu/22.04/Dockerfile @dotnet/source-build-internal @dotnet/dotnet-docker-reviewers
+src/ubuntu/24.04/Dockerfile @dotnet/source-build-internal @dotnet/dotnet-docker-reviewers
+
+# common paths
+# CODEOWNERS selects the last match as the owner so we list these paths last
+# Otherwise these paths will be owned by a different team(s) than the ones listed below
+src/**/helix/ @dotnet/dnceng @dotnet/dotnet-docker-reviewers
+src/**/cross*/ @dotnet/runtime-infrastructure @dotnet/dotnet-docker-reviewers
+src/**/webassembly*/ @dotnet/runtime-infrastructure @dotnet/dotnet-docker-reviewers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -22,7 +22,7 @@ src/azurelinux/**/opt/ @dotnet/runtime-infrastructure @dotnet/dotnet-docker-revi
 src/cbl-mariner/**/android/ @dotnet/runtime-infrastructure @dotnet/dotnet-docker-reviewers
 src/cbl-mariner/**/fpm/ @dotnet/runtime-infrastructure @dotnet/dotnet-docker-reviewers
 src/cbl-mariner/**/opt/ @dotnet/runtime-infrastructure @dotnet/dotnet-docker-reviewers
-src/cbl-mariner/**/docker-testrunner/ @dotnet/dotnet-docker-reviewers @dotnet/dotnet-docker-reviewers
+src/cbl-mariner/**/docker-testrunner/ @dotnet/dotnet-docker-reviewers
 src/cbl-mariner/2.0/amd64/ @dotnet/runtime-infrastructure @dotnet/dotnet-docker-reviewers
 
 # centos

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ There will be a need for modifying existing Dockerfiles or creating new ones.  F
     - Add/Update the Dockerfile(s)
     - If new Dockerfile(s) were added:
         - Update the [manifest](#manifest)
-        - Update the [CODEOWNERS](./CODEOWNERS) with the respective team code owner(s) (not individual users) for the Dockerfile(s). A team code owner must be assigned to each Dockerfile for maintenance and issue assignment purposes. 
+        - Update the [CODEOWNERS](./CODEOWNERS) with the respective team code owner(s) (not individual users) for the Dockerfile(s) and list `@dotnet/dotnet-docker-reviewers` as a secondary owner. Team code owners must be assigned to each Dockerfile for maintenance and issue assignment purposes. 
 
 2. Validate the changes locally by running [build.ps1](./build.ps1).  It is strongly suggested to specify the `-DockerfilePath` option to avoid the overhead of building all the images.
 


### PR DESCRIPTION
Closes https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/1163

This PR introduces changes to add `@dotnet/dotnet-docker-reviewers` as a code owner for every file in the repo. These changes include the addition of a validation step to require that the team is included as an owner on all entries in the CODEOWNERS file.

This PR also moves the assignment of general paths such as `helix` to the bottom of the CODEOWNERS file so that the owners don't get overridden by entries for specific groups of Dockerfiles (such as alpine Dockerfile assignments).