### PR TITLE
Add helix images for Azure Linux 3.0

### DIFF
--- a/src/azurelinux/3.0/helix/Dockerfile
+++ b/src/azurelinux/3.0/helix/Dockerfile
@@ -1,0 +1,36 @@
+FROM mcr.microsoft.com/azurelinux/base/core:3.0
+
+# Install Helix Dependencies
+
+ENV LANG=en_US.utf8
+
+RUN tdnf install --setopt tsflags=nodocs --refresh -y \
+        build-essential \
+        ca-certificates-microsoft \
+        gcc \
+        icu \
+        iputils \
+        llvm \
+        python3-devel \
+        python3-pip \
+        shadow-utils \
+        tar \
+        tzdata \
+        which \
+    && tdnf clean all
+
+RUN ln -sf /usr/bin/python3 /usr/bin/python && \
+    python -m pip install --upgrade setuptools && \
+    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    pip install ./helix_scripts-*-py3-none-any.whl && \
+    rm ./helix_scripts-*-py3-none-any.whl
+
+# create helixbot user and give rights to sudo without password
+RUN /usr/sbin/useradd -c '' --uid 1000 --shell /bin/bash --groups adm helixbot && \
+    chmod 755 /root && \
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers && \
+    mkdir /home/helixbot/ && chown -R helixbot /home/helixbot/
+
+USER helixbot
+
+RUN python -m venv /home/helixbot/.vsts-env

--- a/src/azurelinux/manifest.json
+++ b/src/azurelinux/manifest.json
@@ -518,7 +518,7 @@
               "osVersion": "azurelinux3.0",
               "tags": {
                 "azurelinux-3.0-helix-amd64$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "azurelinux-3.0-helix-amd64-$(FloatingTagSuffix)": {}
+                "azurelinux-3.0-helix-amd64$(FloatingTagSuffix)": {}
               }
             }
           ]

--- a/src/azurelinux/manifest.json
+++ b/src/azurelinux/manifest.json
@@ -537,21 +537,6 @@
               "variant": "v8"
             }
           ]
-        },
-        {
-          "platforms": [
-            {
-              "architecture": "arm",
-              "dockerfile": "src/azurelinux/3.0/helix",
-              "os": "linux",
-              "osVersion": "azurelinux3.0",
-              "tags": {
-                "azurelinux-3.0-helix-arm32v7$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "azurelinux-3.0-helix-arm32v7-$(FloatingTagSuffix)": {}
-              },
-              "variant": "v7"
-            }
-          ]
         }
       ]
     }

--- a/src/azurelinux/manifest.json
+++ b/src/azurelinux/manifest.json
@@ -532,7 +532,7 @@
               "osVersion": "azurelinux3.0",
               "tags": {
                 "azurelinux-3.0-helix-arm64v8$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
-                "azurelinux-3.0-helix-arm64v8-$(FloatingTagSuffix)": {}
+                "azurelinux-3.0-helix-arm64v8$(FloatingTagSuffix)": {}
               },
               "variant": "v8"
             }

--- a/src/azurelinux/manifest.json
+++ b/src/azurelinux/manifest.json
@@ -508,6 +508,50 @@
               }
             }
           ]
+        },
+        {
+          "platforms": [
+            {
+              "architecture": "amd64",
+              "dockerfile": "src/azurelinux/3.0/helix",
+              "os": "linux",
+              "osVersion": "azurelinux3.0",
+              "tags": {
+                "azurelinux-3.0-helix-amd64$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "azurelinux-3.0-helix-amd64-$(FloatingTagSuffix)": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "architecture": "arm64",
+              "dockerfile": "src/azurelinux/3.0/helix",
+              "os": "linux",
+              "osVersion": "azurelinux3.0",
+              "tags": {
+                "azurelinux-3.0-helix-arm64v8$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "azurelinux-3.0-helix-arm64v8-$(FloatingTagSuffix)": {}
+              },
+              "variant": "v8"
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "architecture": "arm",
+              "dockerfile": "src/azurelinux/3.0/helix",
+              "os": "linux",
+              "osVersion": "azurelinux3.0",
+              "tags": {
+                "azurelinux-3.0-helix-arm32v7$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
+                "azurelinux-3.0-helix-arm32v7-$(FloatingTagSuffix)": {}
+              },
+              "variant": "v7"
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
Largely a copy/paste of: https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/4cf84c9cb8d9581f2f1f4e330a8199ede451c424/src/cbl-mariner/2.0/helix/amd64/Dockerfile

`libmsquic` doesn't appear to be in the Azure 3.0 archive yet. https://github.com/microsoft/msquic/issues/4450

Which of the patterns we use is best for Azure Linux 3.0? 

@wfurt @jkoritzinsky 