### PR TITLE
Switch to MCR images

### DIFF
--- a/src/azurelinux/3.0/net8.0/crossdeps-builder/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/crossdeps-builder/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM azurelinuxpreview.azurecr.io/public/azurelinux/base/core:3.0
+FROM mcr.microsoft.com/azurelinux/base/core:3.0
 
 RUN tdnf install -y \
         # Common utilities

--- a/src/azurelinux/3.0/net8.0/crossdeps/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/crossdeps/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM azurelinuxpreview.azurecr.io/public/azurelinux/base/core:3.0
+FROM mcr.microsoft.com/azurelinux/base/core:3.0
 
 RUN tdnf update -y && \
     tdnf install -y \

--- a/src/azurelinux/3.0/net9.0/crossdeps-builder/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/crossdeps-builder/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM azurelinuxpreview.azurecr.io/public/azurelinux/base/core:3.0
+FROM mcr.microsoft.com/azurelinux/base/core:3.0
 
 RUN tdnf install -y \
         # Common utilities

--- a/src/azurelinux/3.0/net9.0/crossdeps/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/crossdeps/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM azurelinuxpreview.azurecr.io/public/azurelinux/base/core:3.0
+FROM mcr.microsoft.com/azurelinux/base/core:3.0
 
 RUN tdnf update -y && \
     tdnf install -y \

--- a/src/azurelinux/3.0/net9.0/fpm/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/fpm/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM azurelinuxpreview.azurecr.io/public/azurelinux/base/core:3.0
+FROM mcr.microsoft.com/azurelinux/base/core:3.0
 RUN tdnf install -y \
         awk \
         build-essential \

--- a/src/azurelinux/3.0/net9.0/opt/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/opt/Dockerfile
@@ -1,4 +1,4 @@
-FROM azurelinuxpreview.azurecr.io/public/azurelinux/base/core:3.0
+FROM mcr.microsoft.com/azurelinux/base/core:3.0
 
 RUN tdnf update -y && \
     tdnf install -y \


### PR DESCRIPTION
Time to switch to MCR images for Azure Linux 3.0.

Image to fixup later: https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/4cf84c9cb8d9581f2f1f4e330a8199ede451c424/src/azurelinux/3.0/net9.0/android/Dockerfile#L18

Also, is there a reason we're using Java 8? That seems quite old.

@sbomer 