### PR TITLE
Add sudo to CBL-Mariner and AzureLinux distros

### DIFF
--- a/src/azurelinux/3.0/helix/Dockerfile
+++ b/src/azurelinux/3.0/helix/Dockerfile
@@ -63,6 +63,7 @@ RUN tdnf install --setopt tsflags=nodocs --refresh -y \
         python3 \
         python3-pip \
         shadow-utils \
+        sudo \
         tar \
         tzdata \
         which \

--- a/src/cbl-mariner/2.0/helix/amd64/Dockerfile
+++ b/src/cbl-mariner/2.0/helix/amd64/Dockerfile
@@ -13,6 +13,7 @@ RUN tdnf install --setopt tsflags=nodocs --refresh -y \
          llvm \
          python3-pip \
          shadow-utils \
+         sudo \
          tar \
          tzdata \
          which \


### PR DESCRIPTION
Adding `sudo` makes it easier to work on container.