### PR TITLE
Remove timestamp tags for Azure Linux

### DIFF
--- a/src/azurelinux/manifest.json
+++ b/src/azurelinux/manifest.json
@@ -482,7 +482,6 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-helix-amd64$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
                 "azurelinux-3.0-helix-amd64": {}
               }
             }
@@ -496,7 +495,6 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-helix-arm64v8$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {},
                 "azurelinux-3.0-helix-arm64v8": {}
               },
               "variant": "v8"


### PR DESCRIPTION
Follow up to https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1178 for some tags that were missed.