### PR TITLE
Add Azure Linux tag names matching directory structure

### DIFF
--- a/src/azurelinux/3.0/net8.0/cross/amd64-alpine/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/cross/amd64-alpine/Dockerfile
@@ -1,12 +1,12 @@
 ARG ROOTFS_DIR=/crossrootfs/x64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-builder-net8.0-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder-local AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh x64 alpine3.13 --skipunmount
 
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-llvm-net8.0-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-llvm-local
 ARG ROOTFS_DIR
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR

--- a/src/azurelinux/3.0/net8.0/cross/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/cross/amd64/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/x64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-builder-net8.0-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder-local AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh x64 xenial --skipunmount
@@ -43,7 +43,7 @@ RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTI
     cp compiler-rt_build/lib/linux/libclang_rt.*-x86_64.a $SANITIZER_RUNTIMES_DIR
 
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-llvm-net8.0-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-llvm-local
 ARG ROOTFS_DIR
 ARG LLVM_VERSION_MAJOR=16
 

--- a/src/azurelinux/3.0/net8.0/cross/arm-alpine/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/cross/arm-alpine/Dockerfile
@@ -1,12 +1,12 @@
 ARG ROOTFS_DIR=/crossrootfs/arm
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-builder-net8.0-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder-local AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh arm alpine3.13 --skipunmount
 
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-llvm-net8.0-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-llvm-local
 ARG ROOTFS_DIR
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR

--- a/src/azurelinux/3.0/net8.0/cross/arm/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/cross/arm/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/arm
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-builder-net8.0-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder-local AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh arm xenial --skipunmount
@@ -43,7 +43,7 @@ RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTI
     cp compiler-rt_build/lib/linux/libclang_rt.*-armhf.a $SANITIZER_RUNTIMES_DIR
 
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-llvm-net8.0-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-llvm-local
 ARG ROOTFS_DIR
 ARG LLVM_VERSION_MAJOR=16
 

--- a/src/azurelinux/3.0/net8.0/cross/arm64-alpine/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/cross/arm64-alpine/Dockerfile
@@ -1,12 +1,12 @@
 ARG ROOTFS_DIR=/crossrootfs/arm64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-builder-net8.0-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder-local AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh arm64 alpine3.13 --skipunmount
 
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-llvm-net8.0-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-llvm-local
 ARG ROOTFS_DIR
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR

--- a/src/azurelinux/3.0/net8.0/cross/arm64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/cross/arm64/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/arm64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-builder-net8.0-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder-local AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh arm64 xenial --skipunmount
@@ -43,7 +43,7 @@ RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTI
     cp compiler-rt_build/lib/linux/libclang_rt.*-aarch64.a $SANITIZER_RUNTIMES_DIR
 
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-llvm-net8.0-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-llvm-local
 ARG ROOTFS_DIR
 ARG LLVM_VERSION_MAJOR=16
 

--- a/src/azurelinux/3.0/net8.0/cross/x86/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/cross/x86/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/x86
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-builder-net8.0-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder-local AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh x86 xenial --skipunmount
@@ -43,7 +43,7 @@ RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTI
     cp compiler-rt_build/lib/linux/libclang_rt.*-i386.a $SANITIZER_RUNTIMES_DIR
 
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-llvm-net8.0-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-llvm-local
 ARG ROOTFS_DIR
 ARG LLVM_VERSION_MAJOR=16
 

--- a/src/azurelinux/3.0/net8.0/crossdeps-llvm/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/crossdeps-llvm/amd64/Dockerfile
@@ -1,6 +1,6 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-builder-net8.0-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder-local AS builder
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-net8.0-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-local
 
 # Install LLVM that we built from source
 COPY --from=builder /usr/local /usr/local

--- a/src/azurelinux/3.0/net9.0/android/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/android/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-llvm-net9.0-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-local
 
 # Dependencies for Android build
 RUN tdnf update -y \

--- a/src/azurelinux/3.0/net9.0/android/docker/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/android/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-android-net9.0-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-android-local
 
 RUN tdnf update -y \
     && tdnf install -y \

--- a/src/azurelinux/3.0/net9.0/cross/amd64-alpine/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/amd64-alpine/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/x64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-builder-net9.0-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-local AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh x64 alpine3.13 --skipunmount
@@ -30,7 +30,7 @@ RUN TARGET_TRIPLE="x86_64-alpine-linux-musl" && \
     cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
     cmake --install runtimes --prefix "$ROOTFS_DIR/usr"
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-llvm-net9.0-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-local
 ARG ROOTFS_DIR
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR

--- a/src/azurelinux/3.0/net9.0/cross/amd64-sanitizer/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/amd64-sanitizer/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/x64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-builder-net9.0-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-local AS builder
 ARG ROOTFS_DIR
 
 # Use Ubuntu Bionic as the base image for the rootfs
@@ -41,7 +41,7 @@ RUN TARGET_TRIPLE="x86_64-linux-gnu" && \
     cmake --build runtimes -j && \
     cmake --install runtimes --prefix "$ROOTFS_DIR/usr"
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-llvm-net9.0-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-local
 ARG ROOTFS_DIR
 
 COPY --from=builder /usr/local/lib/clang /usr/local/lib/clang

--- a/src/azurelinux/3.0/net9.0/cross/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/amd64/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/x64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-builder-net9.0-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-local AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh x64 xenial --skipunmount
@@ -39,7 +39,7 @@ RUN TARGET_TRIPLE="x86_64-linux-gnu" && \
     cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
     cmake --install runtimes --prefix "$ROOTFS_DIR/usr"
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-llvm-net9.0-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-local
 ARG ROOTFS_DIR
 
 COPY --from=builder /usr/local/lib/clang /usr/local/lib/clang/

--- a/src/azurelinux/3.0/net9.0/cross/android/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/android/amd64/Dockerfile
@@ -1,6 +1,6 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-cross-amd64-net9.0-local AS crossrootx64
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-cross-amd64-local AS crossrootx64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-android-net9.0-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-android-local
 
 # Copy crossrootfs from AMD64 build image, so we can build Android-targeting code for that arch
 COPY --from=crossrootx64 /crossrootfs/x64 /crossrootfs/x64

--- a/src/azurelinux/3.0/net9.0/cross/android/openssl/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/android/openssl/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-cross-android-amd64-net9.0-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-cross-android-amd64-local
 
 # Copy the OpenSSL headers and libs from the x64 rootfs into the Anroid NDK so dotnet/runtime's
 # OpenSSL headers hack can find them for the linux-bionic build.

--- a/src/azurelinux/3.0/net9.0/cross/arm-alpine/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/arm-alpine/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/arm
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-builder-net9.0-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-local AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh arm alpine3.13 --skipunmount
@@ -30,7 +30,7 @@ RUN TARGET_TRIPLE="armv7-alpine-linux-musleabihf" && \
     cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
     cmake --install runtimes --prefix "$ROOTFS_DIR/usr"
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-llvm-net9.0-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-local
 ARG ROOTFS_DIR
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR

--- a/src/azurelinux/3.0/net9.0/cross/arm/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/arm/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/arm
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-builder-net9.0-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-local AS builder
 ARG ROOTFS_DIR
 
 # The arm rootfs targets Ubuntu 22.04, which is the first version with a
@@ -41,7 +41,7 @@ RUN TARGET_TRIPLE="arm-linux-gnueabihf" && \
     cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
     cmake --install runtimes --prefix "$ROOTFS_DIR/usr"
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-llvm-net9.0-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-local
 ARG ROOTFS_DIR
 
 COPY --from=builder /usr/local/lib/clang /usr/local/lib/clang/

--- a/src/azurelinux/3.0/net9.0/cross/arm64-alpine/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/arm64-alpine/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/arm64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-builder-net9.0-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-local AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh arm64 alpine3.13 --skipunmount
@@ -30,7 +30,7 @@ RUN TARGET_TRIPLE="aarch64-alpine-linux-musl" && \
     cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
     cmake --install runtimes --prefix "$ROOTFS_DIR/usr"
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-llvm-net9.0-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-local
 ARG ROOTFS_DIR
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR

--- a/src/azurelinux/3.0/net9.0/cross/arm64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/arm64/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/arm64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-builder-net9.0-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-local AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh arm64 xenial --skipunmount
@@ -41,7 +41,7 @@ RUN TARGET_TRIPLE="aarch64-linux-gnu" && \
     cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
     cmake --install runtimes --prefix "$ROOTFS_DIR/usr"
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-llvm-net9.0-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-local
 ARG ROOTFS_DIR
 
 COPY --from=builder /usr/local/lib/clang /usr/local/lib/clang/

--- a/src/azurelinux/3.0/net9.0/cross/armv6/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/armv6/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/armv6
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-builder-net9.0-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-local AS builder
 ARG ROOTFS_DIR
 
 # Install raspbian package signing keys
@@ -12,7 +12,7 @@ RUN wget http://raspbian.raspberrypi.org/raspbian/pool/main/r/raspbian-archive-k
 
 RUN /scripts/eng/common/cross/build-rootfs.sh armv6 bookworm lldb13
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-llvm-net9.0-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-local
 ARG ROOTFS_DIR
 
 COPY --from=builder "$ROOTFS_DIR" "$ROOTFS_DIR"

--- a/src/azurelinux/3.0/net9.0/cross/freebsd/13/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/freebsd/13/amd64/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/x64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-builder-net9.0-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-local AS builder
 ARG ROOTFS_DIR
 
 # Install packages needed by the FreeBSD bootstrap scripts
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 RUN /scripts/eng/common/cross/build-rootfs.sh freebsd13 x64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-llvm-net9.0-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-local
 ARG ROOTFS_DIR
 
 COPY --from=builder "$ROOTFS_DIR" "$ROOTFS_DIR"

--- a/src/azurelinux/3.0/net9.0/cross/ppc64le/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/ppc64le/Dockerfile
@@ -1,11 +1,11 @@
 ARG ROOTFS_DIR=/crossrootfs/ppc64le
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-builder-net9.0-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-local AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh bionic ppc64le
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-llvm-net9.0-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-local
 ARG ROOTFS_DIR
 
 COPY --from=builder "$ROOTFS_DIR" "$ROOTFS_DIR"

--- a/src/azurelinux/3.0/net9.0/cross/riscv64-alpine/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/riscv64-alpine/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/riscv64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-builder-net9.0-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-local AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh riscv64 alpine3.20 --skipunmount
@@ -30,7 +30,7 @@ RUN TARGET_TRIPLE="riscv64-alpine-linux-musl" && \
     cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
     cmake --install runtimes --prefix "$ROOTFS_DIR/usr"
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-llvm-net9.0-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-local
 ARG ROOTFS_DIR
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR

--- a/src/azurelinux/3.0/net9.0/cross/riscv64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/riscv64/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/riscv64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-builder-net9.0-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-local AS builder
 ARG ROOTFS_DIR
 
 # Install the latest debootstrap
@@ -47,7 +47,7 @@ RUN TARGET_TRIPLE="riscv64-linux-gnu" && \
     cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
     cmake --install runtimes --prefix "$ROOTFS_DIR/usr"
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-llvm-net9.0-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-local
 ARG ROOTFS_DIR
 
 COPY --from=builder /usr/local/lib/clang /usr/local/lib/clang/

--- a/src/azurelinux/3.0/net9.0/cross/s390x/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/s390x/Dockerfile
@@ -1,11 +1,11 @@
 ARG ROOTFS_DIR=/crossrootfs/s390x
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-builder-net9.0-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-local AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh bionic s390x
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-llvm-net9.0-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-local
 ARG ROOTFS_DIR
 
 COPY --from=builder "$ROOTFS_DIR" "$ROOTFS_DIR"

--- a/src/azurelinux/3.0/net9.0/cross/x86/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/x86/Dockerfile
@@ -1,13 +1,13 @@
 ARG ROOTFS_DIR=/crossrootfs/x86
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-builder-net9.0-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-local AS builder
 ARG ROOTFS_DIR
 
 # We don't ship linux-x86 binaries, so we don't need to make a custom libc++ build for servicing concerns.
 # We don't sanitize or instrument the linux-x64 build (as we don't ship it), so we don't need to build those runtime support libraries either.
 RUN /scripts/eng/common/cross/build-rootfs.sh x86 xenial --skipunmount
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-llvm-net9.0-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-local
 ARG ROOTFS_DIR
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR

--- a/src/azurelinux/3.0/net9.0/crossdeps-llvm/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/crossdeps-llvm/amd64/Dockerfile
@@ -1,6 +1,6 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-builder-net9.0-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-local AS builder
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-crossdeps-net9.0-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-local
 
 # Install LLVM that we built from source
 COPY --from=builder /usr/local /usr/local

--- a/src/azurelinux/3.0/net9.0/webassembly/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/webassembly/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-cross-amd64-net9.0-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-cross-amd64-local
 
 # Dependencies for WebAssembly build
 RUN tdnf update -y \

--- a/src/azurelinux/manifest.json
+++ b/src/azurelinux/manifest.json
@@ -11,7 +11,8 @@
               "osVersion": "azurelinux3.0",
               "tags": {
                 "azurelinux-3.0-crossdeps-net8.0": {},
-                "azurelinux-3.0-crossdeps-net8.0-local": {
+                "azurelinux-3.0-net8.0-crossdeps": {},
+                "azurelinux-3.0-net8.0-crossdeps-local": {
                   "isLocal": true
                 }
               }
@@ -26,7 +27,8 @@
               "osVersion": "azurelinux3.0",
               "tags": {
                 "azurelinux-3.0-crossdeps-net9.0": {},
-                "azurelinux-3.0-crossdeps-net9.0-local": {
+                "azurelinux-3.0-net9.0-crossdeps": {},
+                "azurelinux-3.0-net9.0-crossdeps-local": {
                   "isLocal": true
                 }
               }
@@ -41,7 +43,8 @@
               "osVersion": "azurelinux3.0",
               "tags": {
                 "azurelinux-3.0-crossdeps-builder-net8.0": {},
-                "azurelinux-3.0-crossdeps-builder-net8.0-local": {
+                "azurelinux-3.0-net8.0-crossdeps-builder": {},
+                "azurelinux-3.0-net8.0-crossdeps-builder-local": {
                   "isLocal": true
                 }
               }
@@ -56,7 +59,8 @@
               "osVersion": "azurelinux3.0",
               "tags": {
                 "azurelinux-3.0-crossdeps-llvm-net8.0": {},
-                "azurelinux-3.0-crossdeps-llvm-net8.0-local": {
+                "azurelinux-3.0-net8.0-crossdeps-llvm": {},
+                "azurelinux-3.0-net8.0-crossdeps-llvm-local": {
                   "isLocal": true
                 }
               }
@@ -71,7 +75,8 @@
               "osVersion": "azurelinux3.0",
               "tags": {
                 "azurelinux-3.0-cross-amd64-net8.0": {},
-                "azurelinux-3.0-cross-amd64-net8.0-local": {
+                "azurelinux-3.0-net8.0-cross-amd64": {},
+                "azurelinux-3.0-net8.0-cross-amd64-local": {
                   "isLocal": true
                 }
               }
@@ -86,7 +91,8 @@
               "osVersion": "azurelinux3.0",
               "tags": {
                 "azurelinux-3.0-cross-amd64-alpine-net8.0": {},
-                "azurelinux-3.0-cross-amd64-alpine-net8.0-local": {
+                "azurelinux-3.0-net8.0-cross-amd64-alpine": {},
+                "azurelinux-3.0-net8.0-cross-amd64-alpine-local": {
                   "isLocal": true
                 }
               }
@@ -100,7 +106,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-cross-arm-net8.0": {}
+                "azurelinux-3.0-cross-arm-net8.0": {},
+                "azurelinux-3.0-net8.0-cross-arm": {}
               }
             }
           ]
@@ -112,7 +119,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-cross-arm-alpine-net8.0": {}
+                "azurelinux-3.0-cross-arm-alpine-net8.0": {},
+                "azurelinux-3.0-net8.0-cross-arm-alpine": {}
               }
             }
           ]
@@ -125,7 +133,8 @@
               "osVersion": "azurelinux3.0",
               "tags": {
                 "azurelinux-3.0-cross-arm64-net8.0": {},
-                "azurelinux-3.0-cross-arm64-net8.0-local": {
+                "azurelinux-3.0-net8.0-cross-arm64": {},
+                "azurelinux-3.0-net8.0-cross-arm64-local": {
                   "isLocal": true
                 }
               }
@@ -140,7 +149,8 @@
               "osVersion": "azurelinux3.0",
               "tags": {
                 "azurelinux-3.0-cross-arm64-alpine-net8.0": {},
-                "azurelinux-3.0-cross-arm64-alpine-net8.0-local": {
+                "azurelinux-3.0-net8.0-cross-arm64-alpine": {},
+                "azurelinux-3.0-net8.0-cross-arm64-alpine-local": {
                   "isLocal": true
                 }
               }
@@ -154,7 +164,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-cross-x86-net8.0": {}
+                "azurelinux-3.0-cross-x86-net8.0": {},
+                "azurelinux-3.0-net8.0-cross-x86": {}
               }
             }
           ]
@@ -166,7 +177,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-fpm-net9.0": {}
+                "azurelinux-3.0-fpm-net9.0": {},
+                "azurelinux-3.0-net9.0-fpm": {}
               }
             }
           ]
@@ -179,7 +191,8 @@
               "osVersion": "azurelinux3.0",
               "tags": {
                 "azurelinux-3.0-crossdeps-builder-net9.0": {},
-                "azurelinux-3.0-crossdeps-builder-net9.0-local": {
+                "azurelinux-3.0-net9.0-crossdeps-builder": {},
+                "azurelinux-3.0-net9.0-crossdeps-builder-local": {
                   "isLocal": true
                 }
               }
@@ -194,7 +207,8 @@
               "osVersion": "azurelinux3.0",
               "tags": {
                 "azurelinux-3.0-crossdeps-llvm-net9.0": {},
-                "azurelinux-3.0-crossdeps-llvm-net9.0-local": {
+                "azurelinux-3.0-net9.0-crossdeps-llvm": {},
+                "azurelinux-3.0-net9.0-crossdeps-llvm-local": {
                   "isLocal": true
                 }
               }
@@ -208,7 +222,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-cross-riscv64-net9.0": {}
+                "azurelinux-3.0-cross-riscv64-net9.0": {},
+                "azurelinux-3.0-net9.0-cross-riscv64": {}
               }
             }
           ]
@@ -219,7 +234,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-cross-riscv64-alpine-net9.0": {}
+                "azurelinux-3.0-cross-riscv64-alpine-net9.0": {},
+                "azurelinux-3.0-net9.0-cross-riscv64-alpine": {}
               }
             }
           ]
@@ -232,7 +248,8 @@
               "osVersion": "azurelinux3.0",
               "tags": {
                 "azurelinux-3.0-cross-amd64-net9.0": {},
-                "azurelinux-3.0-cross-amd64-net9.0-local": {
+                "azurelinux-3.0-net9.0-cross-amd64": {},
+                "azurelinux-3.0-net9.0-cross-amd64-local": {
                   "isLocal": true
                 }
               }
@@ -247,7 +264,8 @@
               "osVersion": "azurelinux3.0",
               "tags": {
                 "azurelinux-3.0-cross-amd64-net9.0-sanitizer": {},
-                "azurelinux-3.0-cross-amd64-net9.0-sanitizer-local": {
+                "azurelinux-3.0-net9.0-cross-amd64-sanitizer": {},
+                "azurelinux-3.0-net9.0-cross-amd64-sanitizer-local": {
                   "isLocal": true
                 }
               }
@@ -262,7 +280,8 @@
               "osVersion": "azurelinux3.0",
               "tags": {
                 "azurelinux-3.0-cross-amd64-alpine-net9.0": {},
-                "azurelinux-3.0-cross-amd64-alpine-net9.0-local": {
+                "azurelinux-3.0-net9.0-cross-amd64-alpine": {},
+                "azurelinux-3.0-net9.0-cross-amd64-alpine-local": {
                   "isLocal": true
                 }
               }
@@ -276,7 +295,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-cross-arm-net9.0": {}
+                "azurelinux-3.0-cross-arm-net9.0": {},
+                "azurelinux-3.0-net9.0-cross-arm": {}
               }
             }
           ]
@@ -288,7 +308,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-cross-arm-alpine-net9.0": {}
+                "azurelinux-3.0-cross-arm-alpine-net9.0": {},
+                "azurelinux-3.0-net9.0-cross-arm-alpine": {}
               }
             }
           ]
@@ -301,7 +322,8 @@
               "osVersion": "azurelinux3.0",
               "tags": {
                 "azurelinux-3.0-cross-arm64-net9.0": {},
-                "azurelinux-3.0-cross-arm64-net9.0-local": {
+                "azurelinux-3.0-net9.0-cross-arm64": {},
+                "azurelinux-3.0-net9.0-cross-arm64-local": {
                   "isLocal": true
                 }
               }
@@ -316,7 +338,8 @@
               "osVersion": "azurelinux3.0",
               "tags": {
                 "azurelinux-3.0-cross-arm64-alpine-net9.0": {},
-                "azurelinux-3.0-cross-arm64-alpine-net9.0-local": {
+                "azurelinux-3.0-net9.0-cross-arm64-alpine": {},
+                "azurelinux-3.0-net9.0-cross-arm64-alpine-local": {
                   "isLocal": true
                 }
               }
@@ -330,7 +353,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-cross-x86-net9.0": {}
+                "azurelinux-3.0-cross-x86-net9.0": {},
+                "azurelinux-3.0-net9.0-cross-x86": {}
               }
             }
           ]
@@ -342,7 +366,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-webassembly-amd64-net9.0": {}
+                "azurelinux-3.0-webassembly-amd64-net9.0": {},
+                "azurelinux-3.0-net9.0-webassembly-amd64": {}
               }
             }
           ]
@@ -355,7 +380,8 @@
               "osVersion": "azurelinux3.0",
               "tags": {
                 "azurelinux-3.0-android-net9.0": {},
-                "azurelinux-3.0-android-net9.0-local": {
+                "azurelinux-3.0-net9.0-android": {},
+                "azurelinux-3.0-net9.0-android-local": {
                   "isLocal": true
                     }
                   }
@@ -370,7 +396,8 @@
               "osVersion": "azurelinux3.0",
               "tags": {
                 "azurelinux-3.0-cross-android-amd64-net9.0": {},
-                "azurelinux-3.0-cross-android-amd64-net9.0-local": {
+                "azurelinux-3.0-net9.0-cross-android-amd64": {},
+                "azurelinux-3.0-net9.0-cross-android-amd64-local": {
                   "isLocal": true
                 }
               }
@@ -384,7 +411,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-android-docker-net9.0": {}
+                "azurelinux-3.0-android-docker-net9.0": {},
+                "azurelinux-3.0-net9.0-android-docker": {}
               }
             }
           ]
@@ -396,7 +424,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-android-openssl-net9.0": {}
+                "azurelinux-3.0-android-openssl-net9.0": {},
+                "azurelinux-3.0-net9.0-android-openssl": {}
               }
             }
           ]
@@ -408,7 +437,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-cross-freebsd-13-net9.0": {}
+                "azurelinux-3.0-cross-freebsd-13-net9.0": {},
+                "azurelinux-3.0-net9.0-cross-freebsd-13": {}
               }
             }
           ]
@@ -420,7 +450,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-cross-s390x-net9.0": {}
+                "azurelinux-3.0-cross-s390x-net9.0": {},
+                "azurelinux-3.0-net9.0-cross-s390x": {}
               }
             }
           ]
@@ -432,7 +463,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-cross-ppc64le-net9.0": {}
+                "azurelinux-3.0-cross-ppc64le-net9.0": {},
+                "azurelinux-3.0-net9.0-cross-ppc64le": {}
               }
             }
           ]
@@ -444,7 +476,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-cross-armv6-net9.0": {}
+                "azurelinux-3.0-cross-armv6-net9.0": {},
+                "azurelinux-3.0-net9.0-cross-armv6": {}
               }
             }
           ]
@@ -456,7 +489,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-opt-amd64-net9.0": {}
+                "azurelinux-3.0-opt-amd64-net9.0": {},
+                "azurelinux-3.0-net9.0-opt-amd64": {}
               }
             }
           ]
@@ -469,7 +503,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-opt-arm64-net9.0": {}
+                "azurelinux-3.0-opt-arm64-net9.0": {},
+                "azurelinux-3.0-net9.0-opt-arm64": {}
               }
             }
           ]


### PR DESCRIPTION
The isLocal images have been renamed, and the others have had new tags added so that we can migrate before removing the old tags.

See https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/1176. I'll leave that issue open until we remove the old tags.