### PR TITLE
Add Linter GH action

### DIFF
--- a/.github/linters/.hadolint.yaml
+++ b/.github/linters/.hadolint.yaml
@@ -1,0 +1,1 @@
+failure-threshold: error

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,31 @@
+name: Lint Code Base
+
+on:
+  pull_request: null
+
+permissions: {}
+
+jobs:
+  run-lint:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: read
+      # To report GitHub Actions status checks
+      statuses: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+      - name: Lint Code Base
+        uses: github/super-linter@v6 # https://github.com/github/super-linter
+        env:
+          DEFAULT_BRANCH: main
+          FILTER_REGEX_EXCLUDE: eng/common/.*
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_DOCKERFILE_HADOLINT: true
+          VALIDATE_MARKDOWN: true


### PR DESCRIPTION
Related to https://github.com/dotnet/docker-tools/issues/1172

The initial state will link MD and Dockerfiles.  The threshold for Dockerfiles is set to errors.  We may want to consider lowering this to warnings as there are some good warnings we should respect.  That will require numerous fixups which should be done in a separate PR.