### PR TITLE
Address Dockerfile linter warnings

### DIFF
--- a/src/almalinux/8/helix/amd64/Dockerfile
+++ b/src/almalinux/8/helix/amd64/Dockerfile
@@ -13,7 +13,8 @@ RUN rpm -Uvh https://packages.microsoft.com/config/centos/8/packages-microsoft-p
         # Required for asp.net core test runs
         sudo \
         libicu \
-        libmsquic
+        libmsquic && \
+    yum clean all
 
 RUN python3 -m pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
     python3 -m pip install ./helix_scripts-*-py3-none-any.whl

--- a/src/centos/stream9/mlnet/helix/Dockerfile
+++ b/src/centos/stream9/mlnet/helix/Dockerfile
@@ -58,7 +58,10 @@ RUN dnf install --setopt tsflags=nodocs --refresh -y \
     && \
     dnf clean all
 
-RUN dnf install perl-FindBin --setopt tsflags=nodocs --refresh -y
+RUN dnf install --setopt tsflags=nodocs --refresh -y \
+        perl-FindBin \
+    && \
+    dnf clean all
 
 # Install openmp from llvm 3.9.1.
 RUN wget http://releases.llvm.org/3.9.1/openmp-3.9.1.src.tar.xz

--- a/src/ubuntu/20.04/webassembly-net8/amd64/Dockerfile
+++ b/src/ubuntu/20.04/webassembly-net8/amd64/Dockerfile
@@ -14,9 +14,9 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 ENV CMAKE_VERSION=3.17
-RUN wget https://cmake.org/files/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}.0-Linux-x86_64.tar.gz \
-    && tar -xf cmake-${CMAKE_VERSION}.0-Linux-x86_64.tar.gz --strip 1 -C /usr/local \
-    && rm cmake-${CMAKE_VERSION}.0-Linux-x86_64.tar.gz
+RUN curl -sSL https://cmake.org/files/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}.0-Linux-x86_64.tar.gz -o cmake.tar.gz \
+    && tar -xf cmake.tar.gz --strip 1 -C /usr/local \
+    && rm cmake.tar.gz
 
 # WebAssembly build needs working UTF-8 locale
 RUN locale-gen en_US.UTF-8

--- a/src/ubuntu/20.04/webassembly/amd64/Dockerfile
+++ b/src/ubuntu/20.04/webassembly/amd64/Dockerfile
@@ -14,9 +14,9 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 ENV CMAKE_VERSION=3.17
-RUN wget https://cmake.org/files/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}.0-Linux-x86_64.tar.gz \
-    && tar -xf cmake-${CMAKE_VERSION}.0-Linux-x86_64.tar.gz --strip 1 -C /usr/local \
-    && rm cmake-${CMAKE_VERSION}.0-Linux-x86_64.tar.gz
+RUN curl -sSL https://cmake.org/files/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}.0-Linux-x86_64.tar.gz -o cmake.tar.gz \
+    && tar -xf cmake.tar.gz --strip 1 -C /usr/local \
+    && rm cmake.tar.gz
 
 # WebAssembly build needs working UTF-8 locale
 RUN locale-gen en_US.UTF-8

--- a/src/ubuntu/22.04/Dockerfile
+++ b/src/ubuntu/22.04/Dockerfile
@@ -43,7 +43,7 @@ RUN apt-get update \
     && mkdir -p /etc/apt/keyrings \
     && curl -sLS https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/keyrings/microsoft.gpg > /dev/null \ 
     && chmod go+r /etc/apt/keyrings/microsoft.gpg \
-    && echo "deb [arch=`dpkg --print-architecture` signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/azure-cli.list \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/azure-cli.list \
     && apt-get update \
     && apt-get install -y azure-cli \
     && rm -rf /var/lib/apt/lists/*

--- a/src/ubuntu/24.04/Dockerfile
+++ b/src/ubuntu/24.04/Dockerfile
@@ -62,10 +62,9 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Remove older version of node & install node 20
-RUN cd /etc/apt/sources.list.d  && \
-    rm -f nodesource.list && \
-    apt --fix-broken install && \
-    apt update && \
+RUN rm -f /etc/apt/sources.list.d/nodesource.list && \
+    apt-get --fix-broken install && \
+    apt-get update && \
     apt-get remove nodejs -y && \
     apt-get remove nodejs-doc -y && \
     apt-get remove libnode-dev -y


### PR DESCRIPTION
Some linter warnings that seemed worthwhile to fix.

- Package installation without appropriate cache cleanup
- Either use Wget or Curl but not both.
- Do not use apt as it is meant to be an end-user tool, use apt-get or apt-cache instead
- Use WORKDIR to switch to a directory.
- Use $(...) notation instead of legacy backticked `...`.