### PR TITLE
Add support for specifing multiple build paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,24 +41,38 @@ The following steps are a guideline for modifying/creating Dockerfiles.
         Team code owners must be assigned to each Dockerfile for maintenance and issue assignment purposes.
 
 2. Validate the changes locally by running [build.ps1](./build.ps1).
-It is strongly suggested to specify the `-DockerfilePath` option to avoid the overhead of building all the images.
+It is strongly suggested to specify the `-Paths` option to avoid the overhead of building all the images.
 
     For example, if editing the [Fedora 40 Dockerfile](./src/fedora/40/amd64/Dockerfile), then run the following command to build just that Dockerfile.
 
     ```powershell
-    .\build.ps1 -DockerfilePath "*fedora/40/amd64*"
+    .\build.ps1 -Paths "*fedora/40/amd64*"
     ```
 
     It is a good practice to use `--dry-run` option on the first attempt to verify what commands will get run.
 
     ```powershell
-    .\build.ps1 -DockerfilePath "*fedora/40/amd64*" -ImageBuilderCustomArgs "--dry-run"
+    .\build.ps1 -Paths "*fedora/40/amd64*" -OptionalImageBuilderArgs "--dry-run"
     ```
 
-    Partial paths and wildcards in the `-DockerfilePath` option are also supported.  The following example will build all the Fedora Dockerfiles.
+    Partial paths and wildcards in the `-Paths` option are also supported.  The following example will build all the Fedora Dockerfiles.
 
     ```powershell
-    .\build.ps1 -DockerfilePath "*fedora/*"
+    .\build.ps1 -Paths "*fedora/*"
+    ```
+
+    To build a dependency graph when there are [dependent images](#image-dependency), multiple paths can be specified.
+
+    ```powershell
+    .\build.ps1 -Paths "*alpine/3.20/amd64*","*alpine/3.20/withnode/amd64*"
+    ```
+
+     Alternatively, wildcards can by utilized to specify everything under a shared directory.
+     Using wildcards can sometimes cause extra images to be built outside of the dependency graph which may be undersirable.
+     In this case, it is recommended to utilize the multiple `paths` approach.
+
+    ```powershell
+    .\build.ps1 -Paths "*alpine/3.20*"
     ```
 
 3. Prepare a PR

--- a/build.ps1
+++ b/build.ps1
@@ -1,14 +1,17 @@
 [cmdletbinding()]
 param(
-    [string]$DockerfilePath = "*",
-    [string]$ImageBuilderCustomArgs
+    # Paths to the Dockerfiles to build
+    [string[]]$Paths,
+
+     # Additional args to pass to ImageBuilder
+    [string]$OptionalImageBuilderArgs
 )
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 pushd $PSScriptRoot
 try {
-    ./eng/common/Invoke-ImageBuilder.ps1 "build --path '$DockerfilePath' $ImageBuilderCustomArgs"
+    ./eng/common/build.ps1 -Paths $Paths -OptionalImageBuilderArgs $OptionalImageBuilderArgs
 }
 finally {
     popd


### PR DESCRIPTION
This PR is in response to [this comment](https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1178#discussion_r1718969554).

Modified the build script to support multiple dockerfile paths.  I in essence updated the entry build script to expose what was already supported in the eng/common build script.  

This is a breaking change from the dev UX perspective.

Fixes https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/1168