### PR TITLE
Use prod feed for Azure Linux 3.0

### DIFF
--- a/src/azurelinux/3.0/net8.0/crossdeps-builder/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/crossdeps-builder/amd64/Dockerfile
@@ -24,7 +24,7 @@ RUN tdnf install -y \
         openssl-devel
 
 # dependencies which are installed from extended repo require additional setup
-RUN wget https://packages.microsoft.com/azurelinux/3.0/preview/extended/x86_64/config.repo -O /etc/yum.repos.d/azurelinux-extended.repo && \
+RUN wget https://packages.microsoft.com/azurelinux/3.0/prod/extended/x86_64/config.repo -O /etc/yum.repos.d/azurelinux-extended.repo && \
     tdnf makecache && \
     tdnf install -y \
         libbsd-devel

--- a/src/azurelinux/3.0/net9.0/crossdeps-builder/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/crossdeps-builder/amd64/Dockerfile
@@ -24,7 +24,7 @@ RUN tdnf install -y \
         openssl-devel
 
 # dependencies which are installed from extended repo require additional setup
-RUN wget https://packages.microsoft.com/azurelinux/3.0/preview/extended/x86_64/config.repo -O /etc/yum.repos.d/azurelinux-extended.repo && \
+RUN wget https://packages.microsoft.com/azurelinux/3.0/prod/extended/x86_64/config.repo -O /etc/yum.repos.d/azurelinux-extended.repo && \
     tdnf makecache && \
     tdnf install -y \
         libbsd-devel


### PR DESCRIPTION
Builds of the Azure Linux 3.0 crossdeps builder Dockerfiles are failing with the following error:

```
#7 [3/8] RUN wget https://packages.microsoft.com/azurelinux/3.0/preview/extended/x86_64/config.repo -O /etc/yum.repos.d/azurelinux-extended.repo &&     tdnf makecache &&     tdnf install -y         libbsd-devel
#7 0.488 [0] Downloading 'https://packages.microsoft.com/azurelinux/3.0/preview/extended/x86_64/config.repo' ...
#7 0.488 Saving '/etc/yum.repos.d/azurelinux-extended.repo'
#7 0.488 HTTP response 200  [https://packages.microsoft.com/azurelinux/3.0/preview/extended/x86_64/config.repo]
#7 0.496 Loaded plugin: tdnfrepogpgcheck
#7 1.003 Refreshing metadata for: 'Azure Linux Official Microsoft Open-Source 3.0 x86_64'
#7 1.585 Refreshing metadata for: 'Azure Linux Official Base 3.0 x86_64'
#7 1.924 Refreshing metadata for: 'Azure Linux Official Microsoft Non-Open-Source 3.0 x86_64'
#7 2.347 Refreshing metadata for: 'azurelinux/3.0/preview/extended/x86_64'
#7 2.977 Metadata cache created.
#7 2.987 Loaded plugin: tdnfrepogpgcheck
#7 3.034 libbsd-devel package not found or not installed
#7 3.034 Error(1011) : No matching packages
```

The issue is that the command in the Dockerfile is configuring a feed that targets the `preview` feed. Azure Linux 3.0 is no longer in preview. Updating this to `prod` fixes the issue.