### PR TITLE
Remove use of local tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,29 +220,6 @@ Each Dockerfile will have an entry that looks like the following.
 > [!Note]
 > The position in manifest determines the sequence in which the image will be built.
 
-### Image Dependency
-
-A precondition for building an image is to ensure that the base image specified in the [FROM](https://docs.docker.com/engine/reference/builder/#from) statement of the Dockerfile is available either locally or can be pulled from a container registry.
-Some of the Dockerfiles depend on images produced from other Dockerfiles (e.g. [src/ubuntu/22.04/debpkg/amd64/Dockerfile](./src/ubuntu/22.04/debpkg/amd64/Dockerfile)).
-In these cases, the `FROM` reference should be to a `local` tag (e.g. `mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-local`).
-To support this scenario, the manifest entry for the base image must be defined to produce the `local` tag.
-
-```json
-"platforms": [
-  {
-    "dockerfile": "src/ubuntu/22.04",
-    "os": "linux",
-    "osVersion": "jammy",
-    "tags": {
-      "ubuntu-22.04": {},
-      "ubuntu-22.04-local": {
-        "isLocal": true
-      }
-    }
-  }
-]
-```
-
 ### Code Owner Responsibilities
 
 - **Code reviews** - Code review all changes made to the owned Dockerfiles.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ It is strongly suggested to specify the `-Paths` option to avoid the overhead of
     .\build.ps1 -Paths "*fedora/*"
     ```
 
-    To build a dependency graph when there are [dependent images](#image-dependency), multiple paths can be specified.
+    To build a dependency graph when there are dependent images, multiple paths can be specified.
 
     ```powershell
     .\build.ps1 -Paths "*alpine/3.20/amd64*","*alpine/3.20/withnode/amd64*"

--- a/src/alpine/3.18/WithNode/amd64/Dockerfile
+++ b/src/alpine/3.18/WithNode/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.18-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.18
 
 RUN apk add --upgrade --no-cache \
         nodejs \

--- a/src/alpine/3.19/WithNode/amd64/Dockerfile
+++ b/src/alpine/3.19/WithNode/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19
 
 RUN apk add --upgrade --no-cache \
         nodejs \

--- a/src/alpine/3.20/withnode/amd64/Dockerfile
+++ b/src/alpine/3.20/withnode/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.20-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.20
 
 RUN apk add --upgrade --no-cache \
         nodejs \

--- a/src/alpine/manifest.json
+++ b/src/alpine/manifest.json
@@ -10,10 +10,7 @@
               "os": "linux",
               "osVersion": "alpine3.17",
               "tags": {
-                "alpine-3.17": {},
-                "alpine-3.17-local": {
-                  "isLocal": true
-                }
+                "alpine-3.17": {}
               }
             }
           ]
@@ -107,10 +104,7 @@
               "os": "linux",
               "osVersion": "alpine3.18",
               "tags": {
-                "alpine-3.18": {},
-                "alpine-3.18-local": {
-                  "isLocal": true
-                }
+                "alpine-3.18": {}
               }
             }
           ]
@@ -134,10 +128,7 @@
               "os": "linux",
               "osVersion": "alpine3.19",
               "tags": {
-                "alpine-3.19": {},
-                "alpine-3.19-local": {
-                  "isLocal": true
-                }
+                "alpine-3.19": {}
               }
             }
           ]
@@ -202,10 +193,7 @@
               "os": "linux",
               "osVersion": "alpine3.20",
               "tags": {
-                "alpine-3.20": {},
-                "alpine-3.20-local": {
-                  "isLocal": true
-                }
+                "alpine-3.20": {}
               }
             }
           ]

--- a/src/azurelinux/3.0/net8.0/cross/amd64-alpine/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/cross/amd64-alpine/Dockerfile
@@ -1,12 +1,12 @@
 ARG ROOTFS_DIR=/crossrootfs/x64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh x64 alpine3.13 --skipunmount
 
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-llvm
 ARG ROOTFS_DIR
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR

--- a/src/azurelinux/3.0/net8.0/cross/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/cross/amd64/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/x64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh x64 xenial --skipunmount
@@ -43,7 +43,7 @@ RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTI
     cp compiler-rt_build/lib/linux/libclang_rt.*-x86_64.a $SANITIZER_RUNTIMES_DIR
 
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-llvm
 ARG ROOTFS_DIR
 ARG LLVM_VERSION_MAJOR=16
 

--- a/src/azurelinux/3.0/net8.0/cross/arm-alpine/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/cross/arm-alpine/Dockerfile
@@ -1,12 +1,12 @@
 ARG ROOTFS_DIR=/crossrootfs/arm
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh arm alpine3.13 --skipunmount
 
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-llvm
 ARG ROOTFS_DIR
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR

--- a/src/azurelinux/3.0/net8.0/cross/arm/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/cross/arm/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/arm
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh arm xenial --skipunmount
@@ -43,7 +43,7 @@ RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTI
     cp compiler-rt_build/lib/linux/libclang_rt.*-armhf.a $SANITIZER_RUNTIMES_DIR
 
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-llvm
 ARG ROOTFS_DIR
 ARG LLVM_VERSION_MAJOR=16
 

--- a/src/azurelinux/3.0/net8.0/cross/arm64-alpine/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/cross/arm64-alpine/Dockerfile
@@ -1,12 +1,12 @@
 ARG ROOTFS_DIR=/crossrootfs/arm64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh arm64 alpine3.13 --skipunmount
 
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-llvm
 ARG ROOTFS_DIR
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR

--- a/src/azurelinux/3.0/net8.0/cross/arm64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/cross/arm64/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/arm64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh arm64 xenial --skipunmount
@@ -43,7 +43,7 @@ RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTI
     cp compiler-rt_build/lib/linux/libclang_rt.*-aarch64.a $SANITIZER_RUNTIMES_DIR
 
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-llvm
 ARG ROOTFS_DIR
 ARG LLVM_VERSION_MAJOR=16
 

--- a/src/azurelinux/3.0/net8.0/cross/x86/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/cross/x86/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/x86
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh x86 xenial --skipunmount
@@ -43,7 +43,7 @@ RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTI
     cp compiler-rt_build/lib/linux/libclang_rt.*-i386.a $SANITIZER_RUNTIMES_DIR
 
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-llvm
 ARG ROOTFS_DIR
 ARG LLVM_VERSION_MAJOR=16
 

--- a/src/azurelinux/3.0/net8.0/crossdeps-llvm/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/crossdeps-llvm/amd64/Dockerfile
@@ -1,6 +1,6 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder AS builder
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps
 
 # Install LLVM that we built from source
 COPY --from=builder /usr/local /usr/local

--- a/src/azurelinux/3.0/net9.0/android/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/android/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm
 
 # Dependencies for Android build
 RUN tdnf update -y \

--- a/src/azurelinux/3.0/net9.0/android/docker/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/android/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-android-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-android
 
 RUN tdnf update -y \
     && tdnf install -y \

--- a/src/azurelinux/3.0/net9.0/cross/amd64-alpine/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/amd64-alpine/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/x64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh x64 alpine3.13 --skipunmount
@@ -30,7 +30,7 @@ RUN TARGET_TRIPLE="x86_64-alpine-linux-musl" && \
     cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
     cmake --install runtimes --prefix "$ROOTFS_DIR/usr"
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm
 ARG ROOTFS_DIR
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR

--- a/src/azurelinux/3.0/net9.0/cross/amd64-sanitizer/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/amd64-sanitizer/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/x64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder AS builder
 ARG ROOTFS_DIR
 
 # Use Ubuntu Bionic as the base image for the rootfs
@@ -41,7 +41,7 @@ RUN TARGET_TRIPLE="x86_64-linux-gnu" && \
     cmake --build runtimes -j && \
     cmake --install runtimes --prefix "$ROOTFS_DIR/usr"
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm
 ARG ROOTFS_DIR
 
 COPY --from=builder /usr/local/lib/clang /usr/local/lib/clang

--- a/src/azurelinux/3.0/net9.0/cross/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/amd64/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/x64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh x64 xenial --skipunmount
@@ -39,7 +39,7 @@ RUN TARGET_TRIPLE="x86_64-linux-gnu" && \
     cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
     cmake --install runtimes --prefix "$ROOTFS_DIR/usr"
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm
 ARG ROOTFS_DIR
 
 COPY --from=builder /usr/local/lib/clang /usr/local/lib/clang/

--- a/src/azurelinux/3.0/net9.0/cross/android/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/android/amd64/Dockerfile
@@ -1,6 +1,6 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-cross-amd64-local AS crossrootx64
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-cross-amd64 AS crossrootx64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-android-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-android
 
 # Copy crossrootfs from AMD64 build image, so we can build Android-targeting code for that arch
 COPY --from=crossrootx64 /crossrootfs/x64 /crossrootfs/x64

--- a/src/azurelinux/3.0/net9.0/cross/android/openssl/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/android/openssl/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-cross-android-amd64-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-cross-android-amd64
 
 # Copy the OpenSSL headers and libs from the x64 rootfs into the Anroid NDK so dotnet/runtime's
 # OpenSSL headers hack can find them for the linux-bionic build.

--- a/src/azurelinux/3.0/net9.0/cross/arm-alpine/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/arm-alpine/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/arm
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh arm alpine3.13 --skipunmount
@@ -30,7 +30,7 @@ RUN TARGET_TRIPLE="armv7-alpine-linux-musleabihf" && \
     cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
     cmake --install runtimes --prefix "$ROOTFS_DIR/usr"
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm
 ARG ROOTFS_DIR
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR

--- a/src/azurelinux/3.0/net9.0/cross/arm/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/arm/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/arm
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder AS builder
 ARG ROOTFS_DIR
 
 # The arm rootfs targets Ubuntu 22.04, which is the first version with a
@@ -41,7 +41,7 @@ RUN TARGET_TRIPLE="arm-linux-gnueabihf" && \
     cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
     cmake --install runtimes --prefix "$ROOTFS_DIR/usr"
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm
 ARG ROOTFS_DIR
 
 COPY --from=builder /usr/local/lib/clang /usr/local/lib/clang/

--- a/src/azurelinux/3.0/net9.0/cross/arm64-alpine/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/arm64-alpine/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/arm64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh arm64 alpine3.13 --skipunmount
@@ -30,7 +30,7 @@ RUN TARGET_TRIPLE="aarch64-alpine-linux-musl" && \
     cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
     cmake --install runtimes --prefix "$ROOTFS_DIR/usr"
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm
 ARG ROOTFS_DIR
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR

--- a/src/azurelinux/3.0/net9.0/cross/arm64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/arm64/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/arm64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh arm64 xenial --skipunmount
@@ -41,7 +41,7 @@ RUN TARGET_TRIPLE="aarch64-linux-gnu" && \
     cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
     cmake --install runtimes --prefix "$ROOTFS_DIR/usr"
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm
 ARG ROOTFS_DIR
 
 COPY --from=builder /usr/local/lib/clang /usr/local/lib/clang/

--- a/src/azurelinux/3.0/net9.0/cross/armv6/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/armv6/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/armv6
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder AS builder
 ARG ROOTFS_DIR
 
 # Install raspbian package signing keys
@@ -12,7 +12,7 @@ RUN wget http://raspbian.raspberrypi.org/raspbian/pool/main/r/raspbian-archive-k
 
 RUN /scripts/eng/common/cross/build-rootfs.sh armv6 bookworm lldb13
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm
 ARG ROOTFS_DIR
 
 COPY --from=builder "$ROOTFS_DIR" "$ROOTFS_DIR"

--- a/src/azurelinux/3.0/net9.0/cross/freebsd/13/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/freebsd/13/amd64/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/x64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder AS builder
 ARG ROOTFS_DIR
 
 # Install packages needed by the FreeBSD bootstrap scripts
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 RUN /scripts/eng/common/cross/build-rootfs.sh freebsd13 x64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm
 ARG ROOTFS_DIR
 
 COPY --from=builder "$ROOTFS_DIR" "$ROOTFS_DIR"

--- a/src/azurelinux/3.0/net9.0/cross/ppc64le/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/ppc64le/Dockerfile
@@ -1,11 +1,11 @@
 ARG ROOTFS_DIR=/crossrootfs/ppc64le
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh bionic ppc64le
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm
 ARG ROOTFS_DIR
 
 COPY --from=builder "$ROOTFS_DIR" "$ROOTFS_DIR"

--- a/src/azurelinux/3.0/net9.0/cross/riscv64-alpine/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/riscv64-alpine/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/riscv64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh riscv64 alpine3.20 --skipunmount
@@ -30,7 +30,7 @@ RUN TARGET_TRIPLE="riscv64-alpine-linux-musl" && \
     cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
     cmake --install runtimes --prefix "$ROOTFS_DIR/usr"
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm
 ARG ROOTFS_DIR
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR

--- a/src/azurelinux/3.0/net9.0/cross/riscv64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/riscv64/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/riscv64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder AS builder
 ARG ROOTFS_DIR
 
 # Install the latest debootstrap
@@ -47,7 +47,7 @@ RUN TARGET_TRIPLE="riscv64-linux-gnu" && \
     cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
     cmake --install runtimes --prefix "$ROOTFS_DIR/usr"
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm
 ARG ROOTFS_DIR
 
 COPY --from=builder /usr/local/lib/clang /usr/local/lib/clang/

--- a/src/azurelinux/3.0/net9.0/cross/s390x/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/s390x/Dockerfile
@@ -1,11 +1,11 @@
 ARG ROOTFS_DIR=/crossrootfs/s390x
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh bionic s390x
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm
 ARG ROOTFS_DIR
 
 COPY --from=builder "$ROOTFS_DIR" "$ROOTFS_DIR"

--- a/src/azurelinux/3.0/net9.0/cross/x86/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/x86/Dockerfile
@@ -1,13 +1,13 @@
 ARG ROOTFS_DIR=/crossrootfs/x86
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder AS builder
 ARG ROOTFS_DIR
 
 # We don't ship linux-x86 binaries, so we don't need to make a custom libc++ build for servicing concerns.
 # We don't sanitize or instrument the linux-x64 build (as we don't ship it), so we don't need to build those runtime support libraries either.
 RUN /scripts/eng/common/cross/build-rootfs.sh x86 xenial --skipunmount
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm
 ARG ROOTFS_DIR
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR

--- a/src/azurelinux/3.0/net9.0/crossdeps-llvm/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/crossdeps-llvm/amd64/Dockerfile
@@ -1,6 +1,6 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder AS builder
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps
 
 # Install LLVM that we built from source
 COPY --from=builder /usr/local /usr/local

--- a/src/azurelinux/3.0/net9.0/webassembly/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/webassembly/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-cross-amd64-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-cross-amd64
 
 # Dependencies for WebAssembly build
 RUN tdnf update -y \

--- a/src/azurelinux/manifest.json
+++ b/src/azurelinux/manifest.json
@@ -10,10 +10,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net8.0-crossdeps": {},
-                "azurelinux-3.0-net8.0-crossdeps-local": {
-                  "isLocal": true
-                }
+                "azurelinux-3.0-net8.0-crossdeps": {}
               }
             }
           ]
@@ -25,10 +22,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net9.0-crossdeps": {},
-                "azurelinux-3.0-net9.0-crossdeps-local": {
-                  "isLocal": true
-                }
+                "azurelinux-3.0-net9.0-crossdeps": {}
               }
             }
           ]
@@ -40,10 +34,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net8.0-crossdeps-builder": {},
-                "azurelinux-3.0-net8.0-crossdeps-builder-local": {
-                  "isLocal": true
-                }
+                "azurelinux-3.0-net8.0-crossdeps-builder": {}
               }
             }
           ]
@@ -55,10 +46,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net8.0-crossdeps-llvm": {},
-                "azurelinux-3.0-net8.0-crossdeps-llvm-local": {
-                  "isLocal": true
-                }
+                "azurelinux-3.0-net8.0-crossdeps-llvm": {}
               }
             }
           ]
@@ -70,10 +58,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net8.0-cross-amd64": {},
-                "azurelinux-3.0-net8.0-cross-amd64-local": {
-                  "isLocal": true
-                }
+                "azurelinux-3.0-net8.0-cross-amd64": {}
               }
             }
           ]
@@ -85,10 +70,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net8.0-cross-amd64-alpine": {},
-                "azurelinux-3.0-net8.0-cross-amd64-alpine-local": {
-                  "isLocal": true
-                }
+                "azurelinux-3.0-net8.0-cross-amd64-alpine": {}
               }
             }
           ]
@@ -124,10 +106,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net8.0-cross-arm64": {},
-                "azurelinux-3.0-net8.0-cross-arm64-local": {
-                  "isLocal": true
-                }
+                "azurelinux-3.0-net8.0-cross-arm64": {}
               }
             }
           ]
@@ -139,10 +118,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net8.0-cross-arm64-alpine": {},
-                "azurelinux-3.0-net8.0-cross-arm64-alpine-local": {
-                  "isLocal": true
-                }
+                "azurelinux-3.0-net8.0-cross-arm64-alpine": {}
               }
             }
           ]
@@ -178,10 +154,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net9.0-crossdeps-builder": {},
-                "azurelinux-3.0-net9.0-crossdeps-builder-local": {
-                  "isLocal": true
-                }
+                "azurelinux-3.0-net9.0-crossdeps-builder": {}
               }
             }
           ]
@@ -193,10 +166,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net9.0-crossdeps-llvm": {},
-                "azurelinux-3.0-net9.0-crossdeps-llvm-local": {
-                  "isLocal": true
-                }
+                "azurelinux-3.0-net9.0-crossdeps-llvm": {}
               }
             }
           ]
@@ -231,10 +201,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net9.0-cross-amd64": {},
-                "azurelinux-3.0-net9.0-cross-amd64-local": {
-                  "isLocal": true
-                }
+                "azurelinux-3.0-net9.0-cross-amd64": {}
               }
             }
           ]
@@ -246,10 +213,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net9.0-cross-amd64-sanitizer": {},
-                "azurelinux-3.0-net9.0-cross-amd64-sanitizer-local": {
-                  "isLocal": true
-                }
+                "azurelinux-3.0-net9.0-cross-amd64-sanitizer": {}
               }
             }
           ]
@@ -261,10 +225,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net9.0-cross-amd64-alpine": {},
-                "azurelinux-3.0-net9.0-cross-amd64-alpine-local": {
-                  "isLocal": true
-                }
+                "azurelinux-3.0-net9.0-cross-amd64-alpine": {}
               }
             }
           ]
@@ -300,10 +261,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net9.0-cross-arm64": {},
-                "azurelinux-3.0-net9.0-cross-arm64-local": {
-                  "isLocal": true
-                }
+                "azurelinux-3.0-net9.0-cross-arm64": {}
               }
             }
           ]
@@ -315,10 +273,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net9.0-cross-arm64-alpine": {},
-                "azurelinux-3.0-net9.0-cross-arm64-alpine-local": {
-                  "isLocal": true
-                }
+                "azurelinux-3.0-net9.0-cross-arm64-alpine": {}
               }
             }
           ]
@@ -354,11 +309,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net9.0-android": {},
-                "azurelinux-3.0-net9.0-android-local": {
-                  "isLocal": true
-                    }
-                  }
+                "azurelinux-3.0-net9.0-android": {}
+              }
             }
           ]
         },
@@ -369,10 +321,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net9.0-cross-android-amd64": {},
-                "azurelinux-3.0-net9.0-cross-android-amd64-local": {
-                  "isLocal": true
-                }
+                "azurelinux-3.0-net9.0-cross-android-amd64": {}
               }
             }
           ]

--- a/src/cbl-mariner/2.0/android/docker/Dockerfile
+++ b/src/cbl-mariner/2.0/android/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-android-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-android
 
 RUN tdnf update -y \
     && tdnf install -y \

--- a/src/cbl-mariner/2.0/cross/amd64-alpine/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/amd64-alpine/Dockerfile
@@ -1,12 +1,12 @@
 ARG ROOTFS_DIR=/crossrootfs/x64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh x64 alpine3.13 --skipunmount
 
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm
 ARG ROOTFS_DIR
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR

--- a/src/cbl-mariner/2.0/cross/amd64/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/amd64/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/x64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh x64 xenial --skipunmount
@@ -43,7 +43,7 @@ RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTI
     cp compiler-rt_build/lib/linux/libclang_rt.*-x86_64.a $SANITIZER_RUNTIMES_DIR
 
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm
 ARG ROOTFS_DIR
 ARG LLVM_VERSION_MAJOR=16
 

--- a/src/cbl-mariner/2.0/cross/android/amd64/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/android/amd64/Dockerfile
@@ -1,6 +1,6 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64-local AS crossrootx64
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64 AS crossrootx64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-android-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-android
 
 # Copy crossrootfs from AMD64 build image, so we can build Android-targeting code for that arch
 COPY --from=crossrootx64 /crossrootfs/x64 /crossrootfs/x64

--- a/src/cbl-mariner/2.0/cross/arm-alpine/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/arm-alpine/Dockerfile
@@ -1,12 +1,12 @@
 ARG ROOTFS_DIR=/crossrootfs/arm
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh arm alpine3.13 --skipunmount
 
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm
 ARG ROOTFS_DIR
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR

--- a/src/cbl-mariner/2.0/cross/arm/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/arm/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/arm
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh arm xenial --skipunmount
@@ -43,7 +43,7 @@ RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTI
     cp compiler-rt_build/lib/linux/libclang_rt.*-armhf.a $SANITIZER_RUNTIMES_DIR
 
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm
 ARG ROOTFS_DIR
 ARG LLVM_VERSION_MAJOR=16
 

--- a/src/cbl-mariner/2.0/cross/arm64-alpine/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/arm64-alpine/Dockerfile
@@ -1,12 +1,12 @@
 ARG ROOTFS_DIR=/crossrootfs/arm64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh arm64 alpine3.13 --skipunmount
 
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm
 ARG ROOTFS_DIR
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR

--- a/src/cbl-mariner/2.0/cross/arm64/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/arm64/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/arm64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh arm64 xenial --skipunmount
@@ -43,7 +43,7 @@ RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTI
     cp compiler-rt_build/lib/linux/libclang_rt.*-aarch64.a $SANITIZER_RUNTIMES_DIR
 
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm
 ARG ROOTFS_DIR
 ARG LLVM_VERSION_MAJOR=16
 

--- a/src/cbl-mariner/2.0/cross/armv6/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/armv6/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/armv6
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder AS builder
 ARG ROOTFS_DIR
 
 # Install raspbian package signing keys
@@ -12,7 +12,7 @@ RUN wget http://raspbian.raspberrypi.org/raspbian/pool/main/r/raspbian-archive-k
 
 RUN /scripts/eng/common/cross/build-rootfs.sh armv6 buster
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm
 ARG ROOTFS_DIR
 
 COPY --from=builder "$ROOTFS_DIR" "$ROOTFS_DIR"

--- a/src/cbl-mariner/2.0/cross/biarch/amd64-alpine/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/biarch/amd64-alpine/Dockerfile
@@ -1,6 +1,6 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64-alpine-local AS crossrootbiarch
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64-alpine AS crossrootbiarch
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64
 
 # Copy crossrootfs from Alpine build image, so we can build and cross-compile
 # cross compilers within the same build system (e.g. required for Node.js)

--- a/src/cbl-mariner/2.0/cross/biarch/arm64-alpine/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/biarch/arm64-alpine/Dockerfile
@@ -1,6 +1,6 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm64-alpine-local AS crossrootbiarch
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm64-alpine AS crossrootbiarch
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64
 
 # Copy crossrootfs from Alpine build image, so we can build and cross-compile
 # cross compilers within the same build system (e.g. required for Node.js)

--- a/src/cbl-mariner/2.0/cross/biarch/arm64/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/biarch/arm64/Dockerfile
@@ -1,6 +1,6 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm64-local AS crossrootbiarch
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm64 AS crossrootbiarch
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64
 
 # Copy crossrootfs from ARM64 build image, so we can build and cross-compile
 # cross compilers within the same build system (e.g. required for Node.js)

--- a/src/cbl-mariner/2.0/cross/bionic/amd64/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/bionic/amd64/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/x64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh x64 bionic --skipunmount
@@ -43,7 +43,7 @@ RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTI
     cp compiler-rt_build/lib/linux/libclang_rt.*-x86_64.a $SANITIZER_RUNTIMES_DIR
 
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm
 ARG ROOTFS_DIR
 ARG LLVM_VERSION_MAJOR=16
 

--- a/src/cbl-mariner/2.0/cross/bionic/arm/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/bionic/arm/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/arm
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh arm bionic --skipunmount
@@ -43,7 +43,7 @@ RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTI
     cp compiler-rt_build/lib/linux/libclang_rt.*-armhf.a $SANITIZER_RUNTIMES_DIR
 
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm
 ARG ROOTFS_DIR
 ARG LLVM_VERSION_MAJOR=16
 

--- a/src/cbl-mariner/2.0/cross/bionic/arm64/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/bionic/arm64/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/arm64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh arm64 bionic --skipunmount
@@ -43,7 +43,7 @@ RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTI
     cp compiler-rt_build/lib/linux/libclang_rt.*-aarch64.a $SANITIZER_RUNTIMES_DIR
 
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm
 ARG ROOTFS_DIR
 ARG LLVM_VERSION_MAJOR=16
 

--- a/src/cbl-mariner/2.0/cross/bionic/x86/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/bionic/x86/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/x86
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh x86 bionic --skipunmount
@@ -43,7 +43,7 @@ RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTI
     cp compiler-rt_build/lib/linux/libclang_rt.*-i386.a $SANITIZER_RUNTIMES_DIR
 
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm
 ARG ROOTFS_DIR
 ARG LLVM_VERSION_MAJOR=16
 

--- a/src/cbl-mariner/2.0/cross/freebsd/13/amd64/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/freebsd/13/amd64/Dockerfile
@@ -1,11 +1,11 @@
 ARG ROOTFS_DIR=/crossrootfs/x64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh freebsd13 x64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm
 ARG ROOTFS_DIR
 
 COPY --from=builder "$ROOTFS_DIR" "$ROOTFS_DIR"

--- a/src/cbl-mariner/2.0/cross/freebsd/13/arm64/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/freebsd/13/arm64/Dockerfile
@@ -1,11 +1,11 @@
 ARG ROOTFS_DIR=/crossrootfs/arm64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh freebsd13 arm64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm
 ARG ROOTFS_DIR
 
 COPY --from=builder "$ROOTFS_DIR" "$ROOTFS_DIR"

--- a/src/cbl-mariner/2.0/cross/freebsd/14/amd64/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/freebsd/14/amd64/Dockerfile
@@ -1,11 +1,11 @@
 ARG ROOTFS_DIR=/crossrootfs/x64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh freebsd14 x64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm
 ARG ROOTFS_DIR
 
 COPY --from=builder "$ROOTFS_DIR" "$ROOTFS_DIR"

--- a/src/cbl-mariner/2.0/cross/freebsd/14/arm64/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/freebsd/14/arm64/Dockerfile
@@ -1,11 +1,11 @@
 ARG ROOTFS_DIR=/crossrootfs/arm64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh freebsd14 arm64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm
 ARG ROOTFS_DIR
 
 COPY --from=builder "$ROOTFS_DIR" "$ROOTFS_DIR"

--- a/src/cbl-mariner/2.0/cross/ppc64le/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/ppc64le/Dockerfile
@@ -1,11 +1,11 @@
 ARG ROOTFS_DIR=/crossrootfs/ppc64le
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh bionic ppc64le
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm
 ARG ROOTFS_DIR
 
 COPY --from=builder "$ROOTFS_DIR" "$ROOTFS_DIR"

--- a/src/cbl-mariner/2.0/cross/s390x/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/s390x/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/s390x
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh bionic s390x
@@ -17,7 +17,7 @@ RUN tdnf install -y awk && \
     make -j $(getconf _NPROCESSORS_ONLN) && \
     make install -C ld
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm
 ARG ROOTFS_DIR
 
 COPY --from=builder "$ROOTFS_DIR" "$ROOTFS_DIR"

--- a/src/cbl-mariner/2.0/cross/x86/Dockerfile
+++ b/src/cbl-mariner/2.0/cross/x86/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/x86
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh x86 xenial --skipunmount
@@ -43,7 +43,7 @@ RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTI
     cp compiler-rt_build/lib/linux/libclang_rt.*-i386.a $SANITIZER_RUNTIMES_DIR
 
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-llvm
 ARG ROOTFS_DIR
 ARG LLVM_VERSION_MAJOR=16
 

--- a/src/cbl-mariner/2.0/crossdeps-llvm/amd64/Dockerfile
+++ b/src/cbl-mariner/2.0/crossdeps-llvm/amd64/Dockerfile
@@ -1,6 +1,6 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-builder AS builder
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-crossdeps
 
 # Install LLVM that we built from source
 COPY --from=builder /usr/local /usr/local

--- a/src/cbl-mariner/2.0/webassembly/amd64/Dockerfile
+++ b/src/cbl-mariner/2.0/webassembly/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64
 
 # Dependencies for WebAssembly build
 RUN tdnf update -y \

--- a/src/cbl-mariner/manifest.json
+++ b/src/cbl-mariner/manifest.json
@@ -59,10 +59,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner2.0",
               "tags": {
-                "cbl-mariner-2.0-crossdeps": {},
-                "cbl-mariner-2.0-crossdeps-local": {
-                  "isLocal": true
-                }
+                "cbl-mariner-2.0-crossdeps": {}
               }
             }
           ]
@@ -74,10 +71,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner2.0",
               "tags": {
-                "cbl-mariner-2.0-crossdeps-builder": {},
-                "cbl-mariner-2.0-crossdeps-builder-local": {
-                  "isLocal": true
-                }
+                "cbl-mariner-2.0-crossdeps-builder": {}
               }
             }
           ]
@@ -89,10 +83,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner2.0",
               "tags": {
-                "cbl-mariner-2.0-crossdeps-llvm": {},
-                "cbl-mariner-2.0-crossdeps-llvm-local": {
-                  "isLocal": true
-                }
+                "cbl-mariner-2.0-crossdeps-llvm": {}
               }
             }
           ]
@@ -104,10 +95,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner2.0",
               "tags": {
-                "cbl-mariner-2.0-cross-amd64": {},
-                "cbl-mariner-2.0-cross-amd64-local": {
-                  "isLocal": true
-                }
+                "cbl-mariner-2.0-cross-amd64": {}
               }
             }
           ]
@@ -119,10 +107,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner2.0",
               "tags": {
-                "cbl-mariner-2.0-cross-amd64-alpine": {},
-                "cbl-mariner-2.0-cross-amd64-alpine-local": {
-                  "isLocal": true
-                }
+                "cbl-mariner-2.0-cross-amd64-alpine": {}
               }
             }
           ]
@@ -158,10 +143,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner2.0",
               "tags": {
-                "cbl-mariner-2.0-cross-arm64": {},
-                "cbl-mariner-2.0-cross-arm64-local": {
-                  "isLocal": true
-                }
+                "cbl-mariner-2.0-cross-arm64": {}
               }
             }
           ]
@@ -173,10 +155,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner2.0",
               "tags": {
-                "cbl-mariner-2.0-cross-arm64-alpine": {},
-                "cbl-mariner-2.0-cross-arm64-alpine-local": {
-                  "isLocal": true
-                }
+                "cbl-mariner-2.0-cross-arm64-alpine": {}
               }
             }
           ]
@@ -188,10 +167,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner2.0",
               "tags": {
-                "cbl-mariner-2.0-cross-armv6": {},
-                "cbl-mariner-2.0-cross-armv6-local": {
-                  "isLocal": true
-                }
+                "cbl-mariner-2.0-cross-armv6": {}
               }
             }
           ]
@@ -324,10 +300,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner2.0",
               "tags": {
-                "cbl-mariner-2.0-android": {},
-                "cbl-mariner-2.0-android-local": {
-                  "isLocal": true
-                }
+                "cbl-mariner-2.0-android": {}
               }
             }
           ]

--- a/src/raspbian/10/helix/arm32v6/Dockerfile
+++ b/src/raspbian/10/helix/arm32v6/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:raspbian-10-crossdeps-local as builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:raspbian-10-crossdeps as builder
 
 ARG ROOTFS_DIR
 

--- a/src/raspbian/manifest.json
+++ b/src/raspbian/manifest.json
@@ -11,10 +11,7 @@
               "os": "linux",
               "osVersion": "buster",
               "tags": {
-                "raspbian-10-crossdeps": {},
-                "raspbian-10-crossdeps-local": {
-                  "isLocal": true
-                }
+                "raspbian-10-crossdeps": {}
               },
               "variant": "v7"
             }

--- a/src/ubuntu/20.04/cross/arm64/Dockerfile
+++ b/src/ubuntu/20.04/cross/arm64/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/arm64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-crossdeps-local AS binutils
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-crossdeps AS binutils
 
 # Install binutils-aarch64-linux-gnu
 RUN apt-get update \

--- a/src/ubuntu/20.04/crossdeps/Dockerfile
+++ b/src/ubuntu/20.04/crossdeps/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-coredeps-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-coredeps
 
 # Install the base toolchain we need to build anything (clang, cmake, make and the like).
 RUN apt-get update \

--- a/src/ubuntu/20.04/helix/sqlserver/amd64/Dockerfile
+++ b/src/ubuntu/20.04/helix/sqlserver/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-helix-amd64-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-helix-amd64
 
 USER root
 

--- a/src/ubuntu/20.04/helix/wasm/amd64/Dockerfile
+++ b/src/ubuntu/20.04/helix/wasm/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-helix-amd64-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-helix-amd64
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/src/ubuntu/20.04/webassembly-net8/amd64/Dockerfile
+++ b/src/ubuntu/20.04/webassembly-net8/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-coredeps-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-coredeps
 
 # Dependencies for WebAssembly build
 RUN apt-get update \

--- a/src/ubuntu/20.04/webassembly/amd64/Dockerfile
+++ b/src/ubuntu/20.04/webassembly/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-coredeps-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-coredeps
 
 # Dependencies for WebAssembly build
 RUN apt-get update \

--- a/src/ubuntu/22.04/cross/arm-alpine/Dockerfile
+++ b/src/ubuntu/22.04/cross/arm-alpine/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/arm
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps AS builder
 ARG ROOTFS_DIR
 
 # Obtain arcade scripts used to build rootfs
@@ -10,7 +10,7 @@ RUN git config --global user.email builder@dotnet-buildtools-prereqs-docker && \
 # Build the rootfs
 RUN /scripts/eng/common/cross/build-rootfs.sh arm alpine3.14 --skipunmount
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps
 ARG ROOTFS_DIR
 
 RUN cd /tmp \

--- a/src/ubuntu/22.04/cross/arm/Dockerfile
+++ b/src/ubuntu/22.04/cross/arm/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/arm
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps AS builder
 ARG ROOTFS_DIR
 
 # Obtain arcade scripts used to build rootfs
@@ -10,7 +10,7 @@ RUN git config --global user.email builder@dotnet-buildtools-prereqs-docker && \
 # Build the rootfs
 RUN /scripts/eng/common/cross/build-rootfs.sh arm jammy lldb14 --skipunmount
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps
 ARG ROOTFS_DIR
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR

--- a/src/ubuntu/22.04/cross/arm64-alpine/Dockerfile
+++ b/src/ubuntu/22.04/cross/arm64-alpine/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/arm64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps-local as builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps as builder
 
 ARG ROOTFS_DIR
 
@@ -11,7 +11,7 @@ RUN git config --global user.email builder@dotnet-buildtools-prereqs-docker && \
 # Build the rootfs
 RUN /scripts/eng/common/cross/build-rootfs.sh arm64 alpine --skipunmount
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps
 
 ARG ROOTFS_DIR
 

--- a/src/ubuntu/22.04/cross/arm64/Dockerfile
+++ b/src/ubuntu/22.04/cross/arm64/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/arm64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps AS builder
 ARG ROOTFS_DIR
 
 # Obtain arcade scripts used to build rootfs
@@ -10,7 +10,7 @@ RUN git config --global user.email builder@dotnet-buildtools-prereqs-docker && \
 # Build the rootfs
 RUN /scripts/eng/common/cross/build-rootfs.sh arm xenial lldb3.9 --skipunmount
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps
 ARG ROOTFS_DIR
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR

--- a/src/ubuntu/22.04/cross/armel-tizen/Dockerfile
+++ b/src/ubuntu/22.04/cross/armel-tizen/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/armel
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps AS builder
 ARG ROOTFS_DIR
 
 # Obtain arcade scripts used to build rootfs
@@ -9,7 +9,7 @@ RUN git config --global user.email builder@dotnet-buildtools-prereqs-docker && \
 
 RUN /scripts/eng/common/cross/tizen-build-rootfs.sh armel
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps
 ARG ROOTFS_DIR
 
 # Install binutils-arm-linux-gnueabi

--- a/src/ubuntu/22.04/cross/haiku/Dockerfile
+++ b/src/ubuntu/22.04/cross/haiku/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/x64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps-local AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps AS builder
 ARG ROOTFS_DIR
 
 # Obtain arcade scripts used to build rootfs
@@ -10,7 +10,7 @@ RUN git config --global user.email builder@dotnet-buildtools-prereqs-docker && \
 # Build the rootfs
 RUN /scripts/eng/common/cross/build-rootfs.sh x64 haiku --skipunmount
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps
 ARG ROOTFS_DIR
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR

--- a/src/ubuntu/22.04/cross/illumos/Dockerfile
+++ b/src/ubuntu/22.04/cross/illumos/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/x64
 
-FROM  mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps-local AS builder
+FROM  mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps AS builder
 ARG ROOTFS_DIR
 
 # Obtain arcade scripts used to build rootfs
@@ -10,7 +10,7 @@ RUN git config --global user.email builder@dotnet-buildtools-prereqs-docker && \
 # Build the rootfs
 RUN /scripts/eng/common/cross/build-rootfs.sh x64 illumos --skipunmount
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps
 ARG ROOTFS_DIR
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR

--- a/src/ubuntu/22.04/cross/ppc64le-alpine/Dockerfile
+++ b/src/ubuntu/22.04/cross/ppc64le-alpine/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/ppc64le
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps-local as builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps as builder
 
 ARG ROOTFS_DIR
 
@@ -11,7 +11,7 @@ RUN git config --global user.email builder@dotnet-buildtools-prereqs-docker && \
 # Build the rootfs
 RUN /scripts/eng/common/cross/build-rootfs.sh ppc64le alpine --skipunmount
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps
 
 ARG ROOTFS_DIR
 

--- a/src/ubuntu/22.04/cross/s390x-alpine/Dockerfile
+++ b/src/ubuntu/22.04/cross/s390x-alpine/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/s390x
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps-local as builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps as builder
 
 ARG ROOTFS_DIR
 
@@ -11,7 +11,7 @@ RUN git config --global user.email builder@dotnet-buildtools-prereqs-docker && \
 # Build the rootfs
 RUN /scripts/eng/common/cross/build-rootfs.sh s390x alpine --skipunmount
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps
 
 ARG ROOTFS_DIR
 

--- a/src/ubuntu/22.04/cross/x86-alpine/Dockerfile
+++ b/src/ubuntu/22.04/cross/x86-alpine/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/x86
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps-local as builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps as builder
 
 ARG ROOTFS_DIR
 
@@ -11,7 +11,7 @@ RUN git config --global user.email builder@dotnet-buildtools-prereqs-docker && \
 # Build the rootfs
 RUN /scripts/eng/common/cross/build-rootfs.sh x86 alpine --skipunmount
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps
 
 ARG ROOTFS_DIR
 

--- a/src/ubuntu/22.04/crossdeps/Dockerfile
+++ b/src/ubuntu/22.04/crossdeps/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-coredeps-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-coredeps
 
 # Install the base toolchain we need to build anything (clang, cmake, make and the like).
 RUN apt-get update \

--- a/src/ubuntu/22.04/debpkg/amd64/Dockerfile
+++ b/src/ubuntu/22.04/debpkg/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04
 
 # Install the deb packaging toolchain we need to build debs
 RUN apt-get update \

--- a/src/ubuntu/22.04/helix/webassembly/amd64/Dockerfile
+++ b/src/ubuntu/22.04/helix/webassembly/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-helix-amd64-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-helix-amd64
 
 USER root
 

--- a/src/ubuntu/22.04/mlnet/Dockerfile
+++ b/src/ubuntu/22.04/mlnet/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04
 
 # Install openmp support
 RUN apt-get update \

--- a/src/ubuntu/22.04/mlnet/helix/Dockerfile
+++ b/src/ubuntu/22.04/mlnet/helix/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-mlnet-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-mlnet
 
 # Install Helix Dependencies
 RUN apt-get update \

--- a/src/ubuntu/manifest.json
+++ b/src/ubuntu/manifest.json
@@ -10,10 +10,7 @@
               "os": "linux",
               "osVersion": "focal",
               "tags": {
-                "ubuntu-20.04-coredeps": {},
-                "ubuntu-20.04-coredeps-local": {
-                  "isLocal": true
-                }
+                "ubuntu-20.04-coredeps": {}
               },
               "buildArgs": {
                 "POWERSHELL_TAG": "ubuntu-20.04"
@@ -28,10 +25,7 @@
               "os": "linux",
               "osVersion": "focal",
               "tags": {
-                "ubuntu-20.04-crossdeps": {},
-                "ubuntu-20.04-crossdeps-local": {
-                  "isLocal": true
-                }
+                "ubuntu-20.04-crossdeps": {}
               }
             }
           ]
@@ -56,10 +50,7 @@
               "os": "linux",
               "osVersion": "focal",
               "tags": {
-                "ubuntu-20.04-helix-amd64": {},
-                "ubuntu-20.04-helix-amd64-local": {
-                  "isLocal": true
-                }
+                "ubuntu-20.04-helix-amd64": {}
               }
             }
           ]
@@ -72,10 +63,7 @@
               "os": "linux",
               "osVersion": "focal",
               "tags": {
-                "ubuntu-20.04-helix-arm64v8": {},
-                "ubuntu-20.04-helix-arm64v8-local": {
-                  "isLocal": true
-                }
+                "ubuntu-20.04-helix-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -114,10 +102,7 @@
               "os": "linux",
               "osVersion": "focal",
               "tags": {
-                "ubuntu-20.04": {},
-                "ubuntu-20.04-local": {
-                  "isLocal": true
-                }
+                "ubuntu-20.04": {}
               }
             }
           ]
@@ -167,10 +152,7 @@
               "os": "linux",
               "osVersion": "jammy",
               "tags": {
-                "ubuntu-22.04": {},
-                "ubuntu-22.04-local": {
-                  "isLocal": true
-                }
+                "ubuntu-22.04": {}
               }
             }
           ]
@@ -196,10 +178,7 @@
               "os": "linux",
               "osVersion": "jammy",
               "tags": {
-                "ubuntu-22.04-coredeps": {},
-                "ubuntu-22.04-coredeps-local": {
-                  "isLocal": true
-                }
+                "ubuntu-22.04-coredeps": {}
               },
               "buildArgs": {
                 "POWERSHELL_TAG": "ubuntu-22.04"
@@ -214,10 +193,7 @@
               "os": "linux",
               "osVersion": "jammy",
               "tags": {
-                "ubuntu-22.04-crossdeps": {},
-                "ubuntu-22.04-crossdeps-local": {
-                  "isLocal": true
-                }
+                "ubuntu-22.04-crossdeps": {}
               }
             }
           ]
@@ -350,10 +326,7 @@
               "os": "linux",
               "osVersion": "jammy",
               "tags": {
-                "ubuntu-22.04-helix-amd64": {},
-                "ubuntu-22.04-helix-amd64-local": {
-                  "isLocal": true
-                }
+                "ubuntu-22.04-helix-amd64": {}
               }
             }
           ]
@@ -404,10 +377,7 @@
               "os": "linux",
               "osVersion": "jammy",
               "tags": {
-                "ubuntu-22.04-mlnet": {},
-                "ubuntu-22.04-mlnet-local": {
-                  "isLocal": true
-                }
+                "ubuntu-22.04-mlnet": {}
               }
             }
           ]
@@ -472,10 +442,7 @@
               "os": "linux",
               "osVersion": "noble",
               "tags": {
-                "ubuntu-24.04-helix-amd64": {},
-                "ubuntu-24.04-helix-amd64-local": {
-                  "isLocal": true
-                }
+                "ubuntu-24.04-helix-amd64": {}
               }
             }
           ]
@@ -488,10 +455,7 @@
               "os": "linux",
               "osVersion": "noble",
               "tags": {
-                "ubuntu-24.04-helix-arm64v8": {},
-                "ubuntu-24.04-helix-arm64v8-local": {
-                  "isLocal": true
-                }
+                "ubuntu-24.04-helix-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -505,10 +469,7 @@
               "os": "linux",
               "osVersion": "noble",
               "tags": {
-                "ubuntu-24.04-helix-arm32v7": {},
-                "ubuntu-24.04-helix-arm32v7-local": {
-                  "isLocal": true
-                }
+                "ubuntu-24.04-helix-arm32v7": {}
               },
               "variant": "v7"
             }

--- a/src/windowsservercore/ltsc2022/helix/webassembly-net8/amd64/Dockerfile
+++ b/src/windowsservercore/ltsc2022/helix/webassembly-net8/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:windowsservercore-ltsc2022-helix-amd64-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:windowsservercore-ltsc2022-helix-amd64
 
 # Install 7zip
 ENV ZIP7_VERSION=1900

--- a/src/windowsservercore/ltsc2022/helix/webassembly/amd64/Dockerfile
+++ b/src/windowsservercore/ltsc2022/helix/webassembly/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:windowsservercore-ltsc2022-helix-amd64-local
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:windowsservercore-ltsc2022-helix-amd64
 
 # Install 7zip
 ENV ZIP7_VERSION=1900

--- a/src/windowsservercore/manifest.json
+++ b/src/windowsservercore/manifest.json
@@ -10,10 +10,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2019",
               "tags": {
-                "windowsservercore-ltsc2019-helix-amd64": {},
-                "windowsservercore-ltsc2019-helix-amd64-local": {
-                  "isLocal": true
-                }
+                "windowsservercore-ltsc2019-helix-amd64": {}
               }
             }
           ]
@@ -37,10 +34,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2022",
               "tags": {
-                "windowsservercore-ltsc2022-helix-amd64": {},
-                "windowsservercore-ltsc2022-helix-amd64-local": {
-                  "isLocal": true
-                }
+                "windowsservercore-ltsc2022-helix-amd64": {}
               }
             }
           ]


### PR DESCRIPTION
Local tags are unnecessary now that we have static tag names defined everywhere. This is necessary for https://github.com/dotnet/docker-tools/issues/1417 (see https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/765#issuecomment-2368417789).

Fixes https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/765