### PR TITLE
Change install repo from testing to community on Alpine for msquic

### DIFF
--- a/src/alpine/3.17/helix/Dockerfile
+++ b/src/alpine/3.17/helix/Dockerfile
@@ -40,7 +40,7 @@ RUN apk add --upgrade --no-cache \
         tzdata
 
 # Install libmsquic from testing repository
-RUN apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/ libmsquic
+RUN apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community/ libmsquic
 
 # Needed for runtime tests to pass
 ENV LANG=en-US.UTF-8

--- a/src/alpine/3.18/helix/Dockerfile
+++ b/src/alpine/3.18/helix/Dockerfile
@@ -35,7 +35,7 @@ RUN apk add --upgrade --no-cache \
         tzdata
 
 # Install libmsquic from testing repository
-RUN apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/ libmsquic
+RUN apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community/ libmsquic
 
 # Needed for runtime tests to pass
 ENV LANG=en-US.UTF-8

--- a/src/alpine/3.20/helix/Dockerfile
+++ b/src/alpine/3.20/helix/Dockerfile
@@ -38,7 +38,7 @@ RUN apk add --upgrade --no-cache \
         tzdata
 
 # Install libmsquic from testing repository
-RUN apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/ libmsquic
+RUN apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community/ libmsquic
 
 # Needed for runtime tests to pass
 ENV LANG=en-US.UTF-8


### PR DESCRIPTION
As of [this PR](https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/72604), libmsquic has been updated to 2.4.5 and moved to `community` repository from `testing` repository.

So, we're updating our images to use community edge repository, also from now on newer alpine versions (3.21 is around corner) will have msquic in `community/3.21` repository without needing to add extra repository (like we do in here `edge`).