### PR TITLE
Add sudo and apt for MicroBuild install in aspnetcore pipelines

### DIFF
--- a/src/alpine/3.19/amd64/Dockerfile
+++ b/src/alpine/3.19/amd64/Dockerfile
@@ -2,6 +2,7 @@ FROM amd64/alpine:3.19
 
 # Install .NET and test dependencies
 RUN apk add --upgrade --no-cache \
+        apt \
         autoconf \
         automake \
         bash \

--- a/src/alpine/3.20/amd64/Dockerfile
+++ b/src/alpine/3.20/amd64/Dockerfile
@@ -2,6 +2,7 @@ FROM amd64/alpine:3.20
 
 # Install .NET and test dependencies
 RUN apk add --upgrade --no-cache \
+        apt \
         autoconf \
         automake \
         bash \

--- a/src/cbl-mariner/2.0/crossdeps/amd64/Dockerfile
+++ b/src/cbl-mariner/2.0/crossdeps/amd64/Dockerfile
@@ -2,6 +2,9 @@ FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
 
 RUN tdnf update -y && \
     tdnf install -y \
+        # Needed to install MicroBuild in Azure DevOps pipelines
+        sudo \
+        apt \
         # Provides 'su', required by Azure DevOps
         ca-certificates \
         git \

--- a/src/cbl-mariner/2.0/fpm/amd64/Dockerfile
+++ b/src/cbl-mariner/2.0/fpm/amd64/Dockerfile
@@ -17,5 +17,8 @@ RUN tdnf install -y \
         # Provides functionality for AzureCLI AzDO task
         powershell \
         azure-cli \
+        # Needed to install MicroBuild in Azure DevOps pipelines
+        sudo \
+        apt \
     && tdnf clean all \
     && gem install fpm


### PR DESCRIPTION
Related to https://github.com/dotnet/arcade/issues/14431

[Example pipeline run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2550492&view=logs&j=9895f7d8-b062-540b-461c-07f8695bfcc6) with failures to install MicroBuild (see Linux legs) (internal Microsoft link)

The `Install MicroBuild Plugin` step runs `sudo apt install nuget`. This step fails in some of the Linux legs because `sudo` and/or `apt` are missing from the dockerfiles. This PR adds these.

Needed for https://github.com/dotnet/aspnetcore/pull/58191