### PR TITLE
Optimize the Fedora 41 image

### DIFF
--- a/src/fedora/41/amd64/Dockerfile
+++ b/src/fedora/41/amd64/Dockerfile
@@ -1,9 +1,10 @@
 FROM library/fedora:41
 
-# Install the base toolchain we need to build anything (clang, cmake, make and the like)
-# this does not include libraries that we need to compile different projects, we'd like
-# them in a different layer.
+# Add MS package repo.
+RUN dnf config-manager addrepo --from-repofile=https://packages.microsoft.com/fedora/41/prod/config.repo
+
 RUN dnf --setopt=install_weak_deps=False install -y \
+        # Base toolchain we need to build anything (clang, cmake, make and the like)
         clang \
         cmake \
         dnf-plugins-core \
@@ -16,32 +17,14 @@ RUN dnf --setopt=install_weak_deps=False install -y \
         pigz \
         python \
         which \
-    && dnf clean all
-
-# Add MS package repo.
-RUN dnf config-manager addrepo --from-repofile=https://packages.microsoft.com/fedora/41/prod/config.repo
-
-# Install tools used by build automation.
-RUN dnf --setopt=install_weak_deps=False install -y \
+        # Tools used by build automation
         azure-cli \
         git \
         jq \
         tar \
         procps \
         zip \
-    && dnf clean all
-
-# Install the latest non-preview powershell release.
-RUN LATEST_TAG=$(curl -L https://api.github.com/repos/powershell/powershell/releases/latest | jq -r '.tag_name') \
-    && curl -L https://github.com/PowerShell/PowerShell/releases/download/$LATEST_TAG/powershell-${LATEST_TAG#*v}-linux-x64.tar.gz -o /tmp/powershell.tar.gz \
-    && mkdir -p /opt/microsoft/powershell \
-    && tar zxf /tmp/powershell.tar.gz -C /opt/microsoft/powershell \
-    && chmod +x /opt/microsoft/powershell/pwsh \
-    && ln -s /opt/microsoft/powershell/pwsh /usr/bin/pwsh \
-    && rm -f /tmp/powershell.tar.gz
-
-# Dependencies of CoreCLR, Mono and CoreFX.
-RUN dnf --setopt=install_weak_deps=False install -y \
+        # Dependencies of CoreCLR, Mono and CoreFX
         autoconf \
         automake \
         brotli-devel \
@@ -60,23 +43,18 @@ RUN dnf --setopt=install_weak_deps=False install -y \
         openssl-devel \
         uuid-devel \
         zlib-devel \
-    && dnf clean all
-
-# Dependencies for VMR/source-build tests
-RUN dnf --setopt=install_weak_deps=False install -y \
+        # Dependencies for VMR/source-build tests
         elfutils \
         file \
-    && dnf clean all
-
-# Install ICU package to support globalization
-RUN dnf --setopt=install_weak_deps=False install -y \
+        # Dependencies to support globalization
         icu \
     && dnf clean all
 
-# Dependencies for Aspnetcore
-RUN cd ~ \
-    && curl -sL https://rpm.nodesource.com/setup_20.x
-RUN dnf --setopt=install_weak_deps=False install -y \
-        nodejs \
-    && dnf clean all
-ENV NO_UPDATE_NOTIFIER=true
+# Install the latest non-preview powershell release.
+RUN LATEST_TAG=$(curl -L https://api.github.com/repos/powershell/powershell/releases/latest | jq -r '.tag_name') \
+    && curl -L https://github.com/PowerShell/PowerShell/releases/download/$LATEST_TAG/powershell-${LATEST_TAG#*v}-linux-x64.tar.gz -o /tmp/powershell.tar.gz \
+    && mkdir -p /opt/microsoft/powershell \
+    && tar zxf /tmp/powershell.tar.gz -C /opt/microsoft/powershell \
+    && chmod +x /opt/microsoft/powershell/pwsh \
+    && ln -s /opt/microsoft/powershell/pwsh /usr/bin/pwsh \
+    && rm -f /tmp/powershell.tar.gz


### PR DESCRIPTION
This reduces the size of the image by around 10% and reduces the build time between 40-50% in my local no-cache build environment.

The only functional difference is the removal of the aspnetcore dependencies which were added in https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/949 and https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/957.  The aspnetcore change that added the node was reverted.

Validated in a [source-build build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2568395&view=results) (internal microsoft link)