### PR TITLE
Add dnf upgrade to Fedora images

### DIFF
--- a/src/fedora/39/amd64/Dockerfile
+++ b/src/fedora/39/amd64/Dockerfile
@@ -1,9 +1,8 @@
-FROM library/fedora:39
+FROM fedora:39
 
-# Install the base toolchain we need to build anything (clang, cmake, make and the like)
-# this does not include libraries that we need to compile different projects, we'd like
-# them in a different layer.
-RUN dnf --setopt=install_weak_deps=False install -y \
+RUN dnf upgrade --refresh -y \
+    && dnf --setopt=install_weak_deps=False install -y \
+        # Base toolchain we need to build anything (clang, cmake, make and the like)
         clang \
         cmake \
         dnf-plugins-core \
@@ -19,30 +18,17 @@ RUN dnf --setopt=install_weak_deps=False install -y \
     && dnf clean all
 
 # Add MS package repo.
-RUN dnf config-manager --add-repo https://packages.microsoft.com/fedora/39/prod/ \
-    && rpm --import https://packages.microsoft.com/keys/microsoft.asc
+RUN dnf config-manager --add-repo=https://packages.microsoft.com/fedora/39/prod/config.repo
 
-# Install tools used by build automation.
 RUN dnf --setopt=install_weak_deps=False install -y \
+        # Tools used by build automation
         azure-cli \
         git \
         jq \
         tar \
         procps \
         zip \
-    && dnf clean all
-
-# Install the latest non-preview powershell release.
-RUN LATEST_TAG=$(curl -L https://api.github.com/repos/powershell/powershell/releases/latest | jq -r '.tag_name') \
-    && curl -L https://github.com/PowerShell/PowerShell/releases/download/$LATEST_TAG/powershell-${LATEST_TAG#*v}-linux-x64.tar.gz -o /tmp/powershell.tar.gz \
-    && mkdir -p /opt/microsoft/powershell \
-    && tar zxf /tmp/powershell.tar.gz -C /opt/microsoft/powershell \
-    && chmod +x /opt/microsoft/powershell/pwsh \
-    && ln -s /opt/microsoft/powershell/pwsh /usr/bin/pwsh \
-    && rm -f /tmp/powershell.tar.gz
-
-# Dependencies of CoreCLR, Mono and CoreFX.
-RUN dnf --setopt=install_weak_deps=False install -y \
+        # Dependencies of CoreCLR, Mono and CoreFX
         autoconf \
         automake \
         glibc-locale-source \
@@ -60,23 +46,18 @@ RUN dnf --setopt=install_weak_deps=False install -y \
         openssl-devel \
         uuid-devel \
         zlib-devel \
-    && dnf clean all
-
-# Dependencies for VMR/source-build tests
-RUN dnf --setopt=install_weak_deps=False install -y \
+        # Dependencies for VMR/source-build tests
         elfutils \
         file \
-    && dnf clean all
-
-# Install ICU package to support globalization
-RUN dnf --setopt=install_weak_deps=False install -y \
+        # Dependencies to support globalization
         icu \
     && dnf clean all
 
-# Dependencies for Aspnetcore
-RUN cd ~ \
-    && curl -sL https://rpm.nodesource.com/setup_20.x
-RUN dnf --setopt=install_weak_deps=False install -y \
-        nodejs \
-    && dnf clean all
-ENV NO_UPDATE_NOTIFIER=true
+# Install the latest non-preview powershell release.
+RUN LATEST_TAG=$(curl -L https://api.github.com/repos/powershell/powershell/releases/latest | jq -r '.tag_name') \
+    && curl -L https://github.com/PowerShell/PowerShell/releases/download/$LATEST_TAG/powershell-${LATEST_TAG#*v}-linux-x64.tar.gz -o /tmp/powershell.tar.gz \
+    && mkdir -p /opt/microsoft/powershell \
+    && tar zxf /tmp/powershell.tar.gz -C /opt/microsoft/powershell \
+    && chmod +x /opt/microsoft/powershell/pwsh \
+    && ln -s /opt/microsoft/powershell/pwsh /usr/bin/pwsh \
+    && rm -f /tmp/powershell.tar.gz

--- a/src/fedora/39/amd64/Dockerfile
+++ b/src/fedora/39/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:39
+FROM library/fedora:39
 
 RUN dnf upgrade --refresh -y \
     && dnf --setopt=install_weak_deps=False install -y \

--- a/src/fedora/40/amd64/Dockerfile
+++ b/src/fedora/40/amd64/Dockerfile
@@ -1,9 +1,8 @@
-FROM library/fedora:40
+FROM fedora:40
 
-# Install the base toolchain we need to build anything (clang, cmake, make and the like)
-# this does not include libraries that we need to compile different projects, we'd like
-# them in a different layer.
-RUN dnf --setopt=install_weak_deps=False install -y \
+RUN dnf upgrade --refresh -y \
+    && dnf --setopt=install_weak_deps=False install -y \
+        # Base toolchain we need to build anything (clang, cmake, make and the like)
         clang \
         cmake \
         dnf-plugins-core \
@@ -19,30 +18,17 @@ RUN dnf --setopt=install_weak_deps=False install -y \
     && dnf clean all
 
 # Add MS package repo.
-RUN dnf config-manager --add-repo https://packages.microsoft.com/fedora/40/prod/ \
-    && rpm --import https://packages.microsoft.com/keys/microsoft.asc
+RUN dnf config-manager --add-repo=https://packages.microsoft.com/fedora/40/prod/config.repo
 
-# Install tools used by build automation.
 RUN dnf --setopt=install_weak_deps=False install -y \
+        # Tools used by build automation
         azure-cli \
         git \
         jq \
         tar \
         procps \
         zip \
-    && dnf clean all
-
-# Install the latest non-preview powershell release.
-RUN LATEST_TAG=$(curl -L https://api.github.com/repos/powershell/powershell/releases/latest | jq -r '.tag_name') \
-    && curl -L https://github.com/PowerShell/PowerShell/releases/download/$LATEST_TAG/powershell-${LATEST_TAG#*v}-linux-x64.tar.gz -o /tmp/powershell.tar.gz \
-    && mkdir -p /opt/microsoft/powershell \
-    && tar zxf /tmp/powershell.tar.gz -C /opt/microsoft/powershell \
-    && chmod +x /opt/microsoft/powershell/pwsh \
-    && ln -s /opt/microsoft/powershell/pwsh /usr/bin/pwsh \
-    && rm -f /tmp/powershell.tar.gz
-
-# Dependencies of CoreCLR, Mono and CoreFX.
-RUN dnf --setopt=install_weak_deps=False install -y \
+        # Dependencies of CoreCLR, Mono and CoreFX
         autoconf \
         automake \
         brotli-devel \
@@ -61,23 +47,18 @@ RUN dnf --setopt=install_weak_deps=False install -y \
         openssl-devel \
         uuid-devel \
         zlib-devel \
-    && dnf clean all
-
-# Dependencies for VMR/source-build tests
-RUN dnf --setopt=install_weak_deps=False install -y \
+        # Dependencies for VMR/source-build tests
         elfutils \
         file \
-    && dnf clean all
-
-# Install ICU package to support globalization
-RUN dnf --setopt=install_weak_deps=False install -y \
+        # Dependencies to support globalization
         icu \
     && dnf clean all
 
-# Dependencies for Aspnetcore
-RUN cd ~ \
-    && curl -sL https://rpm.nodesource.com/setup_20.x
-RUN dnf --setopt=install_weak_deps=False install -y \
-        nodejs \
-    && dnf clean all
-ENV NO_UPDATE_NOTIFIER=true
+# Install the latest non-preview powershell release.
+RUN LATEST_TAG=$(curl -L https://api.github.com/repos/powershell/powershell/releases/latest | jq -r '.tag_name') \
+    && curl -L https://github.com/PowerShell/PowerShell/releases/download/$LATEST_TAG/powershell-${LATEST_TAG#*v}-linux-x64.tar.gz -o /tmp/powershell.tar.gz \
+    && mkdir -p /opt/microsoft/powershell \
+    && tar zxf /tmp/powershell.tar.gz -C /opt/microsoft/powershell \
+    && chmod +x /opt/microsoft/powershell/pwsh \
+    && ln -s /opt/microsoft/powershell/pwsh /usr/bin/pwsh \
+    && rm -f /tmp/powershell.tar.gz

--- a/src/fedora/40/amd64/Dockerfile
+++ b/src/fedora/40/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:40
+FROM library/fedora:40
 
 RUN dnf upgrade --refresh -y \
     && dnf --setopt=install_weak_deps=False install -y \

--- a/src/fedora/41/amd64/Dockerfile
+++ b/src/fedora/41/amd64/Dockerfile
@@ -3,7 +3,8 @@ FROM library/fedora:41
 # Add MS package repo.
 RUN dnf config-manager addrepo --from-repofile=https://packages.microsoft.com/fedora/41/prod/config.repo
 
-RUN dnf --setopt=install_weak_deps=False install -y \
+RUN dnf upgrade --refresh -y \
+    && dnf --setopt=install_weak_deps=False install -y \
         # Base toolchain we need to build anything (clang, cmake, make and the like)
         clang \
         cmake \


### PR DESCRIPTION
This allow the images to pick up available vulnerability fixes prior to a base image update.  This will help make the images more secure.

While doing this I updated the Fedora 39 and 40 images to used the same pattern introduced in https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1219.  The one difference is that base dnf installed does not include config-manager so dnf-plugins-core must be installed before the packages.microsoft.com feed can be registered.