### PR TITLE
Update almalinux images to include package upgrade logic

### DIFF
--- a/src/almalinux/8/helix/amd64/Dockerfile
+++ b/src/almalinux/8/helix/amd64/Dockerfile
@@ -1,11 +1,13 @@
 FROM library/almalinux:8
 
-# Add microsoft centos/8 repo for libmsquic.
-# (Use centos/8 rather than rhel/8 because the latter doesn't have
-#  libmsquic except in the 8.1-specific packages feed.)
-RUN rpm -Uvh https://packages.microsoft.com/config/centos/8/packages-microsoft-prod.rpm && \
-    yum update -y && \
-    yum install -y \
+RUN dnf upgrade --refresh -y \
+    && dnf install -y  \
+        'dnf-command(config-manager)' \
+    # Add microsoft centos/8 repo for libmsquic.
+    # (Use centos/8 rather than rhel/8 because the latter doesn't have
+    #  libmsquic except in the 8.1-specific packages feed.)
+    && dnf config-manager --add-repo=https://packages.microsoft.com/centos/8/prod/config.repo \
+    && dnf install -y \
         # Get recent python3 This is needed to get a pip recent enough
         # not to fail the build when installing cryptography library as
         # a dependency of the helix scripts.
@@ -13,22 +15,22 @@ RUN rpm -Uvh https://packages.microsoft.com/config/centos/8/packages-microsoft-p
         # Required for asp.net core test runs
         sudo \
         libicu \
-        libmsquic && \
-    yum clean all
+        libmsquic \
+    && dnf clean all
 
-RUN python3 -m pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    python3 -m pip install ./helix_scripts-*-py3-none-any.whl
+RUN python3 -m pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
+    && python3 -m pip install ./helix_scripts-*-py3-none-any.whl
 
 # Aspnetcore test runs expect python to be available without version suffix
-RUN alternatives --set python /usr/bin/python3 && \
-    ln -sf /usr/bin/pip3 /usr/bin/pip
+RUN alternatives --set python /usr/bin/python3 \
+    && ln -sf /usr/bin/pip3 /usr/bin/pip
 
 ENV LANG=en-US.UTF-8
 
 # create helixbot user and give rights to sudo without password
-RUN adduser --uid 1000 --shell /bin/bash --gid adm helixbot && \
-    chmod 755 /root && \
-    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
+RUN adduser --uid 1000 --shell /bin/bash --gid adm helixbot \
+    && chmod 755 /root \
+    && echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
 
 USER helixbot
 

--- a/src/almalinux/8/source-build/amd64/Dockerfile
+++ b/src/almalinux/8/source-build/amd64/Dockerfile
@@ -1,12 +1,13 @@
 FROM library/almalinux:8
 
 # Install dependencies
-RUN dnf install -y \
-     'dnf-command(config-manager)' \
-     epel-release && \
-     dnf config-manager --set-enabled powertools && \
-     dnf config-manager --set-enabled epel && \
-     dnf install -y \
+RUN dnf upgrade --refresh -y \
+    && dnf install -y \
+        'dnf-command(config-manager)' \
+        epel-release \
+     && dnf config-manager --set-enabled powertools \
+     && dnf config-manager --set-enabled epel \
+     && dnf install -y \
         "perl(Time::HiRes)" \
         autoconf \
         automake \
@@ -41,8 +42,6 @@ RUN dnf install -y \
         which \
         xz \
         zlib-devel \
-        && \
-    dnf module install -y \
+    && dnf module install -y \
         nodejs:20 \
-        && \
-    dnf clean all
+    && dnf clean all

--- a/src/almalinux/8/source-build/amd64/Dockerfile
+++ b/src/almalinux/8/source-build/amd64/Dockerfile
@@ -5,9 +5,9 @@ RUN dnf upgrade --refresh -y \
     && dnf install -y \
         'dnf-command(config-manager)' \
         epel-release \
-     && dnf config-manager --set-enabled powertools \
-     && dnf config-manager --set-enabled epel \
-     && dnf install -y \
+    && dnf config-manager --set-enabled powertools \
+    && dnf config-manager --set-enabled epel \
+    && dnf install -y \
         "perl(Time::HiRes)" \
         autoconf \
         automake \


### PR DESCRIPTION
Related to https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/1228

This PR contains the following changes:

1. Upgrades the packages from the base image
2. Format changes to make the Dockerfiles more consistent with the rest of the Dockerfiles in the repo
3. Convert the helix Dockerfile to use dnf vs yum to make the Dockerfile more consistent with the rest of the Dockerfiles in the repo.