### PR TITLE
Add package upgrade logic to centos Dockerfiles and misc dnf cleanup

### DIFF
--- a/src/almalinux/8/helix/amd64/Dockerfile
+++ b/src/almalinux/8/helix/amd64/Dockerfile
@@ -1,13 +1,13 @@
 FROM library/almalinux:8
 
 RUN dnf upgrade --refresh -y \
-    && dnf install -y  \
+    && dnf install --setopt tsflags=nodocs -y  \
         'dnf-command(config-manager)' \
     # Add microsoft centos/8 repo for libmsquic.
     # (Use centos/8 rather than rhel/8 because the latter doesn't have
     #  libmsquic except in the 8.1-specific packages feed.)
     && dnf config-manager --add-repo=https://packages.microsoft.com/centos/8/prod/config.repo \
-    && dnf install -y \
+    && dnf install --setopt tsflags=nodocs -y \
         # Get recent python3 This is needed to get a pip recent enough
         # not to fail the build when installing cryptography library as
         # a dependency of the helix scripts.

--- a/src/almalinux/8/source-build/amd64/Dockerfile
+++ b/src/almalinux/8/source-build/amd64/Dockerfile
@@ -2,12 +2,12 @@ FROM library/almalinux:8
 
 # Install dependencies
 RUN dnf upgrade --refresh -y \
-    && dnf install -y \
+    && dnf install --setopt tsflags=nodocs -y \
         'dnf-command(config-manager)' \
         epel-release \
     && dnf config-manager --set-enabled powertools \
     && dnf config-manager --set-enabled epel \
-    && dnf install -y \
+    && dnf install --setopt tsflags=nodocs -y \
         "perl(Time::HiRes)" \
         autoconf \
         automake \

--- a/src/centos/stream9/amd64/Dockerfile
+++ b/src/centos/stream9/amd64/Dockerfile
@@ -1,17 +1,18 @@
 FROM quay.io/centos/centos:stream9
 
 # Install dependencies
-
-RUN dnf install --setopt tsflags=nodocs --refresh -y \
+RUN dnf upgrade --refresh -y \
+    && dnf install --setopt tsflags=nodocs -y \
         dnf-plugins-core \
-    && \
-    dnf config-manager --set-enabled crb \
-    && \
-    dnf module install --setopt tsflags=nodocs -y nodejs:20/common && \
-    dnf install --setopt tsflags=nodocs -y \
+    && dnf config-manager --add-repo=https://packages.microsoft.com/rhel/9/prod/config.repo \
+    && dnf config-manager --set-enabled crb \
+    && dnf module install --setopt tsflags=nodocs -y \
+        nodejs:20/common \
+    && dnf install --setopt tsflags=nodocs -y \
         "perl(Time::HiRes)" \
         autoconf \
         automake \
+        azure-cli \
         brotli-devel \
         clang \
         cmake \
@@ -45,6 +46,7 @@ RUN dnf install --setopt tsflags=nodocs --refresh -y \
         numactl-devel \
         openssl-devel \
         pigz \
+        powershell \
         procps-ng \
         python3 \
         python3-devel \
@@ -56,18 +58,7 @@ RUN dnf install --setopt tsflags=nodocs --refresh -y \
         which \
         xz \
         zlib-devel \
-    && \
-    dnf clean all
-
-# Install powershell and the azure cli from the Microsoft repository
-RUN curl -sSL -O https://packages.microsoft.com/config/rhel/8/packages-microsoft-prod.rpm && \
-    rpm -i packages-microsoft-prod.rpm && \
-    rm -f packages-microsoft-prod.rpm && \
-    dnf update -y && \
-    dnf install -y --setopt tsflags=nodocs \
-        azure-cli \
-        powershell && \
-    dnf clean all
+    && dnf clean all
 
 ENV \
     NO_UPDATE_NOTIFIER=true \

--- a/src/centos/stream9/helix/amd64/Dockerfile
+++ b/src/centos/stream9/helix/amd64/Dockerfile
@@ -1,16 +1,11 @@
 FROM quay.io/centos/centos:stream9
 
 # Install dependencies
-RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
-    echo 2cfd20a306b2fa5e25522d78f2ef50a1f429d35fd30bd983e2ebffc2b80944fa microsoft.asc| sha256sum --check - && \
-    rpm --import microsoft.asc && \
-    rm microsoft.asc && \
-    dnf install --setopt tsflags=nodocs --refresh -y \
+RUN dnf upgrade --refresh -y \
+    && dnf install --setopt tsflags=nodocs -y \
         dnf-plugins-core \
-    && \
-    dnf config-manager --add-repo https://packages.microsoft.com/rhel/9/prod \
-    && \
-    dnf install --setopt tsflags=nodocs -y --allowerasing \
+    && dnf config-manager --add-repo=https://packages.microsoft.com/rhel/9/prod/config.repo \
+    && dnf install --setopt tsflags=nodocs -y --allowerasing \
         autoconf \
         automake \
         curl \
@@ -35,19 +30,18 @@ RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
         tar \
         wget \
         which \
-    && \
-    dnf clean all
+    && dnf clean all
 
-RUN ln -sf /usr/bin/python3 /usr/bin/python && \
-    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    pip install ./helix_scripts-*-py3-none-any.whl
+RUN ln -sf /usr/bin/python3 /usr/bin/python \
+    && pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
+    && pip install ./helix_scripts-*-py3-none-any.whl
 
 ENV LANG=en_US.utf8
 
 # create helixbot user and give rights to sudo without password
-RUN /usr/sbin/adduser --uid 1000 --shell /bin/bash --gid adm helixbot && \
-    chmod 755 /root && \
-    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
+RUN /usr/sbin/adduser --uid 1000 --shell /bin/bash --gid adm helixbot \
+    && chmod 755 /root \
+    && echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
 
 USER helixbot
 

--- a/src/centos/stream9/mlnet/helix/Dockerfile
+++ b/src/centos/stream9/mlnet/helix/Dockerfile
@@ -1,15 +1,13 @@
 FROM quay.io/centos/centos:stream9
 
-USER root
-
 # Install dependencies
-RUN dnf install --setopt tsflags=nodocs --refresh -y \
-        dnf-plugins-core \
-    && \
-    dnf config-manager --set-enabled crb \
-    && \
-    dnf module install --setopt tsflags=nodocs -y nodejs:20/common && \
+RUN dnf upgrade --refresh -y \
     dnf install --setopt tsflags=nodocs -y \
+        dnf-plugins-core \
+    && dnf config-manager --set-enabled crb \
+    && dnf module install --setopt tsflags=nodocs -y \
+        nodejs:20/common \
+    && dnf install --setopt tsflags=nodocs -y \
         "perl(Time::HiRes)" \
         autoconf \
         automake \
@@ -44,6 +42,7 @@ RUN dnf install --setopt tsflags=nodocs --refresh -y \
         ncurses-devel \
         numactl-devel \
         openssl-devel \
+        perl-FindBin \
         procps-ng \
         python3 \
         python3-devel \
@@ -55,25 +54,17 @@ RUN dnf install --setopt tsflags=nodocs --refresh -y \
         which \
         xz \
         zlib-devel \
-    && \
-    dnf clean all
-
-RUN dnf install --setopt tsflags=nodocs --refresh -y \
-        perl-FindBin \
-    && \
-    dnf clean all
+    && dnf clean all
 
 # Install openmp from llvm 3.9.1.
-RUN wget http://releases.llvm.org/3.9.1/openmp-3.9.1.src.tar.xz
-
-RUN mkdir -p llvm-3.9.1.src/openmp
-
-RUN tar -xf openmp-3.9.1.src.tar.xz --strip 1 -C llvm-3.9.1.src/openmp && \
-    rm -f openmp-3.9.1.src.tar.xz && \
+RUN wget http://releases.llvm.org/3.9.1/openmp-3.9.1.src.tar.xz \
+    && mkdir -p llvm-3.9.1.src/openmp \
+    && tar -xf openmp-3.9.1.src.tar.xz --strip 1 -C llvm-3.9.1.src/openmp \
+    && rm -f openmp-3.9.1.src.tar.xz \
     \
-    mkdir llvmbuild && \
-    cd llvmbuild && \
-    cmake \
+    && mkdir llvmbuild \
+    && cd llvmbuild \
+    && cmake \
         -DCMAKE_CXX_COMPILER=/usr/bin/clang++ \
         -DCMAKE_C_COMPILER=/usr/bin/clang \
         -DCMAKE_BUILD_TYPE=Release \
@@ -81,26 +72,26 @@ RUN tar -xf openmp-3.9.1.src.tar.xz --strip 1 -C llvm-3.9.1.src/openmp && \
         -DLLVM_ENABLE_EH=1 \
         -DLLVM_ENABLE_RTTI=1 \
         ../llvm-3.9.1.src/openmp \
-     && \
-     make -j $(($(getconf _NPROCESSORS_ONLN)+1)) && \
-     make install && \
-     cd .. && \
-     rm -f -r llvmbuild && \
-     rm -f -r llvm-3.9.1.src
+     \
+     && make -j $(($(getconf _NPROCESSORS_ONLN)+1)) \
+     && make install \
+     && cd .. \
+     && rm -f -r llvmbuild \
+     && rm -f -r llvm-3.9.1.src
 
 # Sets the library path to pickup openmp
 ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64
 
-RUN ln -sf /usr/bin/python3 /usr/bin/python && \
-    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    pip install ./helix_scripts-*-py3-none-any.whl
+RUN ln -sf /usr/bin/python3 /usr/bin/python \
+    && pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
+    && pip install ./helix_scripts-*-py3-none-any.whl
 
 ENV LANG=en_US.utf8
 
 # create helixbot user and give rights to sudo without password
-RUN /usr/sbin/adduser --uid 1000 --shell /bin/bash --gid adm helixbot && \
-    chmod 755 /root && \
-    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
+RUN /usr/sbin/adduser --uid 1000 --shell /bin/bash --gid adm helixbot \
+    && chmod 755 /root \
+    && echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
 
 USER helixbot
 

--- a/src/fedora/39/amd64/Dockerfile
+++ b/src/fedora/39/amd64/Dockerfile
@@ -1,11 +1,13 @@
 FROM library/fedora:39
 
 RUN dnf upgrade --refresh -y \
-    && dnf --setopt=install_weak_deps=False install -y \
+    && dnf install --setopt tsflags=nodocs -y \
+        dnf-plugins-core \
+    && dnf config-manager --add-repo=https://packages.microsoft.com/fedora/39/prod/config.repo \
+    && dnf install --setopt=install_weak_deps=False --setopt tsflags=nodocs -y \
         # Base toolchain we need to build anything (clang, cmake, make and the like)
         clang \
         cmake \
-        dnf-plugins-core \
         findutils \
         gdb \
         glibc-langpack-en \
@@ -15,12 +17,6 @@ RUN dnf upgrade --refresh -y \
         pigz \
         python \
         which \
-    && dnf clean all
-
-# Add MS package repo.
-RUN dnf config-manager --add-repo=https://packages.microsoft.com/fedora/39/prod/config.repo
-
-RUN dnf --setopt=install_weak_deps=False install -y \
         # Tools used by build automation
         azure-cli \
         git \

--- a/src/fedora/40/amd64/Dockerfile
+++ b/src/fedora/40/amd64/Dockerfile
@@ -1,11 +1,13 @@
 FROM library/fedora:40
 
 RUN dnf upgrade --refresh -y \
-    && dnf --setopt=install_weak_deps=False install -y \
+    && dnf install --setopt tsflags=nodocs -y \
+        dnf-plugins-core \
+    && dnf config-manager --add-repo=https://packages.microsoft.com/fedora/40/prod/config.repo \
+    && dnf install --setopt=install_weak_deps=False --setopt tsflags=nodocs -y \
         # Base toolchain we need to build anything (clang, cmake, make and the like)
         clang \
         cmake \
-        dnf-plugins-core \
         findutils \
         gdb \
         glibc-langpack-en \
@@ -15,12 +17,6 @@ RUN dnf upgrade --refresh -y \
         pigz \
         python \
         which \
-    && dnf clean all
-
-# Add MS package repo.
-RUN dnf config-manager --add-repo=https://packages.microsoft.com/fedora/40/prod/config.repo
-
-RUN dnf --setopt=install_weak_deps=False install -y \
         # Tools used by build automation
         azure-cli \
         git \

--- a/src/fedora/41/amd64/Dockerfile
+++ b/src/fedora/41/amd64/Dockerfile
@@ -1,10 +1,8 @@
 FROM library/fedora:41
 
-# Add MS package repo.
-RUN dnf config-manager addrepo --from-repofile=https://packages.microsoft.com/fedora/41/prod/config.repo
-
 RUN dnf upgrade --refresh -y \
-    && dnf --setopt=install_weak_deps=False install -y \
+    && dnf config-manager addrepo --from-repofile=https://packages.microsoft.com/fedora/41/prod/config.repo \
+    && dnf install --setopt=install_weak_deps=False --setopt tsflags=nodocs -y \
         # Base toolchain we need to build anything (clang, cmake, make and the like)
         clang \
         cmake \


### PR DESCRIPTION
Fixes #https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/1234

The PR contains the following changes
1. Add package upgrade logic to the centos Dockerfiles
2. Misc reformatting for consistency and optimization to the centos Dockerfiles
3. Update all dnf usages to specify `--setopt tsflags=nodocs`