### PR TITLE
Add package upgrade logic to debian Dockerfiles and misc format cleanup

### DIFF
--- a/src/debian/11/amd64/Dockerfile
+++ b/src/debian/11/amd64/Dockerfile
@@ -3,44 +3,53 @@ FROM library/debian:bullseye
 # Dependencies for generic .NET Core builds and the base toolchain we need to
 # build anything (clang, cmake, make and the like)
 RUN apt-get update \
+    && apt-get upgrade -y \
     && apt-get install -y \
-            autoconf \
-            automake \
-            azure-cli \
-            build-essential \
-            clang \
-            cmake \
-            curl \
-            elfutils \
-            file \
-            g++ \
-            gettext \
-            gdb \
-            git \
-            gnupg \
-            jq \
-            libcurl4-openssl-dev \
-            libgdiplus \
-            libicu-dev \
-            libkrb5-dev \
-            liblldb-dev \
-            liblttng-ust-dev \
-            libnuma-dev \
-            libssl-dev \
-            libssl1.1 \
-            libtool \
-            libunwind8-dev \
-            lldb \
-            llvm \
-            locales \
-            make \
-            pigz \
-            python-lldb \
-            sudo \
-            tar \
-            uuid-dev \
-            zip \
-            zlib1g-dev \
+        apt-transport-https \
+        curl \
+        software-properties-common \
+    && curl -sL https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb -o packages-microsoft-prod.deb \
+    && dpkg -i packages-microsoft-prod.deb \
+    && rm packages-microsoft-prod.deb \
+    && apt-get update \
+    && apt-get install -y \
+        autoconf \
+        automake \
+        azure-cli \
+        build-essential \
+        clang \
+        cmake \
+        elfutils \
+        file \
+        g++ \
+        gettext \
+        gdb \
+        git \
+        gnupg \
+        jq \
+        libcurl4-openssl-dev \
+        libgdiplus \
+        libicu-dev \
+        libkrb5-dev \
+        liblldb-dev \
+        liblttng-ust-dev \
+        libnuma-dev \
+        libssl-dev \
+        libssl1.1 \
+        libtool \
+        libunwind8-dev \
+        lldb \
+        llvm \
+        locales \
+        make \
+        pigz \
+        powershell \
+        python-lldb \
+        sudo \
+        tar \
+        uuid-dev \
+        zip \
+        zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # .NET SDK MSBuild requires US.UTF-8 locale to execute tasks
@@ -49,16 +58,3 @@ RUN echo "locales locales/default_environment_locale select en_US.UTF-8" | debco
     && echo "locales locales/locales_to_be_generated multiselect en_US.UTF-8 UTF-8" | debconf-set-selections \
     && rm "/etc/locale.gen" \
     && dpkg-reconfigure --frontend noninteractive locales
-
-# Install powershell.
-RUN apt-get update && \
-    apt-get install -y \
-      apt-transport-https \
-      software-properties-common \
-      curl && \
-    curl -sL https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb -o packages-microsoft-prod.deb && \
-    dpkg -i packages-microsoft-prod.deb && \
-    rm packages-microsoft-prod.deb && \
-    apt-get update && \
-    apt-get install -y powershell && \
-    rm -rf /var/lib/apt/lists/*

--- a/src/debian/11/helix/amd64/Dockerfile
+++ b/src/debian/11/helix/amd64/Dockerfile
@@ -2,13 +2,21 @@ FROM library/debian:bullseye
 
 # Install Helix Dependencies
 
-RUN apt-get update && \
-    apt-get install -y \
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y \
+        apt-transport-https \
+        curl \
+        software-properties-common \
+    && curl -sL https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb -o packages-microsoft-prod.deb \
+    && dpkg -i packages-microsoft-prod.deb \
+    && rm packages-microsoft-prod.deb \
+    && apt-get update \
+    && apt-get install -y \
         autoconf \
         automake \
         at \
         build-essential \
-        curl \
         gcc \
         gdb \
         git \
@@ -17,6 +25,7 @@ RUN apt-get update && \
         libffi-dev \
         libgdiplus \
         libicu-dev \
+        libmsquic \
         libssl-dev \
         libtool \
         libunwind8 \
@@ -26,7 +35,6 @@ RUN apt-get update && \
         python3-dev \
         python3-pip \
         python3-venv \
-        software-properties-common \
         sudo \
         tzdata \
         unzip \
@@ -35,25 +43,15 @@ RUN apt-get update && \
 
 ENV LANG=en_US.utf8
 
-RUN ln -sf /usr/bin/python3 /usr/bin/python && \
-    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    pip install ./helix_scripts-*-py3-none-any.whl
-
-# Add MsQuic
-RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
-    echo 2cfd20a306b2fa5e25522d78f2ef50a1f429d35fd30bd983e2ebffc2b80944fa microsoft.asc| sha256sum --check - && \
-    apt-key add microsoft.asc && \
-    rm microsoft.asc && \
-    apt-add-repository https://packages.microsoft.com/debian/11/prod && \
-    apt-get update && \
-    apt-get install -y libmsquic && \
-    rm -rf /var/lib/apt/lists/*
+RUN ln -sf /usr/bin/python3 /usr/bin/python \
+    && pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
+    && pip install ./helix_scripts-*-py3-none-any.whl
 
 # Create helixbot user and give rights to sudo without password
 # additionally, preinstall the virtualenv packages used for VSTS reporting to save time
-RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm helixbot && \
-    chmod 755 /root && \
-    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
+RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm helixbot \
+    && chmod 755 /root \
+    && echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
 
 USER helixbot
 

--- a/src/debian/11/helix/arm32v7/Dockerfile
+++ b/src/debian/11/helix/arm32v7/Dockerfile
@@ -5,13 +5,21 @@ ENV _PYTHON_HOST_PLATFORM=linux_armv7l
 
 # Install Helix Dependencies
 
-RUN apt-get update && \
-    apt-get install -y \
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y \
+        apt-transport-https \
+        curl \
+        software-properties-common \
+    && curl -sL https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb -o packages-microsoft-prod.deb \
+    && dpkg -i packages-microsoft-prod.deb \
+    && rm packages-microsoft-prod.deb \
+    && apt-get update \
+    && apt-get install -y \
         autoconf \
         automake \
         at \
         build-essential \
-        curl \
         gcc \
         gdb \
         git \
@@ -20,6 +28,7 @@ RUN apt-get update && \
         libffi-dev \
         libgdiplus \
         libicu-dev \
+        libmsquic \
         libssl-dev \
         libtool \
         libunwind8 \
@@ -30,39 +39,27 @@ RUN apt-get update && \
         python3-dev \
         python3-pip \
         python3-venv \
-        software-properties-common \
         sudo \
         tzdata \
         unzip \
     && rm -rf /var/lib/apt/lists/* \
-    \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
-
-# Add MsQuic
-RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
-    echo 2cfd20a306b2fa5e25522d78f2ef50a1f429d35fd30bd983e2ebffc2b80944fa microsoft.asc| sha256sum --check - && \
-    apt-key add microsoft.asc && \
-    rm microsoft.asc && \
-    apt-add-repository https://packages.microsoft.com/debian/11/prod && \
-    apt-get update && \
-    apt-get install -y libmsquic && \
-    rm -rf /var/lib/apt/lists/*
 
 ENV LANG=en_US.utf8
 
-RUN ln -sf /usr/bin/python3 /usr/bin/python && \
-    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    export CRYPTOGRAPHY_DONT_BUILD_RUST=1 && \
-    pip install ./helix_scripts-*-py3-none-any.whl
+RUN ln -sf /usr/bin/python3 /usr/bin/python \
+    && pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
+    && export CRYPTOGRAPHY_DONT_BUILD_RUST=1 \
+    && pip install ./helix_scripts-*-py3-none-any.whl
 
 # Create helixbot user and give rights to sudo without password
 # (we use two users here to ensure volume mounting works with two possible UIDs of the host UID)
 # additionally, preinstall the virtualenv packages used for VSTS reporting to save time
-RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1001 --shell /bin/bash --ingroup adm helixbot && \
-    /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm helixbot2 && \
-    chmod 755 /root && \
-    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers && \
-    echo "helixbot2 ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
+RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1001 --shell /bin/bash --ingroup adm helixbot \
+    && /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm helixbot2 \
+    && chmod 755 /root \
+    && echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers \
+    && echo "helixbot2 ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
 
 USER helixbot
 

--- a/src/debian/11/helix/arm64v8/Dockerfile
+++ b/src/debian/11/helix/arm64v8/Dockerfile
@@ -2,14 +2,22 @@ FROM library/debian:bullseye
 
 # Install Helix Dependencies
 
-RUN apt-get update && \
-    apt-get install -y \
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y \
+        apt-transport-https \
+        curl \
+        software-properties-common \
+    && curl -sL https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb -o packages-microsoft-prod.deb \
+    && dpkg -i packages-microsoft-prod.deb \
+    && rm packages-microsoft-prod.deb \
+    && apt-get update \
+    && apt-get install -y \
         autoconf \
         automake \
         at \
         build-essential \
         cmake \
-        curl \
         gcc \
         gdb \
         git \
@@ -18,6 +26,7 @@ RUN apt-get update && \
         libffi-dev \
         libgdiplus \
         libicu-dev \
+        libmsquic \
         libssl-dev \
         libtool \
         libunwind8 \
@@ -27,39 +36,27 @@ RUN apt-get update && \
         python3-dev \
         python3-pip \
         python3-venv \
-        software-properties-common \
         sudo \
         tzdata \
         unzip \
     && rm -rf /var/lib/apt/lists/* \
-    \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
 ENV LANG=en_US.utf8
 
-RUN ln -sf /usr/bin/python3 /usr/bin/python && \
-    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    export CRYPTOGRAPHY_DONT_BUILD_RUST=1 && \
-    pip install ./helix_scripts-*-py3-none-any.whl
-
-# Add MsQuic
-RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
-    echo 2cfd20a306b2fa5e25522d78f2ef50a1f429d35fd30bd983e2ebffc2b80944fa microsoft.asc| sha256sum --check - && \
-    apt-key add microsoft.asc && \
-    rm microsoft.asc && \
-    apt-add-repository https://packages.microsoft.com/debian/11/prod && \
-    apt-get update && \
-    apt-get install -y libmsquic && \
-    rm -rf /var/lib/apt/lists/*
+RUN ln -sf /usr/bin/python3 /usr/bin/python \
+    && pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
+    && export CRYPTOGRAPHY_DONT_BUILD_RUST=1 \
+    && pip install ./helix_scripts-*-py3-none-any.whl
 
 # Create helixbot users and give rights to sudo without password
 # (we use two users here to ensure volume mounting works with two possible UIDs of the host UID)
 # additionally, preinstall the virtualenv packages used for VSTS reporting to save time
-RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1001 --shell /bin/bash --ingroup adm helixbot && \
-    /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm helixbot2 && \
-    chmod 755 /root && \
-    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers && \
-    echo "helixbot2 ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers 
+RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1001 --shell /bin/bash --ingroup adm helixbot \
+    && /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm helixbot2 \
+    && chmod 755 /root \
+    && echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers \
+    && echo "helixbot2 ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers 
 
 USER helixbot
 

--- a/src/debian/11/opt/arm64v8/Dockerfile
+++ b/src/debian/11/opt/arm64v8/Dockerfile
@@ -2,34 +2,35 @@ FROM library/debian:bullseye
 
 # Dependencies for generic .NET Core optimization runs
 RUN apt-get update \
+    && apt-get upgrade -y \
     && apt-get install -y \
-            autoconf \
-            automake \
-            build-essential \
-            cmake \
-            curl \
-            g++ \
-            gettext \
-            gdb \
-            git \
-            gnupg \
-            jq \
-            libcurl4-openssl-dev \
-            libgdiplus \
-            libicu-dev \
-            libkrb5-dev \
-            liblttng-ust-dev \
-            libnuma-dev \
-            libtool \
-            libunwind8-dev \
-            llvm-9 \
-            locales \
-            make \
-            sudo \
-            tar \
-            uuid-dev \
-            zip \
-            zlib1g-dev \
+        autoconf \
+        automake \
+        build-essential \
+        cmake \
+        curl \
+        g++ \
+        gettext \
+        gdb \
+        git \
+        gnupg \
+        jq \
+        libcurl4-openssl-dev \
+        libgdiplus \
+        libicu-dev \
+        libkrb5-dev \
+        liblttng-ust-dev \
+        libnuma-dev \
+        libtool \
+        libunwind8-dev \
+        llvm-9 \
+        locales \
+        make \
+        sudo \
+        tar \
+        uuid-dev \
+        zip \
+        zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Link llvm-profdata-9 to llvm-profdata

--- a/src/debian/12/gcc14/amd64/Dockerfile
+++ b/src/debian/12/gcc14/amd64/Dockerfile
@@ -1,11 +1,19 @@
 FROM library/gcc:14-bookworm
 
 # Dependencies for dotnet/runtime native components.
-RUN apt-get update && \
-    apt-get install -y \
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y \
+        apt-transport-https \
+        curl \
+        software-properties-common \
+    && curl -sL https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -o packages-microsoft-prod.deb \
+    && dpkg -i packages-microsoft-prod.deb \
+    && rm packages-microsoft-prod.deb \
+    && apt-get update \
+    && apt-get install -y \
         azure-cli \
         cmake \
-        curl \
         gdb \
         git \
         iputils-ping \
@@ -18,6 +26,7 @@ RUN apt-get update && \
         locales \
         locales-all \
         pigz \
+        powershell \
         python3-dev \
         python3-pip \
         sudo \
@@ -29,18 +38,5 @@ ENV LANG=en_US.utf8
 
 # These symlinks are required because this docker has gcc-12 suffixed with version and gcc-14 unsuffixed in PATH.
 # In the runtime repo, we (by design) give precedence to suffixed compilers before selecting unsuffixed one in PATH.
-RUN ln -s $(command -v gcc) /usr/bin/gcc-14 && \
-    ln -s $(command -v g++) /usr/bin/g++-14
-
-# Install powershell. Specifically use deb 11 PMC because 12 doesn't have it yet.
-RUN apt-get update && \
-    apt-get install -y \
-      apt-transport-https \
-      software-properties-common \
-      curl && \
-    curl -sL https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb -o packages-microsoft-prod.deb && \
-    dpkg -i packages-microsoft-prod.deb && \
-    rm packages-microsoft-prod.deb && \
-    apt-get update && \
-    apt-get install -y powershell && \
-    rm -rf /var/lib/apt/lists/*
+RUN ln -s $(command -v gcc) /usr/bin/gcc-14 \
+    && ln -s $(command -v g++) /usr/bin/g++-14

--- a/src/debian/12/helix/amd64/Dockerfile
+++ b/src/debian/12/helix/amd64/Dockerfile
@@ -1,23 +1,33 @@
 FROM library/debian:bookworm AS venv
 
-RUN apt-get update && \
-    apt-get install -y \
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y \
         coreutils \
         python3-dev \
         python3-pip \
         python3-venv \
     && rm -rf /var/lib/apt/lists/*
 
-RUN python3 -m venv /venv && \
-    . /venv/bin/activate && \
-    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    pip install ./helix_scripts-*-py3-none-any.whl
+RUN python3 -m venv /venv \
+    && . /venv/bin/activate \
+    && pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
+    && pip install ./helix_scripts-*-py3-none-any.whl
 
 FROM library/debian:bookworm
 
 # Install Helix Dependencies
-RUN apt-get update && \
-    apt-get install -y \
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y \
+        apt-transport-https \
+        curl \
+        software-properties-common \
+    && curl -sL https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -o packages-microsoft-prod.deb \
+    && dpkg -i packages-microsoft-prod.deb \
+    && rm packages-microsoft-prod.deb \
+    && apt-get update \
+    && apt-get install -y \
         autoconf \
         automake \
         at \
@@ -31,6 +41,7 @@ RUN apt-get update && \
         libffi-dev \
         libgdiplus \
         libicu-dev \
+        libmsquic \
         libssl-dev \
         libtool \
         libunwind8 \
@@ -49,21 +60,11 @@ RUN apt-get update && \
 
 ENV LANG=en_US.utf8
 
-# Add MsQuic
-RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
-    echo 2cfd20a306b2fa5e25522d78f2ef50a1f429d35fd30bd983e2ebffc2b80944fa microsoft.asc| sha256sum --check - && \
-    apt-key add microsoft.asc && \
-    rm microsoft.asc && \
-    echo deb https://packages.microsoft.com/debian/12/prod bookworm main >> /etc/apt/sources.list.d/microsoft.list && \
-    apt-get update && \
-    apt-get install -y libmsquic && \
-    rm -rf /var/lib/apt/lists/*
-
 # Create helixbot user and give rights to sudo without password
 # additionally, preinstall the virtualenv packages used for VSTS reporting to save time
-RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm helixbot && \
-    chmod 755 /root && \
-    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
+RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm helixbot \
+    && chmod 755 /root \
+    && echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
 
 USER helixbot
 

--- a/src/debian/12/helix/amd64/Dockerfile
+++ b/src/debian/12/helix/amd64/Dockerfile
@@ -32,7 +32,6 @@ RUN apt-get update \
         automake \
         at \
         build-essential \
-        curl \
         gcc \
         gdb \
         git \
@@ -51,7 +50,6 @@ RUN apt-get update \
         python3-dev \
         python3-pip \
         python3-venv \
-        software-properties-common \
         sudo \
         tzdata \
         unzip \

--- a/src/debian/12/helix/arm32v7/Dockerfile
+++ b/src/debian/12/helix/arm32v7/Dockerfile
@@ -1,7 +1,8 @@
 FROM library/debian:bookworm AS venv
 
-RUN apt-get update && \
-    apt-get install -y \
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y \
         curl \
         pkg-config \
         coreutils \
@@ -17,20 +18,28 @@ RUN apt-get update && \
 RUN curl -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-RUN python3 -m venv /venv && \
-    . /venv/bin/activate && \
-    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    pip install ./helix_scripts-*-py3-none-any.whl
+RUN python3 -m venv /venv \
+    && . /venv/bin/activate \
+    && pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
+    && pip install ./helix_scripts-*-py3-none-any.whl
 
 FROM library/debian:bookworm
 
-RUN apt-get update && \
-    apt-get install -y \
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y \
+        apt-transport-https \
+        curl \
+        software-properties-common \
+    && curl -sL https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -o packages-microsoft-prod.deb \
+    && dpkg -i packages-microsoft-prod.deb \
+    && rm packages-microsoft-prod.deb \
+    && apt-get update \
+    && apt-get install -y \
         autoconf \
         automake \
         at \
         build-essential \
-        curl \
         gcc \
         gdb \
         git \
@@ -39,6 +48,7 @@ RUN apt-get update && \
         libffi-dev \
         libgdiplus \
         libicu-dev \
+        libmsquic \
         libssl-dev \
         libtool \
         libunwind8 \
@@ -50,7 +60,6 @@ RUN apt-get update && \
         python3-dev \
         python3-pip \
         python3-venv \
-        software-properties-common \
         sudo \
         tzdata \
         unzip \
@@ -59,21 +68,11 @@ RUN apt-get update && \
 
 ENV LANG=en_US.utf8
 
-# Add MsQuic
-RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
-    echo 2cfd20a306b2fa5e25522d78f2ef50a1f429d35fd30bd983e2ebffc2b80944fa microsoft.asc| sha256sum --check - && \
-    apt-key add microsoft.asc && \
-    rm microsoft.asc && \
-    echo deb https://packages.microsoft.com/debian/12/prod bookworm main >> /etc/apt/sources.list.d/microsoft.list && \
-    apt-get update && \
-    apt-get install -y libmsquic && \
-    rm -rf /var/lib/apt/lists/*
-
 # Create helixbot user and give rights to sudo without password
 # additionally, preinstall the virtualenv packages used for VSTS reporting to save time
-RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm helixbot && \
-    chmod 755 /root && \
-    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
+RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm helixbot \
+    && chmod 755 /root \
+    && echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
 
 USER helixbot
 

--- a/src/debian/12/helix/arm64v8/Dockerfile
+++ b/src/debian/12/helix/arm64v8/Dockerfile
@@ -1,29 +1,37 @@
 FROM library/debian:bookworm AS venv
 
-RUN apt-get update && \
-    apt-get install -y \
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y \
         coreutils \
         python3-dev \
         python3-pip \
         python3-venv \
     && rm -rf /var/lib/apt/lists/*
 
-RUN python3 -m venv /venv && \
-    . /venv/bin/activate && \
-    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    pip install ./helix_scripts-*-py3-none-any.whl
+RUN python3 -m venv /venv \
+    && . /venv/bin/activate \
+    && pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
+    && pip install ./helix_scripts-*-py3-none-any.whl
 
 FROM library/debian:bookworm
 
 # Install Helix Dependencies
-RUN apt-get update && \
-    apt-get install -y \
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y \
+        apt-transport-https \
+        curl \
+        software-properties-common \
+    && curl -sL https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -o packages-microsoft-prod.deb \
+    && dpkg -i packages-microsoft-prod.deb \
+    && rm packages-microsoft-prod.deb \
+    && apt-get update \
+    && apt-get install -y \
         autoconf \
         automake \
         at \
         build-essential \
-        curl \
-        gcc \
         gdb \
         git \
         iputils-ping \
@@ -31,6 +39,7 @@ RUN apt-get update && \
         libffi-dev \
         libgdiplus \
         libicu-dev \
+        libmsquic \
         libssl-dev \
         libtool \
         libunwind8 \
@@ -40,7 +49,6 @@ RUN apt-get update && \
         python3-dev \
         python3-pip \
         python3-venv \
-        software-properties-common \
         sudo \
         tzdata \
         unzip \
@@ -49,21 +57,11 @@ RUN apt-get update && \
 
 ENV LANG=en_US.utf8
 
-# Add MsQuic
-RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
-    echo 2cfd20a306b2fa5e25522d78f2ef50a1f429d35fd30bd983e2ebffc2b80944fa microsoft.asc| sha256sum --check - && \
-    apt-key add microsoft.asc && \
-    rm microsoft.asc && \
-    echo deb https://packages.microsoft.com/debian/12/prod bookworm main >> /etc/apt/sources.list.d/microsoft.list && \
-    apt-get update && \
-    apt-get install -y libmsquic && \
-    rm -rf /var/lib/apt/lists/*
-
 # Create helixbot user and give rights to sudo without password
 # additionally, preinstall the virtualenv packages used for VSTS reporting to save time
-RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm helixbot && \
-    chmod 755 /root && \
-    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
+RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm helixbot \
+    && chmod 755 /root \
+    && echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
 
 USER helixbot
 

--- a/src/debian/12/helix/arm64v8/Dockerfile
+++ b/src/debian/12/helix/arm64v8/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update \
         automake \
         at \
         build-essential \
+        gcc \
         gdb \
         git \
         iputils-ping \


### PR DESCRIPTION
Fixes #https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/1235

The PR contains the following changes

1. Add package upgrade logic to the debian Dockerfiles
2. Misc reformatting for consistency and optimization to the debian Dockerfiles