### PR TITLE
Update python version used in opensuse

### DIFF
--- a/src/opensuse/15.6/helix/amd64/Dockerfile
+++ b/src/opensuse/15.6/helix/amd64/Dockerfile
@@ -27,8 +27,8 @@ RUN zypper ref \
         lldb-devel \
         llvm \
         lttng-ust-devel \
-        python3-devel \
-        python3-pip \
+        python311-devel \
+        python311-pip \
         sudo \
         unzip \
         wget \
@@ -46,7 +46,7 @@ RUN wget https://packages.microsoft.com/keys/microsoft.asc \
         libmsquic \
     && zypper clean -a
 
-RUN ln -sf /usr/bin/python3 /usr/bin/python \
+RUN ln -sf /usr/bin/python3.11 /usr/bin/python \
     && pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
     && pip install ./helix_scripts-*-py3-none-any.whl
 


### PR DESCRIPTION
Currently there are [numerous vulnerabilities](https://github.com/dotnet/dotnet-buildtools-prereqs-docker-internal/issues?q=is%3Aissue%20state%3Aopen%20opensuse%20%20cryptography) (Internal Microsoft link) in the Cryptography package (40.0.2) installed by the current version of python/pip (3.6).  To get a more recent Cryptography package, I had to update python to 3.11.  Looking at other buildtools images I see that we use newer python versions (e.g. Ubuntu-24.04-helix comes with 3.12.3).  I would like someone from @dotnet/dnceng to confirm this.