### PR TITLE
Add the cpio package to the docker images we build with

### DIFF
--- a/src/azurelinux/3.0/net9.0/crossdeps/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/crossdeps/amd64/Dockerfile
@@ -16,6 +16,7 @@ RUN tdnf update -y && \
         diffutils \
         icu \
         tar \
+        cpio \
         # Crosscomponents build dependencies
         glibc-devel \
         kernel-headers \

--- a/src/azurelinux/3.0/net9.0/crossdeps/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/crossdeps/amd64/Dockerfile
@@ -10,13 +10,13 @@ RUN tdnf update -y && \
         wget \
         # Common runtime build dependencies
         awk \
+        cpio \
         gcc \
         make \
         cmake \
         diffutils \
         icu \
         tar \
-        cpio \
         # Crosscomponents build dependencies
         glibc-devel \
         kernel-headers \

--- a/src/ubuntu/22.04/Dockerfile
+++ b/src/ubuntu/22.04/Dockerfile
@@ -54,6 +54,7 @@ RUN apt-get update \
     && apt-get install -y \
         autoconf \
         automake \
+        cpio \
         curl \
         build-essential \
         gettext \
@@ -69,7 +70,6 @@ RUN apt-get update \
         libunwind8-dev \
         uuid-dev \
         zlib1g-dev \
-        cpio \
     && rm -rf /var/lib/apt/lists/*
 
 # Dependencies for VMR/source-build tests

--- a/src/ubuntu/22.04/Dockerfile
+++ b/src/ubuntu/22.04/Dockerfile
@@ -69,6 +69,7 @@ RUN apt-get update \
         libunwind8-dev \
         uuid-dev \
         zlib1g-dev \
+        cpio \
     && rm -rf /var/lib/apt/lists/*
 
 # Dependencies for VMR/source-build tests


### PR DESCRIPTION
This package is installed by default on regular distro installs, but is not available in our docker containers today. This is needed for the new rpm tooling in Arcade.