### PR TITLE
Add more missing tools to the images the runtime tooling uses

### DIFF
--- a/src/almalinux/8/source-build/amd64/Dockerfile
+++ b/src/almalinux/8/source-build/amd64/Dockerfile
@@ -13,6 +13,7 @@ RUN dnf upgrade --refresh -y \
         automake \
         brotli-devel \
         cmake \
+        cpio \
         elfutils \
         file \
         gdb \

--- a/src/alpine/3.19/amd64/Dockerfile
+++ b/src/alpine/3.19/amd64/Dockerfile
@@ -12,6 +12,7 @@ RUN apk add --upgrade --no-cache \
         clang-dev \
         cmake \
         coreutils \
+        cpio \
         curl \
         elfutils \
         file \

--- a/src/alpine/3.20/amd64/Dockerfile
+++ b/src/alpine/3.20/amd64/Dockerfile
@@ -12,6 +12,7 @@ RUN apk add --upgrade --no-cache \
         clang-dev \
         cmake \
         coreutils \
+        cpio \
         curl \
         elfutils \
         file \

--- a/src/azurelinux/3.0/net9.0/crossdeps/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/crossdeps/amd64/Dockerfile
@@ -11,6 +11,7 @@ RUN tdnf update -y && \
         # Common runtime build dependencies
         awk \
         cpio \
+        file \
         gcc \
         make \
         cmake \

--- a/src/centos/stream9/amd64/Dockerfile
+++ b/src/centos/stream9/amd64/Dockerfile
@@ -16,6 +16,7 @@ RUN dnf upgrade --refresh -y \
         brotli-devel \
         clang \
         cmake \
+        cpio \
         curl-devel \
         doxygen \
         elfutils \

--- a/src/fedora/41/amd64/Dockerfile
+++ b/src/fedora/41/amd64/Dockerfile
@@ -27,6 +27,7 @@ RUN dnf upgrade --refresh -y \
         autoconf \
         automake \
         brotli-devel \
+        cpio \
         glibc-locale-source \
         iputils \
         jq \


### PR DESCRIPTION
Apparently the file tool also isn't available in the base azl3 image by default. Add it as the rpm tooling requires it.

Add cpio to the source-build images as well.