### PR TITLE
Fix S360 warnings in Android images

### DIFF
--- a/src/azurelinux/3.0/net9.0/android/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/android/Dockerfile
@@ -1,4 +1,46 @@
+ARG ANDROID_SDK_ROOT=/usr/local/android-sdk
+ARG ANDROID_NDK_VERSION=23.2.8568313
+ARG ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/$ANDROID_NDK_VERSION
+FROM mcr.microsoft.com/openjdk/jdk:17-mariner AS android-sdk-download
+ARG ANDROID_SDK_ROOT
+ARG ANDROID_NDK_VERSION
+ARG ANDROID_NDK_ROOT
+
+# Dependencies for Android build
+RUN tdnf update -y \
+    && tdnf install -y \
+        # Android dependencies
+        wget \
+        zip \
+        unzip
+
+# Grab the necessary Android SDK packages / tools
+RUN wget https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip \
+    && echo "2d2d50857e4eb553af5a6dc3ad507a17adf43d115264b1afc116f95c92e5e258 commandlinetools-linux-11076708_latest.zip" | sha256sum -c \
+    && mkdir -p /usr/local/cmdline-tools \
+    && unzip commandlinetools-linux-11076708_latest.zip -d /usr/local/cmdline-tools \
+    && rm -f commandlinetools-linux-11076708_latest.zip \
+    && yes | /usr/local/cmdline-tools/cmdline-tools/bin/sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" --licenses
+
+RUN yes | /usr/local/cmdline-tools/cmdline-tools/bin/sdkmanager --licenses
+RUN /usr/local/cmdline-tools/cmdline-tools/bin/sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" --install "build-tools;33.0.0" "platforms;android-33" "ndk;${ANDROID_NDK_VERSION}"
+
+# We can't upgrade the NDK version as the runtime repo requires tooling that only exists up to NDK 23
+# Remove all components of NDK 23 that are flagged by security scanners
+RUN rm -r ${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/linux-x86_64/python3/lib/python3.9/site-packages/ \
+    && rm -r ${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/linux-x86_64/bin/clang-tidy
+
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm
+
+# Install Microsoft OpenJDK from the Microsoft OpenJDK 17 Mariner image.
+ENV LANG=en_US.UTF-8
+ENV JAVA_HOME=/usr/lib/jvm/msopenjdk-17
+ENV PATH=$JAVA_HOME/bin:$PATH
+COPY --from=mcr.microsoft.com/openjdk/jdk:17-mariner $JAVA_HOME $JAVA_HOME
+ARG ANDROID_SDK_ROOT
+ARG ANDROID_NDK_VERSION
+ARG ANDROID_NDK_ROOT
+
 
 # Dependencies for Android build
 RUN tdnf update -y \
@@ -11,29 +53,7 @@ RUN tdnf update -y \
         # linux-bionic build dependencies
         openssl-devel
 
-# Install Microsoft OpenJDK from the Microsoft OpenJDK 8.0 Mariner image.
-ENV LANG=en_US.UTF-8
-ENV JAVA_HOME=/usr/lib/jvm/temurin-8-jdk
-ENV PATH=$JAVA_HOME/bin:$PATH
-COPY --from=mcr.microsoft.com/openjdk/jdk:8-mariner $JAVA_HOME $JAVA_HOME
+ENV ANDROID_SDK_ROOT=${ANDROID_SDK_ROOT}
+ENV ANDROID_NDK_ROOT=${ANDROID_NDK_ROOT}
 
-# Install Android NDK
-RUN wget https://dl.google.com/android/repository/android-ndk-r23c-linux.zip \
-    && echo "e5053c126a47e84726d9f7173a04686a71f9a67a android-ndk-r23c-linux.zip" | sha1sum -c \
-    && unzip android-ndk-r23c-linux.zip -d /usr/local \
-    && mv /usr/local/android-ndk-r23c /usr/local/android-ndk \
-    && rm -f android-ndk-r23c-linux.zip
-
-ENV ANDROID_NDK_ROOT=/usr/local/android-ndk
-
-# Grab the necessary Android SDK packages / tools
-RUN wget https://dl.google.com/android/repository/commandlinetools-linux-8092744_latest.zip \
-    && echo "d71f75333d79c9c6ef5c39d3456c6c58c613de30e6a751ea0dbd433e8f8b9cbf commandlinetools-linux-8092744_latest.zip" | sha256sum -c \
-    && mkdir -p /usr/local/android-sdk/cmdline-tools \
-    && unzip commandlinetools-linux-8092744_latest.zip -d /usr/local/android-sdk/cmdline-tools \
-    && rm -f commandlinetools-linux-8092744_latest.zip
-
-ENV ANDROID_SDK_ROOT=/usr/local/android-sdk
-
-RUN yes | $ANDROID_SDK_ROOT/cmdline-tools/cmdline-tools/bin/sdkmanager --licenses
-RUN $ANDROID_SDK_ROOT/cmdline-tools/cmdline-tools/bin/sdkmanager --install "build-tools;33.0.0" "platforms;android-33"
+COPY --from=android-sdk-download $ANDROID_SDK_ROOT $ANDROID_SDK_ROOT

--- a/src/cbl-mariner/2.0/android/Dockerfile
+++ b/src/cbl-mariner/2.0/android/Dockerfile
@@ -1,4 +1,39 @@
-FROM mcr.microsoft.com/openjdk/jdk:8-mariner
+ARG ANDROID_SDK_ROOT=/usr/local/android-sdk
+ARG ANDROID_NDK_VERSION=23.2.8568313
+ARG ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/$ANDROID_NDK_VERSION
+FROM mcr.microsoft.com/openjdk/jdk:17-mariner AS android-sdk-download
+ARG ANDROID_SDK_ROOT
+ARG ANDROID_NDK_VERSION
+ARG ANDROID_NDK_ROOT
+
+# Dependencies for Android build
+RUN tdnf update -y \
+    && tdnf install -y \
+        # Android dependencies
+        wget \
+        zip \
+        unzip
+
+# Grab the necessary Android SDK packages / tools
+RUN wget https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip \
+    && echo "2d2d50857e4eb553af5a6dc3ad507a17adf43d115264b1afc116f95c92e5e258 commandlinetools-linux-11076708_latest.zip" | sha256sum -c \
+    && mkdir -p /usr/local/cmdline-tools \
+    && unzip commandlinetools-linux-11076708_latest.zip -d /usr/local/cmdline-tools \
+    && rm -f commandlinetools-linux-11076708_latest.zip \
+    && yes | /usr/local/cmdline-tools/cmdline-tools/bin/sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" --licenses
+
+RUN yes | /usr/local/cmdline-tools/cmdline-tools/bin/sdkmanager --licenses
+RUN /usr/local/cmdline-tools/cmdline-tools/bin/sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" --install "build-tools;33.0.0" "platforms;android-33" "ndk;${ANDROID_NDK_VERSION}"
+
+# We can't upgrade the NDK version as the runtime repo requires tooling that only exists up to NDK 23
+# Remove all components of NDK 23 that are flagged by security scanners
+RUN rm -r ${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/linux-x86_64/python3/lib/python3.9/site-packages/ \
+    && rm -r ${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/linux-x86_64/bin/clang-tidy
+
+FROM mcr.microsoft.com/openjdk/jdk:17-mariner
+ARG ANDROID_SDK_ROOT
+ARG ANDROID_NDK_VERSION
+ARG ANDROID_NDK_ROOT
 
 # Dependencies for Android build
 RUN tdnf update -y \
@@ -28,23 +63,7 @@ RUN tdnf update -y \
         # ICU dependencies
         awk
 
-# Install Android NDK
-RUN wget https://dl.google.com/android/repository/android-ndk-r23c-linux.zip \
-    && echo "e5053c126a47e84726d9f7173a04686a71f9a67a android-ndk-r23c-linux.zip" | sha1sum -c \
-    && unzip android-ndk-r23c-linux.zip -d /usr/local \
-    && mv /usr/local/android-ndk-r23c /usr/local/android-ndk \
-    && rm -f android-ndk-r23c-linux.zip
+ENV ANDROID_SDK_ROOT=${ANDROID_SDK_ROOT}
+ENV ANDROID_NDK_ROOT=${ANDROID_NDK_ROOT}
 
-ENV ANDROID_NDK_ROOT=/usr/local/android-ndk
-
-# Grab the necessary Android SDK packages / tools
-RUN wget https://dl.google.com/android/repository/commandlinetools-linux-8092744_latest.zip \
-    && echo "d71f75333d79c9c6ef5c39d3456c6c58c613de30e6a751ea0dbd433e8f8b9cbf commandlinetools-linux-8092744_latest.zip" | sha256sum -c \
-    && mkdir -p /usr/local/android-sdk/cmdline-tools \
-    && unzip commandlinetools-linux-8092744_latest.zip -d /usr/local/android-sdk/cmdline-tools \
-    && rm -f commandlinetools-linux-8092744_latest.zip
-
-ENV ANDROID_SDK_ROOT=/usr/local/android-sdk
-
-RUN yes | $ANDROID_SDK_ROOT/cmdline-tools/cmdline-tools/bin/sdkmanager --licenses
-RUN $ANDROID_SDK_ROOT/cmdline-tools/cmdline-tools/bin/sdkmanager --install "build-tools;33.0.0" "platforms;android-33"
+COPY --from=android-sdk-download $ANDROID_SDK_ROOT $ANDROID_SDK_ROOT


### PR DESCRIPTION
Only use the Android command line tools to download the platform, build-tools, and ndk.

The most recent release of the command line tools still has a ton of vulnerabilities that light up on `docker scout` and S360.

Delete files in the NDK that are lighting up with `docker scout` that we don't use.

We can't upgrade the NDK as the Mono AOT compiler (in dotnet/runtime) depends on the `as` assembler being available, which is not the case in NDK 24 or newer. In any case, the python failures still exist in the most recently released NDK.

Contributes to dotnet/dotnet-buildtools-prereqs-docker-internal#112
Contributes to dotnet/dotnet-buildtools-prereqs-docker-internal#111
Contributes to dotnet/dotnet-buildtools-prereqs-docker-internal#97
Contributes to dotnet/dotnet-buildtools-prereqs-docker-internal#96
Contributes to dotnet/dotnet-buildtools-prereqs-docker-internal#95
Contributes to dotnet/dotnet-buildtools-prereqs-docker-internal#94
Contributes to dotnet/dotnet-buildtools-prereqs-docker-internal#93
Contributes to dotnet/dotnet-buildtools-prereqs-docker-internal#91
Contributes to dotnet/dotnet-buildtools-prereqs-docker-internal#89
Contributes to dotnet/dotnet-buildtools-prereqs-docker-internal#88
Contributes to dotnet/dotnet-buildtools-prereqs-docker-internal#86
Contributes to dotnet/dotnet-buildtools-prereqs-docker-internal#85
Contributes to dotnet/dotnet-buildtools-prereqs-docker-internal#83
Contributes to dotnet/dotnet-buildtools-prereqs-docker-internal#81
Contributes to dotnet/dotnet-buildtools-prereqs-docker-internal#90
Contributes to dotnet/dotnet-buildtools-prereqs-docker-internal#98
Contributes to dotnet/dotnet-buildtools-prereqs-docker-internal#113
Contributes to dotnet/dotnet-buildtools-prereqs-docker-internal#87

Validated that dotnet/runtime still builds with the new images in https://github.com/dotnet/runtime/pull/109622

cc: @MichaelSimons @steveisok 