### PR TITLE
Fix azurelinux-3.0-net9.0-android-openssl image to include OpenSSL

### DIFF
--- a/src/azurelinux/3.0/net9.0/cross/android/openssl/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/android/openssl/amd64/Dockerfile
@@ -2,9 +2,9 @@ FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-cross-and
 
 # Copy the OpenSSL headers and libs from the x64 rootfs into the Anroid NDK so dotnet/runtime's
 # OpenSSL headers hack can find them for the linux-bionic build.
-RUN mkdir -p /usr/local/android-ndk/usr/local/include && \
-    mkdir /usr/local/android-ndk/usr/local/lib && \
-    cp -r /crossrootfs/x64/usr/include/openssl  /usr/local/android-ndk/usr/local/include/openssl && \
-    cp -r /crossrootfs/x64/usr/include/x86_64-linux-gnu/openssl  /usr/local/android-ndk/usr/local/include && \
-    cp -r $(readlink -f /crossrootfs/x64/usr/lib/x86_64-linux-gnu/libssl.so)  /usr/local/android-ndk/usr/local/lib/libssl.so && \
-    cp -r $(readlink -f /crossrootfs/x64/usr/lib/x86_64-linux-gnu/libcrypto.so)  /usr/local/android-ndk/usr/local/lib/libcrypto.so
+RUN mkdir -p ${ANDROID_NDK_ROOT}/usr/local/include && \
+    mkdir ${ANDROID_NDK_ROOT}/usr/local/lib && \
+    cp -r /crossrootfs/x64/usr/include/openssl  ${ANDROID_NDK_ROOT}/usr/local/include/openssl && \
+    cp -r /crossrootfs/x64/usr/include/x86_64-linux-gnu/openssl  ${ANDROID_NDK_ROOT}/usr/local/include && \
+    cp -r $(readlink -f /crossrootfs/x64/usr/lib/x86_64-linux-gnu/libssl.so)  ${ANDROID_NDK_ROOT}/usr/local/lib/libssl.so && \
+    cp -r $(readlink -f /crossrootfs/x64/usr/lib/x86_64-linux-gnu/libcrypto.so)  ${ANDROID_NDK_ROOT}/usr/local/lib/libcrypto.so


### PR DESCRIPTION
https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1250 changed the path where Android NDK is installed but this image was still using the old path, causing dotnet/runtime linux-bionic build to break.