### PR TITLE
Fix tag for android-openssl image

### DIFF
--- a/src/azurelinux/manifest.json
+++ b/src/azurelinux/manifest.json
@@ -345,7 +345,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net9.0-android-openssl": {}
+                "azurelinux-3.0-net9.0-android-openssl": {},
+                "azurelinux-3.0-net9.0-cross-android-openssl": {}
               }
             }
           ]


### PR DESCRIPTION
The tag was missing the `cross` part which made it a bit confusing to map back to the correct Dockerfile. Add another tag so the existing one keeps working.