### PR TITLE
Add cpio to the ubuntu-24.04 Dockerfile

### DIFF
--- a/src/ubuntu/24.04/Dockerfile
+++ b/src/ubuntu/24.04/Dockerfile
@@ -39,6 +39,7 @@ RUN apt-get update \
         autoconf \
         automake \
         build-essential \
+        cpio \
         curl \
         gettext \
         jq \


### PR DESCRIPTION
It was missed in https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1246