### PR TITLE
Add lld explicitly to almalinux source-build image

### DIFF
--- a/src/almalinux/8/source-build/amd64/Dockerfile
+++ b/src/almalinux/8/source-build/amd64/Dockerfile
@@ -29,6 +29,7 @@ RUN dnf upgrade --refresh -y \
         libuuid-devel \
         libxml2-devel \
         llvm-toolset \
+        lld \
         # Requires powertools
         lttng-ust-devel \
         make \


### PR DESCRIPTION
In https://git.almalinux.org/rpms/llvm/commit/0d20929ba71d2f2e1bf5e1786a4ca7b3e6dcd24a the lld dependency got removed from the llvm-toolset package.

We now need to add it explicitly as it is required by e.g. the llvm-project repo build.