### PR TITLE
Re-enable Helix Debian 11 arm32 Dockerfile

### DIFF
--- a/src/debian/manifest.json
+++ b/src/debian/manifest.json
@@ -46,6 +46,20 @@
         {
           "platforms": [
             {
+              "architecture": "arm",
+              "dockerfile": "src/debian/11/helix/arm32v7",
+              "os": "linux",
+              "osVersion": "bullseye",
+              "tags": {
+                "debian-11-helix-arm32v7": {}
+              },
+              "variant": "v7"
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
               "architecture": "arm64",
               "dockerfile": "src/debian/11/opt/arm64v8",
               "os": "linux",


### PR DESCRIPTION
Related to https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/1132