### PR TITLE
Fix tag names for Azure Linux images

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The images produced from the Dockerfiles in this repository are published to the
 
 ## How to identify an image
 
-There are two tag formats used by the images from this repository. Most of the imagces follow the format `mcr.microsoft.com/dotnet-buildtools/prereqs:<os-name>-<os-version>-<variant>-<architecture>`.
+There are two tag formats used by the images from this repository. Most of the images follow the format `mcr.microsoft.com/dotnet-buildtools/prereqs:<os-name>-<os-version>-<variant>-<architecture>`.
 
 - `<os-name>` - Name of the Linux distribution or Windows OS the image is based on
 - `<os-version>` - Version of the OS
@@ -171,7 +171,7 @@ From this commit of the `image-info.dotnet-dotnet-buildtools-prereqs-docker-main
 
 The folder structure used in [src](./src) aligns with the tagging convention - `<os-name>-<os-version>-<variant>-<architecture>` or `<os-name>-<os-version>-<variant>-cross-<target>`.
 For example, the Dockerfile used to produce the `mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.20-amd64` image is stored in the [src/alpine/3.20/amd64](./src/alpine/3.20/amd64) folder.
-The Dockerfile used to produce the `mcr.`microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-cross-arm64` image is stored in the [src/azurelinux/3.0/net8.0/cross/arm64](./src/azurelinux/3.0/net8.0/cross/arm64) folder.
+The Dockerfile used to produce the `mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-cross-arm64` image is stored in the [src/azurelinux/3.0/net8.0/cross/arm64](./src/azurelinux/3.0/net8.0/cross/arm64) folder.
 
 If a Dockerfile is shared across multiple architectures, then the `<architecture>` folder should be omitted.
 For example, the [src\alpine\3.20\helix\Dockerfile](./src/alpine/3.20/helix/Dockerfile) is built for all supported architectures (amd64, arm64 and arm) therefore there is no architecture folder in its path.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ The cross-compilation images follow the format `mcr.microsoft.com/dotnet-buildto
 
 - `<target>` - Specifies the target for cross-compilation, including the targeted architecture and libc variant (glibc if not specified).
 
+Examples:
+
+- mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-cross-arm64
+- mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-cross-amd64-alpine
+
 ## How to modify or create a new image
 
 There will be a need for modifying existing Dockerfiles or creating new ones.

--- a/README.md
+++ b/README.md
@@ -12,19 +12,23 @@ The images produced from the Dockerfiles in this repository are published to the
 
 ## How to identify an image
 
-The tag format used by the images from this repository is `mcr.microsoft.com/dotnet-buildtools/prereqs:<os-name>-<os-version>-<variant>-<architecture>`
+There are two tag formats used by the images from this repository. Most of the imagces follow the format `mcr.microsoft.com/dotnet-buildtools/prereqs:<os-name>-<os-version>-<variant>-<architecture>`.
 
 - `<os-name>` - Name of the Linux distribution or Windows OS the image is based on
 - `<os-version>` - Version of the OS
 - `<variant>` - Name describing the specialization purpose of the image.
 Often special dependencies are needed for certain parts of the product.
 It can be beneficial to separate these dependencies into a separate Dockerfile/image.
-- `<architecture>` - Architecture of the OS (amd64 shall be implied if not specified).
+- `<architecture>` - Architecture of the OS.
 
 Examples:
 
-- mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.20
+- mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.20-amd64
 - mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-helix-arm64v8
+
+The cross-compilation images follow the format `mcr.microsoft.com/dotnet-buildtools/prereqs:<os-name>-<os-version>-<variant>-cross-<target>`. These are all implicitly amd64 images.
+
+- `<target>` - Specifies the target for cross-compilation, including the targeted architecture and libc variant (glibc if not specified).
 
 ## How to modify or create a new image
 
@@ -165,8 +169,8 @@ From this commit of the `image-info.dotnet-dotnet-buildtools-prereqs-docker-main
 
 ### Source Folder Structure
 
-The folder structure used in [src](./src) aligns with the tagging convention - `<os-name>-<os-version>-<variant>-<architecture>`.
-For example, the Dockerfile used to produce the `mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.20` image is stored in the [src/alpine/3.20/amd64](./src/alpine/3.20/amd64) folder.
+The folder structure used in [src](./src) aligns with the tagging convention - `<os-name>-<os-version>-<variant>-<architecture>` or `<os-name>-<os-version>-<variant>-cross-<target>`.
+For example, the Dockerfile used to produce the `mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.20-amd64` image is stored in the [src/alpine/3.20/amd64](./src/alpine/3.20/amd64) folder. The Dockerfile used to produce the `mcr.`microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-cross-arm64` image is stored in the [src/azurelinux/3.0/net8.0/cross/arm64](./src/azurelinux/3.0/net8.0/cross/arm64) folder.
 
 If a Dockerfile is shared across multiple architectures, then the `<architecture>` folder should be omitted.
 For example, the [src\alpine\3.20\helix\Dockerfile](./src/alpine/3.20/helix/Dockerfile) is built for all supported architectures (amd64, arm64 and arm) therefore there is no architecture folder in its path.
@@ -189,7 +193,7 @@ Each Dockerfile will have an entry that looks like the following.
       "os": "linux",
       "osVersion": "alpine3.20",
       "tags": {
-        "alpine-3.20": {}
+        "alpine-3.20-amd64": {}
       }
     }
   ]

--- a/README.md
+++ b/README.md
@@ -170,7 +170,8 @@ From this commit of the `image-info.dotnet-dotnet-buildtools-prereqs-docker-main
 ### Source Folder Structure
 
 The folder structure used in [src](./src) aligns with the tagging convention - `<os-name>-<os-version>-<variant>-<architecture>` or `<os-name>-<os-version>-<variant>-cross-<target>`.
-For example, the Dockerfile used to produce the `mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.20-amd64` image is stored in the [src/alpine/3.20/amd64](./src/alpine/3.20/amd64) folder. The Dockerfile used to produce the `mcr.`microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-cross-arm64` image is stored in the [src/azurelinux/3.0/net8.0/cross/arm64](./src/azurelinux/3.0/net8.0/cross/arm64) folder.
+For example, the Dockerfile used to produce the `mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.20-amd64` image is stored in the [src/alpine/3.20/amd64](./src/alpine/3.20/amd64) folder.
+The Dockerfile used to produce the `mcr.`microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-cross-arm64` image is stored in the [src/azurelinux/3.0/net8.0/cross/arm64](./src/azurelinux/3.0/net8.0/cross/arm64) folder.
 
 If a Dockerfile is shared across multiple architectures, then the `<architecture>` folder should be omitted.
 For example, the [src\alpine\3.20\helix\Dockerfile](./src/alpine/3.20/helix/Dockerfile) is built for all supported architectures (amd64, arm64 and arm) therefore there is no architecture folder in its path.

--- a/src/alpine/manifest.json
+++ b/src/alpine/manifest.json
@@ -10,7 +10,8 @@
               "os": "linux",
               "osVersion": "alpine3.17",
               "tags": {
-                "alpine-3.17": {}
+                "alpine-3.17": {},
+                "alpine-3.17-amd64": {}
               }
             }
           ]
@@ -104,7 +105,8 @@
               "os": "linux",
               "osVersion": "alpine3.18",
               "tags": {
-                "alpine-3.18": {}
+                "alpine-3.18": {},
+                "alpine-3.18-amd64": {}
               }
             }
           ]
@@ -116,7 +118,8 @@
               "os": "linux",
               "osVersion": "alpine3.18",
               "tags": {
-                "alpine-3.18-WithNode": {}
+                "alpine-3.18-WithNode": {},
+                "alpine-3.18-WithNode-amd64": {}
               }
             }
           ]
@@ -128,7 +131,8 @@
               "os": "linux",
               "osVersion": "alpine3.19",
               "tags": {
-                "alpine-3.19": {}
+                "alpine-3.19": {},
+                "alpine-3.19-amd64": {}
               }
             }
           ]
@@ -140,7 +144,8 @@
               "os": "linux",
               "osVersion": "alpine3.19",
               "tags": {
-                "alpine-3.19-WithNode": {}
+                "alpine-3.19-WithNode": {},
+                "alpine-3.19-WithNode-amd64": {}
               }
             }
           ]
@@ -193,7 +198,8 @@
               "os": "linux",
               "osVersion": "alpine3.20",
               "tags": {
-                "alpine-3.20": {}
+                "alpine-3.20": {},
+                "alpine-3.20-amd64": {}
               }
             }
           ]
@@ -205,7 +211,8 @@
               "os": "linux",
               "osVersion": "alpine3.20",
               "tags": {
-                "alpine-3.20-withnode": {}
+                "alpine-3.20-withnode": {},
+                "alpine-3.20-withnode-amd64": {}
               }
             }
           ]

--- a/src/azurelinux/3.0/net8.0/cross/amd64-alpine/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/cross/amd64-alpine/Dockerfile
@@ -1,12 +1,12 @@
 ARG ROOTFS_DIR=/crossrootfs/x64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh x64 alpine3.13 --skipunmount
 
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-llvm
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR

--- a/src/azurelinux/3.0/net8.0/cross/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/cross/amd64/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/x64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh x64 xenial --skipunmount
@@ -43,7 +43,7 @@ RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTI
     cp compiler-rt_build/lib/linux/libclang_rt.*-x86_64.a $SANITIZER_RUNTIMES_DIR
 
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-llvm
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR
 ARG LLVM_VERSION_MAJOR=16
 

--- a/src/azurelinux/3.0/net8.0/cross/arm-alpine/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/cross/arm-alpine/Dockerfile
@@ -1,12 +1,12 @@
 ARG ROOTFS_DIR=/crossrootfs/arm
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh arm alpine3.13 --skipunmount
 
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-llvm
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR

--- a/src/azurelinux/3.0/net8.0/cross/arm/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/cross/arm/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/arm
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh arm xenial --skipunmount
@@ -43,7 +43,7 @@ RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTI
     cp compiler-rt_build/lib/linux/libclang_rt.*-armhf.a $SANITIZER_RUNTIMES_DIR
 
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-llvm
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR
 ARG LLVM_VERSION_MAJOR=16
 

--- a/src/azurelinux/3.0/net8.0/cross/arm64-alpine/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/cross/arm64-alpine/Dockerfile
@@ -1,12 +1,12 @@
 ARG ROOTFS_DIR=/crossrootfs/arm64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh arm64 alpine3.13 --skipunmount
 
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-llvm
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR

--- a/src/azurelinux/3.0/net8.0/cross/arm64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/cross/arm64/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/arm64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh arm64 xenial --skipunmount
@@ -43,7 +43,7 @@ RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTI
     cp compiler-rt_build/lib/linux/libclang_rt.*-aarch64.a $SANITIZER_RUNTIMES_DIR
 
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-llvm
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR
 ARG LLVM_VERSION_MAJOR=16
 

--- a/src/azurelinux/3.0/net8.0/cross/x86/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/cross/x86/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/x86
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh x86 xenial --skipunmount
@@ -43,7 +43,7 @@ RUN LLVM_VERSION=16.0.0 LLVM_VERSION_MAJOR="${LLVM_VERSION%%.*}" SANITIZER_RUNTI
     cp compiler-rt_build/lib/linux/libclang_rt.*-i386.a $SANITIZER_RUNTIMES_DIR
 
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-llvm
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR
 ARG LLVM_VERSION_MAJOR=16
 

--- a/src/azurelinux/3.0/net8.0/crossdeps-llvm/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/crossdeps-llvm/amd64/Dockerfile
@@ -1,6 +1,6 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder-amd64 AS builder
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-amd64
 
 # Install LLVM that we built from source
 COPY --from=builder /usr/local /usr/local

--- a/src/azurelinux/3.0/net9.0/android/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/android/amd64/Dockerfile
@@ -30,7 +30,7 @@ RUN /usr/local/cmdline-tools/cmdline-tools/bin/sdkmanager --sdk_root="${ANDROID_
 RUN rm -r ${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/linux-x86_64/python3/lib/python3.9/site-packages/ \
     && rm -r ${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/linux-x86_64/bin/clang-tidy
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-amd64
 
 # Install Microsoft OpenJDK from the Microsoft OpenJDK 17 Mariner image.
 ENV LANG=en_US.UTF-8

--- a/src/azurelinux/3.0/net9.0/android/docker/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/android/docker/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-android
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-android-amd64
 
 RUN tdnf update -y \
     && tdnf install -y \

--- a/src/azurelinux/3.0/net9.0/cross/amd64-alpine/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/amd64-alpine/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/x64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh x64 alpine3.13 --skipunmount
@@ -30,7 +30,7 @@ RUN TARGET_TRIPLE="x86_64-alpine-linux-musl" && \
     cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
     cmake --install runtimes --prefix "$ROOTFS_DIR/usr"
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR

--- a/src/azurelinux/3.0/net9.0/cross/amd64-sanitizer/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/amd64-sanitizer/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/x64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
 # Use Ubuntu Bionic as the base image for the rootfs
@@ -38,10 +38,10 @@ RUN TARGET_TRIPLE="x86_64-linux-gnu" && \
         -DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
         -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON \
         -DCOMPILER_RT_INSTALL_PATH="/usr/local/lib/clang/$CLANG_MAJOR_VERSION" && \
-    cmake --build runtimes -j && \
+    cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
     cmake --install runtimes --prefix "$ROOTFS_DIR/usr"
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR
 
 COPY --from=builder /usr/local/lib/clang /usr/local/lib/clang

--- a/src/azurelinux/3.0/net9.0/cross/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/amd64/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/x64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh x64 xenial --skipunmount
@@ -39,7 +39,7 @@ RUN TARGET_TRIPLE="x86_64-linux-gnu" && \
     cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
     cmake --install runtimes --prefix "$ROOTFS_DIR/usr"
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR
 
 COPY --from=builder /usr/local/lib/clang /usr/local/lib/clang/

--- a/src/azurelinux/3.0/net9.0/cross/android/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/android/amd64/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-cross-amd64 AS crossrootx64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-android
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-android-amd64
 
 # Copy crossrootfs from AMD64 build image, so we can build Android-targeting code for that arch
 COPY --from=crossrootx64 /crossrootfs/x64 /crossrootfs/x64

--- a/src/azurelinux/3.0/net9.0/cross/arm-alpine/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/arm-alpine/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/arm
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh arm alpine3.13 --skipunmount
@@ -30,7 +30,7 @@ RUN TARGET_TRIPLE="armv7-alpine-linux-musleabihf" && \
     cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
     cmake --install runtimes --prefix "$ROOTFS_DIR/usr"
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR

--- a/src/azurelinux/3.0/net9.0/cross/arm/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/arm/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/arm
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
 # The arm rootfs targets Ubuntu 22.04, which is the first version with a
@@ -41,7 +41,7 @@ RUN TARGET_TRIPLE="arm-linux-gnueabihf" && \
     cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
     cmake --install runtimes --prefix "$ROOTFS_DIR/usr"
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR
 
 COPY --from=builder /usr/local/lib/clang /usr/local/lib/clang/

--- a/src/azurelinux/3.0/net9.0/cross/arm64-alpine/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/arm64-alpine/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/arm64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh arm64 alpine3.13 --skipunmount
@@ -30,7 +30,7 @@ RUN TARGET_TRIPLE="aarch64-alpine-linux-musl" && \
     cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
     cmake --install runtimes --prefix "$ROOTFS_DIR/usr"
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR

--- a/src/azurelinux/3.0/net9.0/cross/arm64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/arm64/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/arm64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh arm64 xenial --skipunmount
@@ -41,7 +41,7 @@ RUN TARGET_TRIPLE="aarch64-linux-gnu" && \
     cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
     cmake --install runtimes --prefix "$ROOTFS_DIR/usr"
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR
 
 COPY --from=builder /usr/local/lib/clang /usr/local/lib/clang/

--- a/src/azurelinux/3.0/net9.0/cross/armv6/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/armv6/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/armv6
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
 # Install raspbian package signing keys
@@ -12,7 +12,7 @@ RUN wget http://raspbian.raspberrypi.org/raspbian/pool/main/r/raspbian-archive-k
 
 RUN /scripts/eng/common/cross/build-rootfs.sh armv6 bookworm lldb13
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR
 
 COPY --from=builder "$ROOTFS_DIR" "$ROOTFS_DIR"

--- a/src/azurelinux/3.0/net9.0/cross/freebsd/13/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/freebsd/13/amd64/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/x64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
 # Install packages needed by the FreeBSD bootstrap scripts
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 RUN /scripts/eng/common/cross/build-rootfs.sh freebsd13 x64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR
 
 COPY --from=builder "$ROOTFS_DIR" "$ROOTFS_DIR"

--- a/src/azurelinux/3.0/net9.0/cross/ppc64le/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/ppc64le/Dockerfile
@@ -1,11 +1,11 @@
 ARG ROOTFS_DIR=/crossrootfs/ppc64le
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh bionic ppc64le
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR
 
 COPY --from=builder "$ROOTFS_DIR" "$ROOTFS_DIR"

--- a/src/azurelinux/3.0/net9.0/cross/riscv64-alpine/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/riscv64-alpine/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/riscv64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh riscv64 alpine3.20 --skipunmount
@@ -30,7 +30,7 @@ RUN TARGET_TRIPLE="riscv64-alpine-linux-musl" && \
     cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
     cmake --install runtimes --prefix "$ROOTFS_DIR/usr"
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR

--- a/src/azurelinux/3.0/net9.0/cross/riscv64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/riscv64/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/riscv64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
 # Install the latest debootstrap
@@ -47,7 +47,7 @@ RUN TARGET_TRIPLE="riscv64-linux-gnu" && \
     cmake --build runtimes -j $(getconf _NPROCESSORS_ONLN) && \
     cmake --install runtimes --prefix "$ROOTFS_DIR/usr"
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR
 
 COPY --from=builder /usr/local/lib/clang /usr/local/lib/clang/

--- a/src/azurelinux/3.0/net9.0/cross/s390x/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/s390x/Dockerfile
@@ -1,11 +1,11 @@
 ARG ROOTFS_DIR=/crossrootfs/s390x
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
 RUN /scripts/eng/common/cross/build-rootfs.sh bionic s390x
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR
 
 COPY --from=builder "$ROOTFS_DIR" "$ROOTFS_DIR"

--- a/src/azurelinux/3.0/net9.0/cross/x86/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/x86/Dockerfile
@@ -1,13 +1,13 @@
 ARG ROOTFS_DIR=/crossrootfs/x86
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
 # We don't ship linux-x86 binaries, so we don't need to make a custom libc++ build for servicing concerns.
 # We don't sanitize or instrument the linux-x64 build (as we don't ship it), so we don't need to build those runtime support libraries either.
 RUN /scripts/eng/common/cross/build-rootfs.sh x86 xenial --skipunmount
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR
 
 COPY --from=builder $ROOTFS_DIR $ROOTFS_DIR

--- a/src/azurelinux/3.0/net9.0/crossdeps-llvm/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/crossdeps-llvm/amd64/Dockerfile
@@ -1,6 +1,6 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-amd64 AS builder
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-amd64
 
 # Install LLVM that we built from source
 COPY --from=builder /usr/local /usr/local

--- a/src/azurelinux/manifest.json
+++ b/src/azurelinux/manifest.json
@@ -10,7 +10,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net8.0-crossdeps": {}
+                "azurelinux-3.0-net8.0-crossdeps-amd64": {}
               }
             }
           ]
@@ -22,7 +22,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net9.0-crossdeps": {}
+                "azurelinux-3.0-net9.0-crossdeps-amd64": {}
               }
             }
           ]
@@ -34,7 +34,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net8.0-crossdeps-builder": {}
+                "azurelinux-3.0-net8.0-crossdeps-builder-amd64": {}
               }
             }
           ]
@@ -46,7 +46,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net8.0-crossdeps-llvm": {}
+                "azurelinux-3.0-net8.0-crossdeps-llvm-amd64": {}
               }
             }
           ]
@@ -142,7 +142,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net9.0-fpm": {}
+                "azurelinux-3.0-net9.0-fpm-amd64": {}
               }
             }
           ]
@@ -154,7 +154,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net9.0-crossdeps-builder": {}
+                "azurelinux-3.0-net9.0-crossdeps-builder-amd64": {}
               }
             }
           ]
@@ -166,7 +166,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net9.0-crossdeps-llvm": {}
+                "azurelinux-3.0-net9.0-crossdeps-llvm-amd64": {}
               }
             }
           ]
@@ -305,11 +305,11 @@
         {
          "platforms": [
             {
-              "dockerfile": "src/azurelinux/3.0/net9.0/android",
+              "dockerfile": "src/azurelinux/3.0/net9.0/android/amd64",
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net9.0-android": {}
+                "azurelinux-3.0-net9.0-android-amd64": {}
               }
             }
           ]
@@ -329,11 +329,11 @@
         {
           "platforms": [
             {
-              "dockerfile": "src/azurelinux/3.0/net9.0/android/docker",
+              "dockerfile": "src/azurelinux/3.0/net9.0/android/docker/amd64",
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net9.0-android-docker": {}
+                "azurelinux-3.0-net9.0-android-docker-amd64": {}
               }
             }
           ]
@@ -346,7 +346,7 @@
               "osVersion": "azurelinux3.0",
               "tags": {
                 "azurelinux-3.0-net9.0-android-openssl": {},
-                "azurelinux-3.0-net9.0-cross-android-openssl": {}
+                "azurelinux-3.0-net9.0-cross-android-openssl-amd64": {}
               }
             }
           ]
@@ -358,7 +358,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net9.0-cross-freebsd-13": {}
+                "azurelinux-3.0-net9.0-cross-freebsd-13-amd64": {}
               }
             }
           ]

--- a/src/azurelinux/manifest.json
+++ b/src/azurelinux/manifest.json
@@ -333,6 +333,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
+                "azurelinux-3.0-net9.0-android-docker": {},
                 "azurelinux-3.0-net9.0-android-docker-amd64": {}
               }
             }
@@ -358,6 +359,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
+                "azurelinux-3.0-net9.0-cross-freebsd-13": {},
                 "azurelinux-3.0-net9.0-cross-freebsd-13-amd64": {}
               }
             }


### PR DESCRIPTION
The tag names should match the directory structure, and should include the architecture for arch-specific images.