### PR TITLE
Add back Emscripten install for net8.0 wasm image

### DIFF
--- a/src/azurelinux/3.0/net8.0/webassembly/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/webassembly/amd64/Dockerfile
@@ -14,6 +14,20 @@ RUN tdnf update -y \
 # WebAssembly build needs typescript
 RUN npm i -g typescript
 
+# Install Emscripten toolchain
+ENV EMSCRIPTEN_VERSION=3.1.34
+ENV EMSCRIPTEN_PATH=/usr/local/emscripten
+ENV EMSDK_PATH=/usr/local/emscripten/emsdk
+
+RUN mkdir ${EMSCRIPTEN_PATH} \
+    && cd ${EMSCRIPTEN_PATH} \
+    && git clone https://github.com/emscripten-core/emsdk.git ${EMSDK_PATH} \
+    && cd ${EMSDK_PATH} \
+    && git checkout ${EMSCRIPTEN_VERSION} \
+    && ./emsdk install ${EMSCRIPTEN_VERSION}-upstream \
+    && ./emsdk activate ${EMSCRIPTEN_VERSION}-upstream \
+    && chmod -R 777 ${EMSCRIPTEN_PATH}
+
 # Install V8 Engine
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/110199 is failing with:
```
src/libraries/sendtohelixhelp.proj(326,5): error : Could not find emsdk at , needed to provision for running tests on helix
```
I think we need to add back the EMSDK provision step that was removed in https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/992.  This could explain why the net8.0 build images were pinned to a specific version: https://github.com/dotnet/runtime/pull/110199#discussion_r1859075989.