### PR TITLE
Use wasi-sdk version 16 in net8.0 image

### DIFF
--- a/src/azurelinux/3.0/net8.0/webassembly/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/webassembly/amd64/Dockerfile
@@ -39,7 +39,7 @@ RUN curl -sSL https://netcorenativeassets.blob.core.windows.net/resource-package
     && chmod +x /usr/local/bin/v8
 
 # Install Wasi toolchain
-ENV WASI_SDK_VERSION=22
+ENV WASI_SDK_VERSION=16
 ENV WASI_SDK_PATH=/usr/local/wasi-sdk
 ENV WASI_SDK_URL=https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_SDK_VERSION}/wasi-sdk-${WASI_SDK_VERSION}.0-linux.tar.gz
 


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/110199 is failing with:

```
src/mono/mono.proj(209,5): error : (NETCORE_ENGINEERING_TELEMETRY=Build) Expected and actual version of WASI SDK does not match. Please delete /usr/local/wasi-sdk/ folder to provision a new version.
```

This image was [pinned](https://github.com/dotnet/runtime/pull/92232) to an older version in the .NET 8 builds shortly after the version was [updated](https://github.com/dotnet/dotnet-buildtools-prereqs-docker/commit/2aaa02c2be15e148aa07c94b729f6dba47042ac5) from 16 to 20. .NET 8 [expects](https://github.com/dotnet/runtime/blob/905ce13e78929bbb429258defff88f6d5626b894/src/mono/wasi/wasi-sdk-version.txt) version 16.