### PR TITLE
Add Debian 12 Dockerfile

### DIFF
--- a/src/debian/12/amd64/Dockerfile
+++ b/src/debian/12/amd64/Dockerfile
@@ -1,0 +1,60 @@
+FROM library/debian:bookworm
+
+# Dependencies for generic .NET Core builds and the base toolchain we need to
+# build anything (clang, cmake, make and the like)
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y \
+        apt-transport-https \
+        curl \
+        software-properties-common \
+    && curl -sL https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -o packages-microsoft-prod.deb \
+    && dpkg -i packages-microsoft-prod.deb \
+    && rm packages-microsoft-prod.deb \
+    && apt-get update \
+    && apt-get install -y \
+        autoconf \
+        automake \
+        azure-cli \
+        build-essential \
+        clang \
+        cmake \
+        elfutils \
+        file \
+        g++ \
+        gettext \
+        gdb \
+        git \
+        gnupg \
+        jq \
+        libcurl4-openssl-dev \
+        libgdiplus \
+        libicu-dev \
+        libkrb5-dev \
+        liblldb-dev \
+        liblttng-ust-dev \
+        libnuma-dev \
+        libssl-dev \
+        libssl1.1 \
+        libtool \
+        libunwind8-dev \
+        lldb \
+        llvm \
+        locales \
+        make \
+        pigz \
+        powershell \
+        python-lldb \
+        sudo \
+        tar \
+        uuid-dev \
+        zip \
+        zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# .NET SDK MSBuild requires US.UTF-8 locale to execute tasks
+# These commands are from https://askubuntu.com/a/1027038
+RUN echo "locales locales/default_environment_locale select en_US.UTF-8" | debconf-set-selections \
+    && echo "locales locales/locales_to_be_generated multiselect en_US.UTF-8 UTF-8" | debconf-set-selections \
+    && rm "/etc/locale.gen" \
+    && dpkg-reconfigure --frontend noninteractive locales

--- a/src/debian/manifest.json
+++ b/src/debian/manifest.json
@@ -61,6 +61,19 @@
           "platforms": [
             {
               "architecture": "amd64",
+              "dockerfile": "src/debian/12/amd64",
+              "os": "linux",
+              "osVersion": "bookworm",
+              "tags": {
+                "debian-12-amd64": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "architecture": "amd64",
               "dockerfile": "src/debian/12/helix/amd64",
               "os": "linux",
               "osVersion": "bookworm",


### PR DESCRIPTION
This is intended to be the replacement for the Debian 11 Dockerfile that will be removed by https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/1260.