### PR TITLE
Add 24.10 helix images

### DIFF
--- a/src/ubuntu/24.10/helix/Dockerfile
+++ b/src/ubuntu/24.10/helix/Dockerfile
@@ -1,0 +1,86 @@
+FROM ubuntu.azurecr.io/ubuntu:oracular AS venv
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y \
+        cargo \
+        pkg-config \
+        libffi-dev \
+        coreutils \
+        python3-dev \
+        python3-pip \
+        python3-venv \
+        libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m venv /venv && \
+    . /venv/bin/activate && \
+    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    pip install ./helix_scripts-*-py3-none-any.whl
+
+FROM ubuntu.azurecr.io/ubuntu:oracular
+ARG TARGETARCH
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN LIBCURL=libcurl4 && \
+    if [ "$TARGETARCH" = "arm" ]; then \
+        LIBCURL="libcurl4t64"; fi && \ 
+    apt-get update && \
+    apt-get install -qq -y \
+        autoconf \
+        automake \
+        build-essential \
+        cmake \
+        clang \
+        curl \
+        gcc \
+        gdb \
+        git \
+        gss-ntlmssp \
+        iputils-ping \
+        $LIBCURL \
+        libffi-dev \
+        libgdiplus \
+        libicu-dev \
+        libnuma1 \
+        libssl-dev \
+        libtool \
+        libunwind8 \
+        libunwind-dev \
+        lldb \
+        llvm \
+        locales \
+        locales-all \
+        python3-dev \
+        python3-pip \
+        python3-venv \
+        software-properties-common \
+        sudo \
+        tzdata \
+        unzip \
+    && rm -rf /var/lib/apt/lists/* \
+    \
+    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+ENV LANG=en_US.utf8
+
+# Add MsQuic
+RUN if [ "$TARGETARCH" = "arm" ]; then \
+        TARGETARCH="armhf"; fi && \ 
+    curl -O https://packages.microsoft.com/ubuntu/24.04/prod/pool/main/libm/libmsquic/libmsquic_2.4.1_$TARGETARCH.deb && \
+    dpkg -i libmsquic* && \
+    rm libmsquic*
+
+# create helixbot user and give rights to sudo without password
+RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1001 --shell /bin/bash --ingroup adm helixbot && \
+    chmod 755 /root && \
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
+
+USER helixbot
+
+# Install Helix Dependencies
+
+ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+COPY --from=venv /venv $VIRTUAL_ENV

--- a/src/ubuntu/24.10/helix/Dockerfile
+++ b/src/ubuntu/24.10/helix/Dockerfile
@@ -65,9 +65,7 @@ RUN LIBCURL=libcurl4 && \
 ENV LANG=en_US.utf8
 
 # Add MsQuic
-RUN if [ "$TARGETARCH" = "arm" ]; then \
-        TARGETARCH="armhf"; fi && \ 
-    curl -O https://packages.microsoft.com/ubuntu/24.04/prod/pool/main/libm/libmsquic/libmsquic_2.4.1_$TARGETARCH.deb && \
+RUN curl -O https://packages.microsoft.com/ubuntu/24.04/prod/pool/main/libm/libmsquic/libmsquic_2.4.1_$TARGETARCH.deb && \
     dpkg -i libmsquic* && \
     rm libmsquic*
 

--- a/src/ubuntu/manifest.json
+++ b/src/ubuntu/manifest.json
@@ -489,20 +489,6 @@
               "variant": "v8"
             }
           ]
-        },
-        {
-          "platforms": [
-            {
-              "architecture": "arm",
-              "dockerfile": "src/ubuntu/24.10/helix",
-              "os": "linux",
-              "osVersion": "oracular",
-              "tags": {
-                "ubuntu-24.10-helix-arm32v7": {}
-              },
-              "variant": "v7"
-            }
-          ]
         }
       ]
     }

--- a/src/ubuntu/manifest.json
+++ b/src/ubuntu/manifest.json
@@ -462,6 +462,47 @@
               "variant": "v7"
             }
           ]
+        },
+        {
+          "platforms": [
+            {
+              "architecture": "amd64",
+              "dockerfile": "src/ubuntu/24.10/helix",
+              "os": "linux",
+              "osVersion": "oracular",
+              "tags": {
+                "ubuntu-24.10-helix-amd64": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "architecture": "arm64",
+              "dockerfile": "src/ubuntu/24.10/helix",
+              "os": "linux",
+              "osVersion": "oracular",
+              "tags": {
+                "ubuntu-24.10-helix-arm64v8": {}
+              },
+              "variant": "v8"
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "architecture": "arm",
+              "dockerfile": "src/ubuntu/24.10/helix",
+              "os": "linux",
+              "osVersion": "oracular",
+              "tags": {
+                "ubuntu-24.10-helix-arm32v7": {}
+              },
+              "variant": "v7"
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
Prep for the eventual 26.04 release. I don't think we've typically added the regular Ubuntu releases. I believe we should.

There is no libmsquic available so took the easy path. The `2.4.5` image required more packages so the PR is using `2.4.1`.