### PR TITLE
Add a Fedora 41 helix image

### DIFF
--- a/src/fedora/40/helix/Dockerfile
+++ b/src/fedora/40/helix/Dockerfile
@@ -1,0 +1,70 @@
+FROM library/fedora:40 AS venv
+
+RUN dnf upgrade --refresh -y && \
+    dnf install --setopt tsflags=nodocs -y \
+        dnf-plugins-core && \
+    dnf install --setopt=install_weak_deps=False --setopt tsflags=nodocs -y \
+        openssl \
+        python3-devel \
+        python3-pip \
+        gcc \
+        libatomic \
+        redhat-rpm-config && \
+    dnf clean all
+
+RUN python3 -m venv /venv && \
+    source /venv/bin/activate && \
+    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    pip install ./helix_scripts-*-py3-none-any.whl
+
+FROM library/fedora:40
+
+# Install Helix Dependencies
+
+RUN dnf upgrade --refresh -y \
+    && dnf install --setopt tsflags=nodocs -y \
+        dnf-plugins-core \
+    && dnf config-manager --add-repo=https://packages.microsoft.com/fedora/40/prod/config.repo \
+    && dnf install --setopt=install_weak_deps=False --setopt tsflags=nodocs -y \
+        # Helix dependencies
+        python3 \
+        python3-pip \
+        # Tools used by build automation
+        azure-cli \
+        git \
+        jq \
+        tar \
+        redhat-rpm-config \
+        procps \
+        zip \
+        # Runtime dependencies
+        curl \
+        icu \
+        iputils \
+        krb5-libs \
+        libatomic \
+        libmsquic \
+        libunwind \
+        lttng-ust \
+        openssl \
+        sudo && \
+    dnf clean all
+
+# Needed for .NET libraries tests to pass
+ENV LANG=en-US.UTF-8
+
+# create helixbot user and give rights to sudo without password
+# Fedora does not have all options as other Linux systems
+RUN /usr/sbin/adduser --uid 1000 --shell /bin/bash --group adm helixbot && \
+    chmod 755 /root && \
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers && \
+    chmod +s /usr/bin/ping
+
+USER helixbot
+
+# Install Helix Dependencies
+
+ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+COPY --from=venv /venv $VIRTUAL_ENV

--- a/src/fedora/41/helix/Dockerfile
+++ b/src/fedora/41/helix/Dockerfile
@@ -1,4 +1,4 @@
-FROM library/fedora:40 AS venv
+FROM library/fedora:41 AS venv
 
 RUN dnf upgrade --refresh -y && \
     dnf install --setopt tsflags=nodocs -y \
@@ -17,14 +17,13 @@ RUN python3 -m venv /venv && \
     pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
     pip install ./helix_scripts-*-py3-none-any.whl
 
-FROM library/fedora:40
+FROM library/fedora:41
 
-# Install Helix Dependencies
+# Install Dependencies
 
 RUN dnf upgrade --refresh -y \
     && dnf install --setopt tsflags=nodocs -y \
         dnf-plugins-core \
-    && dnf config-manager --add-repo=https://packages.microsoft.com/fedora/40/prod/config.repo \
     && dnf install --setopt=install_weak_deps=False --setopt tsflags=nodocs -y \
         # Helix dependencies
         python3 \
@@ -43,12 +42,17 @@ RUN dnf upgrade --refresh -y \
         iputils \
         krb5-libs \
         libatomic \
-        libmsquic \
         libunwind \
         lttng-ust \
         openssl \
         sudo && \
     dnf clean all
+
+# Install MSQuic. Fedora 41 does not have it in the repositories, so use the Fedora 40 package
+
+RUN dnf config-manager addrepo --from-repofile=https://packages.microsoft.com/fedora/40/prod/config.repo && \
+    dnf install --setopt=install_weak_deps=False --setopt tsflags=nodocs -y \
+        libmsquic
 
 # Needed for .NET libraries tests to pass
 ENV LANG=en-US.UTF-8

--- a/src/fedora/41/helix/Dockerfile
+++ b/src/fedora/41/helix/Dockerfile
@@ -12,10 +12,11 @@ RUN dnf upgrade --refresh -y \
         redhat-rpm-config \
     && dnf clean all
 
-RUN python3 -m venv /venv && \
-    source /venv/bin/activate && \
-    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    pip install ./helix_scripts-*-py3-none-any.whl
+RUN python3 -m venv /venv \
+    && source /venv/bin/activate \
+    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
+    && pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
+    && pip install ./helix_scripts-*-py3-none-any.whl
 
 FROM library/fedora:41
 
@@ -45,13 +46,13 @@ RUN dnf upgrade --refresh -y \
         libunwind \
         lttng-ust \
         openssl \
-        sudo && \
-    dnf clean all
+        sudo \
+    && dnf clean all
 
 # Install MSQuic. Fedora 41 does not have it in the repositories, so use the Fedora 40 package
 
-RUN dnf config-manager addrepo --from-repofile=https://packages.microsoft.com/fedora/40/prod/config.repo && \
-    dnf install --setopt=install_weak_deps=False --setopt tsflags=nodocs -y \
+RUN dnf config-manager addrepo --from-repofile=https://packages.microsoft.com/fedora/40/prod/config.repo \
+    && dnf install --setopt=install_weak_deps=False --setopt tsflags=nodocs -y \
         libmsquic
 
 # Needed for .NET libraries tests to pass
@@ -59,10 +60,10 @@ ENV LANG=en-US.UTF-8
 
 # create helixbot user and give rights to sudo without password
 # Fedora does not have all options as other Linux systems
-RUN /usr/sbin/adduser --uid 1000 --shell /bin/bash --group adm helixbot && \
-    chmod 755 /root && \
-    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers && \
-    chmod +s /usr/bin/ping
+RUN /usr/sbin/adduser --uid 1000 --shell /bin/bash --group adm helixbot \
+    && chmod 755 /root \
+    && echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers \
+    && chmod +s /usr/bin/ping
 
 USER helixbot
 

--- a/src/fedora/41/helix/Dockerfile
+++ b/src/fedora/41/helix/Dockerfile
@@ -1,16 +1,16 @@
 FROM library/fedora:41 AS venv
 
-RUN dnf upgrade --refresh -y && \
-    dnf install --setopt tsflags=nodocs -y \
-        dnf-plugins-core && \
-    dnf install --setopt=install_weak_deps=False --setopt tsflags=nodocs -y \
+RUN dnf upgrade --refresh -y \
+    && dnf install --setopt tsflags=nodocs -y \
+        dnf-plugins-core \
+    && dnf install --setopt=install_weak_deps=False --setopt tsflags=nodocs -y \
         openssl \
         python3-devel \
         python3-pip \
         gcc \
         libatomic \
-        redhat-rpm-config && \
-    dnf clean all
+        redhat-rpm-config \
+    && dnf clean all
 
 RUN python3 -m venv /venv && \
     source /venv/bin/activate && \

--- a/src/fedora/manifest.json
+++ b/src/fedora/manifest.json
@@ -18,6 +18,18 @@
         {
           "platforms": [
             {
+              "dockerfile": "src/fedora/40/helix",
+              "os": "linux",
+              "osVersion": "fedora40",
+              "tags": {
+                "fedora-40-helix": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
               "dockerfile": "src/fedora/41/amd64",
               "os": "linux",
               "osVersion": "fedora41",

--- a/src/fedora/manifest.json
+++ b/src/fedora/manifest.json
@@ -18,11 +18,11 @@
         {
           "platforms": [
             {
-              "dockerfile": "src/fedora/40/helix",
+              "dockerfile": "src/fedora/41/amd64",
               "os": "linux",
-              "osVersion": "fedora40",
+              "osVersion": "fedora41",
               "tags": {
-                "fedora-40-helix": {}
+                "fedora-41": {}
               }
             }
           ]
@@ -30,11 +30,11 @@
         {
           "platforms": [
             {
-              "dockerfile": "src/fedora/41/amd64",
+              "dockerfile": "src/fedora/41/helix",
               "os": "linux",
               "osVersion": "fedora41",
               "tags": {
-                "fedora-41": {}
+                "fedora-41-helix": {}
               }
             }
           ]


### PR DESCRIPTION
We don't currently have any supported docker images for testing on Fedora. Add one for Fedora 41 so we can test with a supported docker image.