### PR TITLE
Add Azure Linux 3.0 testrunner image

### DIFF
--- a/src/azurelinux/3.0/docker-testrunner/Dockerfile
+++ b/src/azurelinux/3.0/docker-testrunner/Dockerfile
@@ -1,0 +1,16 @@
+# Dockerfile used to create a testrunner image that can perform Docker operations.
+# Usage:  docker run --rm -v /var/run/docker.sock:/var/run/docker.sock testrunner pwsh -File xyz.ps1
+
+FROM mcr.microsoft.com/azurelinux/base/core:3.0
+
+RUN tdnf install -y \
+        ca-certificates \
+        # Install Docker
+        moby-engine \
+        docker-buildx \
+        docker-cli \
+        # Test dependencies
+        azure-cli \
+        git \
+        powershell \
+    && tdnf clean all


### PR DESCRIPTION
Part 1/2 of [Upgrade testrunner image to Azure Linux 3.0 (dotnet/docker-tools#1513)](https://github.com/dotnet/docker-tools/issues/1513)