### PR TITLE
Add Debian trixie image

### DIFF
--- a/src/debian/13/helix/Dockerfile
+++ b/src/debian/13/helix/Dockerfile
@@ -8,8 +8,7 @@ RUN apt-get install -y \
         coreutils \
         python3-dev \
         python3-pip \
-        python3-venv \
-    && rm -rf /var/lib/apt/lists/*
+        python3-venv
 
 RUN python3 -m venv /venv \
     && . /venv/bin/activate \
@@ -20,14 +19,12 @@ FROM base
 ARG TARGETARCH
 
 # Install Helix Dependencies
-RUN apt-get install -y \
+RUN LIBCURL=libcurl4 \
+    && if [ "$TARGETARCH" = "arm" ]; then \
+           LIBCURL="libcurl4t64"; fi \ 
+    && apt-get install -y \
         apt-transport-https \
         curl \
-    && curl -sOL https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb \
-    && dpkg -i packages-microsoft-prod.deb \
-    && rm packages-microsoft-prod.deb \
-    && apt-get update \
-    && apt-get install -y \
         autoconf \
         automake \
         at \
@@ -38,9 +35,8 @@ RUN apt-get install -y \
         iputils-ping \
         libcurl4 \
         libffi-dev \
-        libgdiplus \
         libicu-dev \
-        libmsquic \
+        libnuma1 \
         libssl-dev \
         libtool \
         libunwind8 \
@@ -56,6 +52,10 @@ RUN apt-get install -y \
         unzip \
     && rm -rf /var/lib/apt/lists/* \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+RUN curl -O https://packages.microsoft.com/ubuntu/24.04/prod/pool/main/libm/libmsquic/libmsquic_2.4.7_$TARGETARCH.deb \
+    && dpkg -i libmsquic* \
+    && rm libmsquic*
 
 ENV LANG=en_US.utf8
 

--- a/src/debian/13/helix/Dockerfile
+++ b/src/debian/13/helix/Dockerfile
@@ -1,0 +1,74 @@
+FROM library/debian:trixie AS venv
+
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y \
+        coreutils \
+        python3-dev \
+        python3-pip \
+        python3-venv \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m venv /venv \
+    && . /venv/bin/activate \
+    && pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
+    && pip install ./helix_scripts-*-py3-none-any.whl
+
+FROM library/debian:trixie
+
+# Install Helix Dependencies
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y \
+        apt-transport-https \
+        curl \
+    && curl -sOL https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb \
+    && dpkg -i packages-microsoft-prod.deb \
+    && rm packages-microsoft-prod.deb \
+    && apt-get update \
+    && apt-get install -y \
+        autoconf \
+        automake \
+        at \
+        build-essential \
+        gcc \
+        gdb \
+        git \
+        iputils-ping \
+        libcurl4 \
+        libffi-dev \
+        libgdiplus \
+        libicu-dev \
+        libmsquic \
+        libssl-dev \
+        libtool \
+        libunwind8 \
+        lldb \
+        llvm \
+        locales \
+        locales-all \
+        python3-dev \
+        python3-pip \
+        python3-venv \
+        sudo \
+        tzdata \
+        unzip \
+    && rm -rf /var/lib/apt/lists/* \
+    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+ENV LANG=en_US.utf8
+
+# Create helixbot user and give rights to sudo without password
+# additionally, preinstall the virtualenv packages used for VSTS reporting to save time
+RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bash --ingroup adm helixbot \
+    && chmod 755 /root \
+    && echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers
+
+USER helixbot
+
+# Install Helix Dependencies
+
+ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+COPY --from=venv /venv $VIRTUAL_ENV

--- a/src/debian/13/helix/Dockerfile
+++ b/src/debian/13/helix/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update \
         python3-dev \
         python3-pip \
         python3-venv \
-        && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*
 
 RUN python3 -m venv /venv \
     && . /venv/bin/activate \

--- a/src/debian/13/helix/Dockerfile
+++ b/src/debian/13/helix/Dockerfile
@@ -1,8 +1,10 @@
-FROM library/debian:trixie AS venv
+FROM library/debian:trixie AS base
 
-RUN apt-get update \
-    && apt-get upgrade -y \
-    && apt-get install -y \
+RUN apt-get update
+
+FROM base AS venv
+
+RUN apt-get install -y \
         coreutils \
         python3-dev \
         python3-pip \
@@ -14,15 +16,11 @@ RUN python3 -m venv /venv \
     && pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
     && pip install ./helix_scripts-*-py3-none-any.whl
 
-FROM library/debian:trixie
+FROM base
+ARG TARGETARCH
 
 # Install Helix Dependencies
-RUN LIBCURL=libcurl4 && \
-if [ "$TARGETARCH" = "arm" ]; then \
-    LIBCURL="libcurl4t64"; fi && \ 
-    apt-get update \
-    && apt-get upgrade -y \
-    && apt-get install -y \
+RUN apt-get install -y \
         apt-transport-https \
         curl \
     && curl -sOL https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb \
@@ -38,7 +36,7 @@ if [ "$TARGETARCH" = "arm" ]; then \
         gdb \
         git \
         iputils-ping \
-        $LIBCURL \
+        libcurl4 \
         libffi-dev \
         libgdiplus \
         libicu-dev \

--- a/src/debian/13/helix/Dockerfile
+++ b/src/debian/13/helix/Dockerfile
@@ -17,7 +17,10 @@ RUN python3 -m venv /venv \
 FROM library/debian:trixie
 
 # Install Helix Dependencies
-RUN apt-get update \
+RUN LIBCURL=libcurl4 && \
+if [ "$TARGETARCH" = "arm" ]; then \
+    LIBCURL="libcurl4t64"; fi && \ 
+    apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y \
         apt-transport-https \
@@ -35,7 +38,7 @@ RUN apt-get update \
         gdb \
         git \
         iputils-ping \
-        libcurl4 \
+        $LIBCURL \
         libffi-dev \
         libgdiplus \
         libicu-dev \

--- a/src/debian/13/helix/Dockerfile
+++ b/src/debian/13/helix/Dockerfile
@@ -2,7 +2,11 @@ FROM library/debian:trixie AS venv
 
 RUN apt-get update \
     && apt-get install -y \
+        cargo \
         coreutils \
+        libffi-dev \
+        libssl-dev \
+        pkg-config \
         python3-dev \
         python3-pip \
         python3-venv \
@@ -77,7 +81,6 @@ RUN /usr/sbin/adduser --disabled-password --gecos '' --uid 1000 --shell /bin/bas
 USER helixbot
 
 # Install Helix Dependencies
-
 ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"

--- a/src/debian/13/helix/Dockerfile
+++ b/src/debian/13/helix/Dockerfile
@@ -59,7 +59,10 @@ RUN LIBCURL=libcurl4 \
     && rm -rf /var/lib/apt/lists/* \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
-RUN curl -O https://packages.microsoft.com/ubuntu/24.04/prod/pool/main/libm/libmsquic/libmsquic_2.4.7_$TARGETARCH.deb \
+RUN ARCH=$TARGETARCH \
+    && if [ "$TARGETARCH" = "arm" ]; then \
+        ARCH="armhf"; fi \
+    && curl -LO https://packages.microsoft.com/ubuntu/24.04/prod/pool/main/libm/libmsquic/libmsquic_2.4.7_$ARCH.deb \
     && dpkg -i libmsquic* \
     && rm libmsquic*
 

--- a/src/debian/13/helix/Dockerfile
+++ b/src/debian/13/helix/Dockerfile
@@ -1,27 +1,27 @@
-FROM library/debian:trixie AS base
+FROM library/debian:trixie AS venv
 
-RUN apt-get update
-
-FROM base AS venv
-
-RUN apt-get install -y \
+RUN apt-get update \
+    && apt-get install -y \
         coreutils \
         python3-dev \
         python3-pip \
-        python3-venv
+        python3-venv \
+        && rm -rf /var/lib/apt/lists/*
 
 RUN python3 -m venv /venv \
     && . /venv/bin/activate \
     && pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
     && pip install ./helix_scripts-*-py3-none-any.whl
 
-FROM base
+FROM library/debian:trixie
 ARG TARGETARCH
 
 # Install Helix Dependencies
 RUN LIBCURL=libcurl4 \
     && if [ "$TARGETARCH" = "arm" ]; then \
-           LIBCURL="libcurl4t64"; fi \ 
+          LIBCURL="libcurl4t64"; fi \
+    && apt-get update \
+    && apt-get upgrade -y \
     && apt-get install -y \
         apt-transport-https \
         curl \
@@ -36,7 +36,6 @@ RUN LIBCURL=libcurl4 \
         libcurl4 \
         libffi-dev \
         libicu-dev \
-        libnuma1 \
         libssl-dev \
         libtool \
         libunwind8 \
@@ -50,6 +49,13 @@ RUN LIBCURL=libcurl4 \
         sudo \
         tzdata \
         unzip \
+        # libmsquic dependencies
+        libbpf1 \
+        libelf1t64 \
+        libnl-3-200 \
+        libnl-route-3-200 \
+        libnuma1 \
+        libxdp1 \
     && rm -rf /var/lib/apt/lists/* \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 

--- a/src/debian/13/helix/Dockerfile
+++ b/src/debian/13/helix/Dockerfile
@@ -19,7 +19,7 @@ ARG TARGETARCH
 # Install Helix Dependencies
 RUN LIBCURL=libcurl4 \
     && if [ "$TARGETARCH" = "arm" ]; then \
-          LIBCURL="libcurl4t64"; fi \
+        LIBCURL="libcurl4t64"; fi \
     && apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y \
@@ -33,7 +33,7 @@ RUN LIBCURL=libcurl4 \
         gdb \
         git \
         iputils-ping \
-        libcurl4 \
+        $LIBCURL \
         libffi-dev \
         libicu-dev \
         libssl-dev \

--- a/src/debian/manifest.json
+++ b/src/debian/manifest.json
@@ -127,8 +127,22 @@
         {
           "platforms": [
             {
+              "architecture": "arm",
+              "dockerfile": "src/debian/13/helix/arm32v7",
+              "os": "linux",
+              "osVersion": "trixie",
+              "tags": {
+                "debian-13-helix-arm32v7": {}
+              },
+              "variant": "v7"
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
               "architecture": "arm64",
-              "dockerfile": "src/debian/12/helix/",
+              "dockerfile": "src/debian/13/helix/",
               "os": "linux",
               "osVersion": "trixie",
               "tags": {
@@ -137,7 +151,7 @@
               "variant": "v8"
             }
           ]
-        },
+        }
       ]
     }
   ]

--- a/src/debian/manifest.json
+++ b/src/debian/manifest.json
@@ -128,7 +128,7 @@
           "platforms": [
             {
               "architecture": "arm",
-              "dockerfile": "src/debian/13/helix/arm32v7",
+              "dockerfile": "src/debian/13/helix/",
               "os": "linux",
               "osVersion": "trixie",
               "tags": {

--- a/src/debian/manifest.json
+++ b/src/debian/manifest.json
@@ -110,7 +110,48 @@
               }
             }
           ]
-        }
+        },
+        {
+          "platforms": [
+            {
+              "architecture": "amd64",
+              "dockerfile": "src/debian/13/helix/",
+              "os": "linux",
+              "osVersion": "trixie",
+              "tags": {
+                "debian-13-helix-amd64": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "architecture": "arm",
+              "dockerfile": "src/debian/13/helix/",
+              "os": "linux",
+              "osVersion": "trixie",
+              "tags": {
+                "debian-13-helix-arm32v7": {}
+              },
+              "variant": "v7"
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "architecture": "arm64",
+              "dockerfile": "src/debian/12/helix/",
+              "os": "linux",
+              "osVersion": "trixie",
+              "tags": {
+                "debian-13-helix-arm64v8": {}
+              },
+              "variant": "v8"
+            }
+          ]
+        },
       ]
     }
   ]

--- a/src/debian/manifest.json
+++ b/src/debian/manifest.json
@@ -127,20 +127,6 @@
         {
           "platforms": [
             {
-              "architecture": "arm",
-              "dockerfile": "src/debian/13/helix/",
-              "os": "linux",
-              "osVersion": "trixie",
-              "tags": {
-                "debian-13-helix-arm32v7": {}
-              },
-              "variant": "v7"
-            }
-          ]
-        },
-        {
-          "platforms": [
-            {
               "architecture": "arm64",
               "dockerfile": "src/debian/12/helix/",
               "os": "linux",

--- a/src/debian/manifest.json
+++ b/src/debian/manifest.json
@@ -127,20 +127,6 @@
         {
           "platforms": [
             {
-              "architecture": "arm",
-              "dockerfile": "src/debian/13/helix/",
-              "os": "linux",
-              "osVersion": "trixie",
-              "tags": {
-                "debian-13-helix-arm32v7": {}
-              },
-              "variant": "v7"
-            }
-          ]
-        },
-        {
-          "platforms": [
-            {
               "architecture": "arm64",
               "dockerfile": "src/debian/13/helix/",
               "os": "linux",
@@ -149,6 +135,20 @@
                 "debian-13-helix-arm64v8": {}
               },
               "variant": "v8"
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "architecture": "arm",
+              "dockerfile": "src/debian/13/helix/",
+              "os": "linux",
+              "osVersion": "trixie",
+              "tags": {
+                "debian-13-helix-arm32v7": {}
+              },
+              "variant": "v7"
             }
           ]
         }


### PR DESCRIPTION
It's another Debian release year! My assumption is that we'll start shipping Trixie images in Preview 1, in February. We should look at starting testing in January.

I was unable to make Arm32 work per https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/1286

I adopted a slightly different pattern, which I think is superior:

- One `apt-get updated` is consumed by all stages.
- Upstream image is mentioned once
- Removed `apt-get upgrade -y`, which seems wasteful.