### PR TITLE
Delete libgdiplus from all images

### DIFF
--- a/src/debian/11/amd64/Dockerfile
+++ b/src/debian/11/amd64/Dockerfile
@@ -28,7 +28,6 @@ RUN apt-get update \
         gnupg \
         jq \
         libcurl4-openssl-dev \
-        libgdiplus \
         libicu-dev \
         libkrb5-dev \
         liblldb-dev \

--- a/src/debian/11/helix/amd64/Dockerfile
+++ b/src/debian/11/helix/amd64/Dockerfile
@@ -23,7 +23,6 @@ RUN apt-get update \
         iputils-ping \
         libcurl4 \
         libffi-dev \
-        libgdiplus \
         libicu-dev \
         libmsquic \
         libssl-dev \

--- a/src/debian/11/helix/arm32v7/Dockerfile
+++ b/src/debian/11/helix/arm32v7/Dockerfile
@@ -26,7 +26,6 @@ RUN apt-get update \
         iputils-ping \
         libcurl4 \
         libffi-dev \
-        libgdiplus \
         libicu-dev \
         libmsquic \
         libssl-dev \

--- a/src/debian/11/helix/arm64v8/Dockerfile
+++ b/src/debian/11/helix/arm64v8/Dockerfile
@@ -24,7 +24,6 @@ RUN apt-get update \
         iputils-ping \
         libcurl4 \
         libffi-dev \
-        libgdiplus \
         libicu-dev \
         libmsquic \
         libssl-dev \

--- a/src/debian/11/opt/arm64v8/Dockerfile
+++ b/src/debian/11/opt/arm64v8/Dockerfile
@@ -16,7 +16,6 @@ RUN apt-get update \
         gnupg \
         jq \
         libcurl4-openssl-dev \
-        libgdiplus \
         libicu-dev \
         libkrb5-dev \
         liblttng-ust-dev \

--- a/src/debian/12/helix/amd64/Dockerfile
+++ b/src/debian/12/helix/amd64/Dockerfile
@@ -38,7 +38,6 @@ RUN apt-get update \
         iputils-ping \
         libcurl4 \
         libffi-dev \
-        libgdiplus \
         libicu-dev \
         libmsquic \
         libssl-dev \

--- a/src/debian/12/helix/arm32v7/Dockerfile
+++ b/src/debian/12/helix/arm32v7/Dockerfile
@@ -46,7 +46,6 @@ RUN apt-get update \
         iputils-ping \
         libcurl4 \
         libffi-dev \
-        libgdiplus \
         libicu-dev \
         libmsquic \
         libssl-dev \

--- a/src/debian/12/helix/arm64v8/Dockerfile
+++ b/src/debian/12/helix/arm64v8/Dockerfile
@@ -38,7 +38,6 @@ RUN apt-get update \
         iputils-ping \
         libcurl4 \
         libffi-dev \
-        libgdiplus \
         libicu-dev \
         libmsquic \
         libssl-dev \

--- a/src/fedora/40/amd64/Dockerfile
+++ b/src/fedora/40/amd64/Dockerfile
@@ -33,7 +33,6 @@ RUN dnf upgrade --refresh -y \
         jq \
         krb5-devel \
         libcurl-devel \
-        libgdiplus \
         libicu-devel \
         libomp-devel \
         libtool \

--- a/src/fedora/41/amd64/Dockerfile
+++ b/src/fedora/41/amd64/Dockerfile
@@ -33,7 +33,6 @@ RUN dnf upgrade --refresh -y \
         jq \
         krb5-devel \
         libcurl-devel \
-        libgdiplus \
         libicu-devel \
         libomp-devel \
         libtool \

--- a/src/opensuse/15.6/helix/amd64/Dockerfile
+++ b/src/opensuse/15.6/helix/amd64/Dockerfile
@@ -19,7 +19,6 @@ RUN zypper ref \
         krb5-devel \
         lato-fonts \
         libffi-devel \
-        libgdiplus-devel \
         libicu-devel \
         libopenssl-devel \
         libtool \

--- a/src/ubuntu/20.04/Dockerfile
+++ b/src/ubuntu/20.04/Dockerfile
@@ -45,7 +45,6 @@ RUN apt-get update \
         build-essential \
         gettext \
         jq \
-        libgdiplus \
         libicu-dev \
         libkrb5-dev \
         liblttng-ust-dev \

--- a/src/ubuntu/20.04/helix/Dockerfile
+++ b/src/ubuntu/20.04/helix/Dockerfile
@@ -18,7 +18,6 @@ RUN apt-get update && \
         iputils-ping \
         libcurl4 \
         libffi-dev \
-        libgdiplus \
         libicu-dev \
         libssl-dev \
         libtool \

--- a/src/ubuntu/22.04/Dockerfile
+++ b/src/ubuntu/22.04/Dockerfile
@@ -59,7 +59,6 @@ RUN apt-get update \
         build-essential \
         gettext \
         jq \
-        libgdiplus \
         libicu-dev \
         libkrb5-dev \
         liblttng-ust-dev \

--- a/src/ubuntu/22.04/helix/Dockerfile
+++ b/src/ubuntu/22.04/helix/Dockerfile
@@ -18,7 +18,6 @@ RUN apt-get update && \
         iputils-ping \
         libcurl4 \
         libffi-dev \
-        libgdiplus \
         libicu-dev \
         libssl-dev \
         libtool \

--- a/src/ubuntu/24.04/Dockerfile
+++ b/src/ubuntu/24.04/Dockerfile
@@ -45,7 +45,6 @@ RUN apt-get update \
         gettext \
         jq \
         libbrotli-dev \
-        libgdiplus \
         libicu-dev \
         libkrb5-dev \
         liblttng-ust-dev \

--- a/src/ubuntu/24.04/helix/Dockerfile
+++ b/src/ubuntu/24.04/helix/Dockerfile
@@ -40,7 +40,6 @@ RUN LIBCURL=libcurl4 && \
         iputils-ping \
         $LIBCURL \
         libffi-dev \
-        libgdiplus \
         libicu-dev \
         libnuma1 \
         libssl-dev \

--- a/src/ubuntu/24.10/helix/Dockerfile
+++ b/src/ubuntu/24.10/helix/Dockerfile
@@ -40,7 +40,6 @@ RUN LIBCURL=libcurl4 && \
         iputils-ping \
         $LIBCURL \
         libffi-dev \
-        libgdiplus \
         libicu-dev \
         libnuma1 \
         libssl-dev \

--- a/src/ubuntu/common/coredeps/Dockerfile
+++ b/src/ubuntu/common/coredeps/Dockerfile
@@ -21,7 +21,6 @@ RUN apt-get update \
         gettext \
         jq \
         libcurl4-openssl-dev \
-        libgdiplus \
         libicu-dev \
         libkrb5-dev \
         liblttng-ust-dev \


### PR DESCRIPTION
Dependency on libgdiplus was removed in .NET 7 (https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/7.0/system-drawing). libgdiplus should not be needed anymore.