### PR TITLE
Add Node to Alpine 3.21

### DIFF
--- a/src/alpine/3.21/amd64/Dockerfile
+++ b/src/alpine/3.21/amd64/Dockerfile
@@ -1,7 +1,7 @@
 FROM amd64/alpine:3.21
 
-# Install .NET and test dependencies
 RUN apk add --upgrade --no-cache \
+        # Install .NET and test dependencies
         autoconf \
         automake \
         bash \
@@ -52,7 +52,10 @@ RUN apk add --upgrade --no-cache \
         userspace-rcu \
         util-linux-dev \
         which \
-        zlib-dev
+        zlib-dev \
+        \
+        # Azure DevOps container job requirements
+        nodejs
 
 # Install the latest non-preview powershell release.
 RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust \
@@ -70,3 +73,6 @@ RUN azureEnv="/usr/local/share/azure-cli-env" \
     && "$azureEnv/bin/python" -m pip install --upgrade setuptools \
     && "$azureEnv/bin/python" -m pip install azure-cli \
     && ln -s "$azureEnv/bin/az" /usr/local/bin/az
+
+# Add label for bring your own node in azure devops
+LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/bin/node"


### PR DESCRIPTION
Per https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1284#issuecomment-2536689335, adding Node to the Alpine image to satisfy the requirements of [Azure DevOps container jobs](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/container-phases?view=azure-devops&tabs=linux#nonglibc-based-containers) (related: https://github.com/dotnet/source-build/issues/4547).