### PR TITLE
Update npm ip package to address CVE

### DIFF
--- a/src/ubuntu/20.04/Dockerfile
+++ b/src/ubuntu/20.04/Dockerfile
@@ -15,7 +15,8 @@ RUN apt-get update \
         make \
         pigz \
         sudo \
-        wget
+        wget \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install tools used by the VSO build automation.
 RUN apt-get update \
@@ -26,7 +27,9 @@ RUN apt-get update \
         tar \
         zip \
         curl \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    # npm installs a vulnerable node-ip pkg. Upgrading the node-ip pkg requires Ubuntu PRO subscription. Workaround by using NPM.
+    && npm install -g ip@latest
 
 # .NET SDK MSBuild requires US.UTF-8 locale to execute tasks
 RUN locale-gen en_US.UTF-8

--- a/src/ubuntu/22.04/Dockerfile
+++ b/src/ubuntu/22.04/Dockerfile
@@ -14,7 +14,8 @@ RUN apt-get update \
         locales \
         make \
         pigz \
-        sudo
+        sudo \
+        && rm -rf /var/lib/apt/lists/*
 
 # This link fixes the broken lldb python scripting that the diagnostics tests require
 RUN mkdir -p /usr/lib/local/lib/python3.10/dist-packages/lldb \
@@ -27,7 +28,9 @@ RUN apt-get update \
         npm \
         zip \
         curl \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    # npm installs a vulnerable node-ip pkg. Upgrading the node-ip pkg requires Ubuntu PRO subscription. Workaround by using NPM.
+    && npm install -g ip@latest
 
 # .NET SDK MSBuild requires US.UTF-8 locale to execute tasks
 RUN locale-gen en_US.UTF-8


### PR DESCRIPTION
Related to https://github.com/dotnet/dotnet-buildtools-prereqs-docker-internal/issues/151