### PR TITLE
Install pip for MicroBuild install task validation

### DIFF
--- a/src/cbl-mariner/2.0/fpm/amd64/Dockerfile
+++ b/src/cbl-mariner/2.0/fpm/amd64/Dockerfile
@@ -17,5 +17,7 @@ RUN tdnf install -y \
         # Provides functionality for AzureCLI AzDO task
         powershell \
         azure-cli \
+        # Provides functionality for MicroBuild install task
+        python3-pip \
     && tdnf clean all \
     && gem install fpm


### PR DESCRIPTION
Needed for https://github.com/dotnet/arcade-validation/pull/4698.

From [test build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2602846&view=logs&j=1295a90a-32ad-54ea-34e1-74b5e62ea3f1&t=8cb7b92e-c6cc-54f8-18ad-d65fb3c861c6&l=130):

```
Error: Unable to locate executable file: 'pip'. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.
```

MicroBuild install task uses `pip` to install the ESRP Az CLI extension. As such, we should include pip as a dependency in the image.