### PR TITLE
Add `cpio` and `file` packages to Helix images

### DIFF
--- a/src/almalinux/8/helix/amd64/Dockerfile
+++ b/src/almalinux/8/helix/amd64/Dockerfile
@@ -16,6 +16,9 @@ RUN dnf upgrade --refresh -y \
         sudo \
         libicu \
         libmsquic \
+        # Required for arcade test runs
+        cpio \
+        file \
     && dnf clean all
 
 RUN python3 -m pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \

--- a/src/debian/12/helix/amd64/Dockerfile
+++ b/src/debian/12/helix/amd64/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update \
         automake \
         at \
         build-essential \
+        cpio \
         gcc \
         gdb \
         git \


### PR DESCRIPTION
`cpio` and `file` packages are required for Helix execution of `arcade` tests. `file` package is already included in base `debian` image.

Required for RPM repack work: https://github.com/dotnet/arcade/pull/15405