### PR TITLE
Enable long paths on Webassembly's Windows image.

### DIFF
--- a/src/windowsservercore/ltsc2022/helix/webassembly/amd64/Dockerfile
+++ b/src/windowsservercore/ltsc2022/helix/webassembly/amd64/Dockerfile
@@ -22,6 +22,9 @@ RUN curl -SL --output %TEMP%\%GIT_INSTALLER% https://github.com/git-for-windows/
     && tar -C C:\git -zxf %TEMP%\%GIT_INSTALLER% `
     && setx PATH "%PATH%;C:\git\cmd"
 
+# Enable long paths
+RUN reg add HKLM\SYSTEM\CurrentControlSet\Control\FileSystem /v LongPathsEnabled /t REG_DWORD /d 1 /f
+
 # Install latest 18.x Node JS
 ENV NODE_RELEASE=18
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/111793.
When running WebAssembly tests locally, we require this setting: https://github.com/dotnet/runtime/blob/0a477a86d0fea6234ada63e660c0faa310fe121d/docs/workflow/requirements/windows-requirements.md?plain=1#L22. The image should be in line with this requirement.