### PR TITLE
Fix Node install for WSC to get latest version

### DIFF
--- a/src/windowsservercore/ltsc2022/helix/webassembly-net8/amd64/Dockerfile
+++ b/src/windowsservercore/ltsc2022/helix/webassembly-net8/amd64/Dockerfile
@@ -48,8 +48,13 @@ RUN powershell -Command " `
         $ProgressPreference = 'SilentlyContinue'; `
         `
         $json = Invoke-RestMethod -Uri 'https://nodejs.org/dist/index.json'; `
-        $nodeVersion = ($json | ForEach-Object { if ($_.version.StartsWith(\"v$env:NODE_RELEASE.\")) { $_ } } | Sort-Object -Property version -Descending | Select-Object -First 1).version.TrimStart('v'); `
-        Invoke-WebRequest -Uri https://nodejs.org/dist/v$nodeVersion/node-v$nodeVersion-x64.msi -OutFile $env:TEMP\nodejs.msi; `
+        $nodeVersionUrl = \"https://nodejs.org/dist/latest-v$env:NODE_RELEASE.x/SHASUMS256.txt\"; `
+        $versionInfo = Invoke-WebRequest -Uri $nodeVersionUrl -UseBasicParsing; `
+        $versionInfo.Content -match \"node-v$env:NODE_RELEASE\.\d+\.\d+-x64\.msi\" | Out-Null; `
+        $latestVersion = $matches[0]; `
+        $nodeUrl = \"https://nodejs.org/dist/latest-v$env:NODE_RELEASE.x/$latestVersion\"; `
+        Write-Host \"Installing Node from $nodeUrl\"; `
+        Invoke-WebRequest -Uri $nodeUrl -OutFile $env:TEMP\nodejs.msi; `
         Start-Process msiexec.exe -ArgumentList '/i', $env:TEMP\nodejs.msi, '/quiet', '/passive', '/qn', '/norestart' -NoNewWindow -Wait"
 
 # install latest jsvu and v8 engine

--- a/src/windowsservercore/ltsc2022/helix/webassembly/amd64/Dockerfile
+++ b/src/windowsservercore/ltsc2022/helix/webassembly/amd64/Dockerfile
@@ -33,8 +33,13 @@ RUN powershell -Command " `
         $ProgressPreference = 'SilentlyContinue'; `
         `
         $json = Invoke-RestMethod -Uri 'https://nodejs.org/dist/index.json'; `
-        $nodeVersion = ($json | ForEach-Object { if ($_.version.StartsWith(\"v$env:NODE_RELEASE.\")) { $_ } } | Sort-Object -Property version -Descending | Select-Object -First 1).version.TrimStart('v'); `
-        Invoke-WebRequest -Uri https://nodejs.org/dist/v$nodeVersion/node-v$nodeVersion-x64.msi -OutFile $env:TEMP\nodejs.msi; `
+        $nodeVersionUrl = \"https://nodejs.org/dist/latest-v$env:NODE_RELEASE.x/SHASUMS256.txt\"; `
+        $versionInfo = Invoke-WebRequest -Uri $nodeVersionUrl -UseBasicParsing; `
+        $versionInfo.Content -match \"node-v$env:NODE_RELEASE\.\d+\.\d+-x64\.msi\" | Out-Null; `
+        $latestVersion = $matches[0]; `
+        $nodeUrl = \"https://nodejs.org/dist/latest-v$env:NODE_RELEASE.x/$latestVersion\"; `
+        Write-Host \"Installing Node from $nodeUrl\"; `
+        Invoke-WebRequest -Uri $nodeUrl -OutFile $env:TEMP\nodejs.msi; `
         Start-Process msiexec.exe -ArgumentList '/i', $env:TEMP\nodejs.msi, '/quiet', '/passive', '/qn', '/norestart' -NoNewWindow -Wait"
 
 # install latest jsvu and v8 engine


### PR DESCRIPTION
The latest version of Node in these two Dockerfiles is not being installed. It's actually installing 18.9.1 which is definitely not the latest. The logic in the Dockerfile is attempting to dynamically find the latest patch version of Node 18. But the issue is in the sorting of the version numbers. It's using text-based comparison, not version-based comparisons. So `18.9.1` is determined to be "higher" than `18.10.0`, because it ends up comparing `9` to `1`.

To fix this, I've redone the logic to simply use the `latest-v18` URL which will automatically provide the latest Node 18 version. But the key to that is that you need to know the name of the file you want and the file has the version number in it. So to get the file name, it first requests the `SHASUMS256.txt`, a statically known file name. That includes the list of files in it that we can then match to find the .msi file with the version in the name. Then we download and install that file.