### PR TITLE
Don't set helixbot as the default user

### DIFF
--- a/src/fedora/41/helix/Dockerfile
+++ b/src/fedora/41/helix/Dockerfile
@@ -65,8 +65,6 @@ RUN /usr/sbin/adduser --uid 1000 --shell /bin/bash --group adm helixbot \
     && echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers \
     && chmod +s /usr/bin/ping
 
-USER helixbot
-
 # Install Helix Dependencies
 ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
 RUN python3 -m venv $VIRTUAL_ENV


### PR DESCRIPTION
Contributes to https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/1333

I've already done some validation that removing the `helixbot` user as the default user works in a test build. But I want to roll this out as a "pilot" image first to validate within the runtime repo. If this is successful, then I'll roll this change out to the rest of the Dockerfiles.