### PR TITLE
Install powershell/azure-cli from AzLinux native package feed

### DIFF
--- a/src/azurelinux/3.0/net10.0/crossdeps/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/crossdeps/amd64/Dockerfile
@@ -26,24 +26,7 @@ RUN tdnf update -y && \
         python3-pip \
         # aspnetcore build dependencies
         nodejs \
-        npm
-
-# Powershell and azure cli aren't currently part of the azure linux 3.0 repositories.
-# Install powershell from the rhel8 MS repo, and azure-cli using PIP
-
-# Install powershell from the Microsoft repository. 
-RUN curl -sSL -O https://packages.microsoft.com/config/rhel/8/packages-microsoft-prod.rpm && \
-    rpm -i packages-microsoft-prod.rpm && \
-    rm -f packages-microsoft-prod.rpm && \
-    tdnf update -y && \
-    tdnf install -y --setopt tsflags=nodocs \
-         powershell && \
-    rm /etc/yum.repos.d/microsoft-prod.repo && \
-    tdnf clean all
-
-# Install azurecli from PIP
-RUN azureEnv="/usr/local/share/azure-cli-env" && \
-    python3 -m venv "$azureEnv" && \
-    "$azureEnv/bin/python" -m pip install --upgrade setuptools && \
-    "$azureEnv/bin/python" -m pip install azure-cli && \
-    ln -s "$azureEnv/bin/az" /usr/local/bin/az
+        npm \
+        # Provides functionality for AzureCLI AzDO task
+        azure-cli \
+        powershell

--- a/src/azurelinux/3.0/net8.0/crossdeps/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/crossdeps/amd64/Dockerfile
@@ -24,24 +24,7 @@ RUN tdnf update -y && \
         python3-pip \
         # aspnetcore build dependencies
         nodejs \
-        npm
-
-# Powershell and azure cli aren't currently part of the azure linux 3.0 repositories.
-# Install powershell from the rhel8 MS repo, and azure-cli using PIP
-
-# Install powershell from the Microsoft repository. 
-RUN curl -sSL -O https://packages.microsoft.com/config/rhel/8/packages-microsoft-prod.rpm && \
-    rpm -i packages-microsoft-prod.rpm && \
-    rm -f packages-microsoft-prod.rpm && \
-    tdnf update -y && \
-    tdnf install -y --setopt tsflags=nodocs \
-         powershell && \
-    rm /etc/yum.repos.d/microsoft-prod.repo && \
-    tdnf clean all
-
-# Install azurecli from PIP
-RUN azureEnv="/usr/local/share/azure-cli-env" && \
-    python3 -m venv "$azureEnv" && \
-    "$azureEnv/bin/python" -m pip install --upgrade setuptools && \
-    "$azureEnv/bin/python" -m pip install azure-cli && \
-    ln -s "$azureEnv/bin/az" /usr/local/bin/az
+        npm \
+        # Provides functionality for AzureCLI AzDO task
+        azure-cli \
+        powershell

--- a/src/azurelinux/3.0/net9.0/crossdeps/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/crossdeps/amd64/Dockerfile
@@ -26,24 +26,7 @@ RUN tdnf update -y && \
         python3-pip \
         # aspnetcore build dependencies
         nodejs \
-        npm
-
-# Powershell and azure cli aren't currently part of the azure linux 3.0 repositories.
-# Install powershell from the rhel8 MS repo, and azure-cli using PIP
-
-# Install powershell from the Microsoft repository. 
-RUN curl -sSL -O https://packages.microsoft.com/config/rhel/8/packages-microsoft-prod.rpm && \
-    rpm -i packages-microsoft-prod.rpm && \
-    rm -f packages-microsoft-prod.rpm && \
-    tdnf update -y && \
-    tdnf install -y --setopt tsflags=nodocs \
-         powershell && \
-    rm /etc/yum.repos.d/microsoft-prod.repo && \
-    tdnf clean all
-
-# Install azurecli from PIP
-RUN azureEnv="/usr/local/share/azure-cli-env" && \
-    python3 -m venv "$azureEnv" && \
-    "$azureEnv/bin/python" -m pip install --upgrade setuptools && \
-    "$azureEnv/bin/python" -m pip install azure-cli && \
-    ln -s "$azureEnv/bin/az" /usr/local/bin/az
+        npm \
+        # Provides functionality for AzureCLI AzDO task
+        azure-cli \
+        powershell

--- a/src/cbl-mariner/2.0/crossdeps/amd64/Dockerfile
+++ b/src/cbl-mariner/2.0/crossdeps/amd64/Dockerfile
@@ -22,9 +22,9 @@ RUN tdnf update -y && \
         python3-pip \
         # diagnostics build dependency
         lldb-devel \
-        # Provdies azure cli and powershell, used for common AzureCLI AzDO tasks
-        powershell \
-        azure-cli
+        # Provides functionality for AzureCLI AzDO task
+        azure-cli \
+        powershell
 
 # Validate checksums with keyring after https://github.com/microsoft/azurelinux/issues/3142 is resolved
 ENV NODE_VERSION=20.11.1

--- a/src/cbl-mariner/2.0/fpm/amd64/Dockerfile
+++ b/src/cbl-mariner/2.0/fpm/amd64/Dockerfile
@@ -15,7 +15,7 @@ RUN tdnf install -y \
         # Provides sudo
         sudo \
         # Provides functionality for AzureCLI AzDO task
-        powershell \
         azure-cli \
+        powershell \
     && tdnf clean all \
     && gem install fpm


### PR DESCRIPTION
Fixes https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/1269

The reason I'm fixing this now is because there's an issue with PMC when targeting https://packages.microsoft.com/config/rhel/8/packages-microsoft-prod.rpm:

```
 > [3/4] RUN curl -sSL -O https://packages.microsoft.com/config/rhel/8/packages-microsoft-prod.rpm &&     rpm -i packages-microsoft-prod.rpm &&     rm -f packages-microsoft-prod.rpm &&     tdnf update -y &&     tdnf install -y --setopt tsflags=nodocs          powershell &&     rm /etc/yum.repos.d/microsoft-prod.repo &&     tdnf clean all:
0.297 warning: packages-microsoft-prod.rpm: Header V4 RSA/SHA256 Signature, key ID be1229cf: NOKEY
1.844 Loaded plugin: tdnfrepogpgcheck
1.892 Refreshing metadata for: 'Microsoft Production'
2.026 repo md signature check: No public key
2.026 Error: TDNFVerifySignature 2004
2.026 Plugin error: repogpgcheck plugin error: failed to verify signature
2.026 
2.026 Error(2004) : Unknown error 404
2.027 Error: Failed to synchronize cache for repo 'Microsoft Production'
2.027 Error(2004) : Unknown error 404
```

This avoids that by getting the packages directly from the native feed.