### PR TITLE
Remove lldb from armv6 images

### DIFF
--- a/src/azurelinux/3.0/net10.0/cross/armv6/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/cross/armv6/Dockerfile
@@ -10,7 +10,7 @@ RUN wget http://raspbian.raspberrypi.org/raspbian/pool/main/r/raspbian-archive-k
     mv raspbian-archive-keyring-20120528.2/keyrings/raspbian-archive-keyring.gpg /usr/share/keyrings/ && \
     rm -r raspbian-archive-keyring_20120528.2.tar.gz raspbian-archive-keyring-20120528.2
 
-RUN /scripts/eng/common/cross/build-rootfs.sh armv6 bookworm lldb13
+RUN /scripts/eng/common/cross/build-rootfs.sh armv6 bookworm no-lldb
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR

--- a/src/azurelinux/3.0/net9.0/cross/armv6/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/armv6/Dockerfile
@@ -10,7 +10,7 @@ RUN wget http://raspbian.raspberrypi.org/raspbian/pool/main/r/raspbian-archive-k
     mv raspbian-archive-keyring-20120528.2/keyrings/raspbian-archive-keyring.gpg /usr/share/keyrings/ && \
     rm -r raspbian-archive-keyring_20120528.2.tar.gz raspbian-archive-keyring-20120528.2
 
-RUN /scripts/eng/common/cross/build-rootfs.sh armv6 bookworm lldb13
+RUN /scripts/eng/common/cross/build-rootfs.sh armv6 bookworm no-lldb
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR


### PR DESCRIPTION
I think this should help with https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/1331 - it looks like lldb is what was pulling in the Pygments python package. We don't need lldb on these images because armv6 isn't officially supported.