### PR TITLE
Update npm version in azurelinux-3.0-net8.0-webassembly-amd64

### DIFF
--- a/src/azurelinux/3.0/net8.0/webassembly/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/webassembly/amd64/Dockerfile
@@ -35,7 +35,7 @@ RUN mkdir ${EMSCRIPTEN_PATH} \
     # update packages to non-vulnerable versions
     && export PATH=$PATH:${EMSDK_PATH}/node/${NODE_VERSION_IN_EMSDK}/bin \
     && cd ${EMSDK_PATH}/node/${NODE_VERSION_IN_EMSDK}/lib \
-    && npm install npm@latest \
+    && npm install npm@9 \
     && npm prune --production \
     && cd ${EMSDK_PATH}/upstream/emscripten \
     && jq 'del(.devDependencies)' package.json > package.json.tmp && mv package.json.tmp package.json \


### PR DESCRIPTION
The latest npm doesn't support node 15.x anymore, install npm 9.x instead.

Should unblock https://github.com/dotnet/runtime/pull/110199#issuecomment-2625689200