### PR TITLE
Update npm to 8.0 in azurelinux-3.0-net8.0-webassembly image

### DIFF
--- a/src/azurelinux/3.0/net8.0/webassembly/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/webassembly/amd64/Dockerfile
@@ -35,6 +35,7 @@ RUN mkdir ${EMSCRIPTEN_PATH} \
     # update packages to non-vulnerable versions
     && export PATH=$PATH:${EMSDK_PATH}/node/${NODE_VERSION_IN_EMSDK}/bin \
     && cd ${EMSDK_PATH}/node/${NODE_VERSION_IN_EMSDK}/lib \
+    && npm install npm@8 \
     && npm prune --production \
     && cd ${EMSDK_PATH}/upstream/emscripten \
     && jq 'del(.devDependencies)' package.json > package.json.tmp && mv package.json.tmp package.json \


### PR DESCRIPTION
9.0 was still too new. Should fix the issues with incompatible node.