### PR TITLE
Add .NET 8 and 9 variants of Azure Linux build image

### DIFF
--- a/src/azurelinux/3.0/net8.0/build/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/build/Dockerfile
@@ -1,0 +1,6 @@
+FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-azurelinux3.0
+
+RUN tdnf install -y \
+        nodejs \
+        shadow-utils \
+    && tdnf clean all

--- a/src/azurelinux/3.0/net9.0/build/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/build/Dockerfile
@@ -1,0 +1,6 @@
+FROM mcr.microsoft.com/dotnet/runtime-deps:9.0-azurelinux3.0
+
+RUN tdnf install -y \
+        nodejs \
+        shadow-utils \
+    && tdnf clean all

--- a/src/azurelinux/manifest.json
+++ b/src/azurelinux/manifest.json
@@ -946,6 +946,32 @@
           "platforms": [
             {
               "architecture": "amd64",
+              "dockerfile": "src/azurelinux/3.0/net8.0/build",
+              "os": "linux",
+              "osVersion": "azurelinux3.0",
+              "tags": {
+                "azurelinux-3.0-net8.0-build-amd64": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "architecture": "amd64",
+              "dockerfile": "src/azurelinux/3.0/net9.0/build",
+              "os": "linux",
+              "osVersion": "azurelinux3.0",
+              "tags": {
+                "azurelinux-3.0-net9.0-build-amd64": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "architecture": "amd64",
               "dockerfile": "src/azurelinux/3.0/net10.0/build",
               "os": "linux",
               "osVersion": "azurelinux3.0",


### PR DESCRIPTION
Same as #1346 and #1349 for .NET 8 and 9.