### PR TITLE
Add tar to Azure Linux build image

### DIFF
--- a/src/azurelinux/3.0/net10.0/build/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/build/Dockerfile
@@ -3,9 +3,11 @@ FROM mcr.microsoft.com/dotnet/nightly/runtime-deps:10.0-preview-azurelinux3.0
 
 RUN tdnf install -y \
         awk \
+        curl \
         nodejs \
         # provides 'useradd', required by Azure DevOps
         shadow-utils \
         # Provides 'su', required by Azure DevOps
+        tar \
         util-linux \
     && tdnf clean all

--- a/src/azurelinux/3.0/net10.0/build/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/build/Dockerfile
@@ -3,11 +3,12 @@ FROM mcr.microsoft.com/dotnet/nightly/runtime-deps:10.0-preview-azurelinux3.0
 
 RUN tdnf install -y \
         awk \
+        # added to ensure latest patches over the base image
         curl \
         nodejs \
         # provides 'useradd', required by Azure DevOps
         shadow-utils \
-        # Provides 'su', required by Azure DevOps
         tar \
+        # Provides 'su', required by Azure DevOps
         util-linux \
     && tdnf clean all

--- a/src/azurelinux/3.0/net8.0/build/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/build/Dockerfile
@@ -2,11 +2,12 @@ FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-azurelinux3.0
 
 RUN tdnf install -y \
         awk \
+        # added to ensure latest patches over the base image
         curl \
         nodejs \
         # provides 'useradd', required by Azure DevOps
         shadow-utils \
-        # Provides 'su', required by Azure DevOps
         tar \
+        # Provides 'su', required by Azure DevOps
         util-linux \
     && tdnf clean all

--- a/src/azurelinux/3.0/net8.0/build/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/build/Dockerfile
@@ -2,9 +2,11 @@ FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-azurelinux3.0
 
 RUN tdnf install -y \
         awk \
+        curl \
         nodejs \
         # provides 'useradd', required by Azure DevOps
         shadow-utils \
         # Provides 'su', required by Azure DevOps
+        tar \
         util-linux \
     && tdnf clean all

--- a/src/azurelinux/3.0/net9.0/build/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/build/Dockerfile
@@ -2,11 +2,12 @@ FROM mcr.microsoft.com/dotnet/runtime-deps:9.0-azurelinux3.0
 
 RUN tdnf install -y \
         awk \
+        # added to ensure latest patches over the base image
         curl \
         nodejs \
         # provides 'useradd', required by Azure DevOps
         shadow-utils \
-        # Provides 'su', required by Azure DevOps
         tar \
+        # Provides 'su', required by Azure DevOps
         util-linux \
     && tdnf clean all

--- a/src/azurelinux/3.0/net9.0/build/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/build/Dockerfile
@@ -2,9 +2,11 @@ FROM mcr.microsoft.com/dotnet/runtime-deps:9.0-azurelinux3.0
 
 RUN tdnf install -y \
         awk \
+        curl \
         nodejs \
         # provides 'useradd', required by Azure DevOps
         shadow-utils \
         # Provides 'su', required by Azure DevOps
+        tar \
         util-linux \
     && tdnf clean all


### PR DESCRIPTION
- Discovered we also need `tar`.
- Added `curl` as well to ensure we get the latest patches for it.