### PR TITLE
Add CentOS Stream 10 build image

### DIFF
--- a/src/centos-stream/10.0/amd64/Dockerfile
+++ b/src/centos-stream/10.0/amd64/Dockerfile
@@ -51,6 +51,7 @@ RUN dnf upgrade --refresh -y \
         python3 \
         python3-devel \
         readline-devel \
+        sudo \
         swig \
         tar \
         wget \
@@ -58,5 +59,3 @@ RUN dnf upgrade --refresh -y \
         xz \
         zlib-devel \
     && dnf clean all
-
-ENV NO_UPDATE_NOTIFIER=true

--- a/src/centos-stream/10.0/amd64/Dockerfile
+++ b/src/centos-stream/10.0/amd64/Dockerfile
@@ -1,0 +1,62 @@
+FROM quay.io/centos/centos:stream10
+
+# Install dependencies
+RUN dnf upgrade --refresh -y \
+    && dnf install --setopt tsflags=nodocs -y \
+        dnf-plugins-core \
+    # rhel/10 packages don't exist yet, so we use the rhel/9 packages
+    && dnf config-manager --add-repo=https://packages.microsoft.com/rhel/9/prod/config.repo \
+    && dnf config-manager --set-enabled crb \
+    && dnf install --setopt tsflags=nodocs -y \
+        "perl(Time::HiRes)" \
+        autoconf \
+        automake \
+        brotli-devel \
+        clang \
+        cmake \
+        cpio \
+        curl-devel \
+        doxygen \
+        elfutils \
+        file \
+        findutils \
+        gcc \
+        gdb \
+        git \
+        glibc-langpack-en \
+        hostname \
+        iproute \
+        jq \
+        krb5-devel \
+        libcurl-devel \
+        libedit-devel \
+        libicu-devel \
+        libidn2-devel \
+        libnghttp2-devel \
+        libtool \
+        libuuid-devel \
+        libxml2-devel \
+        lld \
+        lldb-devel \
+        llvm \
+        lttng-ust-devel \
+        lzma \
+        make \
+        ncurses-devel \
+        numactl-devel \
+        openssl-devel \
+        pigz \
+        powershell \
+        procps-ng \
+        python3 \
+        python3-devel \
+        readline-devel \
+        swig \
+        tar \
+        wget \
+        which \
+        xz \
+        zlib-devel \
+    && dnf clean all
+
+ENV NO_UPDATE_NOTIFIER=true

--- a/src/centos-stream/manifest.json
+++ b/src/centos-stream/manifest.json
@@ -49,7 +49,7 @@
               "os": "linux",
               "osVersion": "centos-stream10",
               "tags": {
-                "centos-stream-10": {}
+                "centos-stream-10-amd64": {}
               }
             }
           ]

--- a/src/centos-stream/manifest.json
+++ b/src/centos-stream/manifest.json
@@ -45,6 +45,18 @@
         {
           "platforms": [
             {
+              "dockerfile": "src/centos-stream/10.0/amd64",
+              "os": "linux",
+              "osVersion": "centos-stream10",
+              "tags": {
+                "centos-stream-10": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
               "architecture": "amd64",
               "dockerfile": "src/centos-stream/10.0/helix/",
               "os": "linux",


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/4890

There following changes were made vs the 9 version.

1. NodeJS module not installed - the NodeJS module is no longer available in the CentOS Stream 10 - AppStream  package feed.  If any repo's rely on this, they will need to decide where to install it from.
2. Azure CLI not installed - Azure has not published 10 packages yet.  The version from the 9 feed will not install because of missing requirements.  This will have to be added later when available.  
3. sudo was dropped - sudo is not recommended in container scenarios.
4. ENV OPENSSL_ENABLE_SHA1_SIGNATURES=1 was dropped.  This is an attempt to cleanup.  Not sure if this is still required or not.