### PR TITLE
Remove debootstrap dependency from riscv64 images

### DIFF
--- a/src/azurelinux/3.0/net10.0/cross/riscv64/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/cross/riscv64/Dockerfile
@@ -3,15 +3,10 @@ ARG ROOTFS_DIR=/crossrootfs/riscv64
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
-# Install the latest debootstrap
-RUN tdnf remove -y debootstrap && \
-    curl -fsL -o debootstrap.tar.gz https://deb.debian.org/debian/pool/main/d/debootstrap/debootstrap_1.0.140.tar.gz && \
-    echo "c95eb2aeb952b3fd09f4a07859115d40c4d04a8d551b3071b0a10fcd0db7ebc4 debootstrap.tar.gz" | sha256sum -c - && \
-    tar xzf debootstrap.tar.gz -C / && \
-    ln -s /debootstrap/debootstrap -t /usr/local/bin && \
-    rm -f debootstrap.tar.gz
-
-RUN /scripts/eng/common/cross/build-rootfs.sh riscv64 noble --skipunmount
+RUN rootfsEnv="/usr/local/share/rootfs" && \
+    python3 -m venv "$rootfsEnv" && \
+    "$rootfsEnv/bin/python" -m pip install aiohttp zstandard && \
+    PYTHON_EXECUTABLE="$rootfsEnv/bin/python" /scripts/eng/common/cross/build-rootfs.sh riscv64 noble --skipunmount --skipemulation
 
 RUN TARGET_TRIPLE="riscv64-linux-gnu" && \
     CLANG_MAJOR_VERSION=$(clang --version | grep -oP "(?<=version )\d+") && \

--- a/src/azurelinux/3.0/net8.0/cross/riscv64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/cross/riscv64/Dockerfile
@@ -3,15 +3,10 @@ ARG ROOTFS_DIR=/crossrootfs/riscv64
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
-# Install the latest debootstrap
-RUN tdnf remove -y debootstrap && \
-    curl -fsL -o debootstrap.tar.gz https://deb.debian.org/debian/pool/main/d/debootstrap/debootstrap_1.0.140.tar.gz && \
-    echo "c95eb2aeb952b3fd09f4a07859115d40c4d04a8d551b3071b0a10fcd0db7ebc4 debootstrap.tar.gz" | sha256sum -c - && \
-    tar xzf debootstrap.tar.gz -C / && \
-    ln -s /debootstrap/debootstrap -t /usr/local/bin && \
-    rm -f debootstrap.tar.gz
-
-RUN /scripts/eng/common/cross/build-rootfs.sh riscv64 noble --skipunmount
+RUN rootfsEnv="/usr/local/share/rootfs" && \
+    python3 -m venv "$rootfsEnv" && \
+    "$rootfsEnv/bin/python" -m pip install aiohttp zstandard && \
+    PYTHON_EXECUTABLE="$rootfsEnv/bin/python" /scripts/eng/common/cross/build-rootfs.sh riscv64 noble --skipunmount --skipemulation
 
 RUN TARGET_TRIPLE="riscv64-linux-gnu" && \
     CLANG_MAJOR_VERSION=$(clang --version | grep -oP "(?<=version )\d+") && \

--- a/src/azurelinux/3.0/net9.0/cross/riscv64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/riscv64/Dockerfile
@@ -3,15 +3,10 @@ ARG ROOTFS_DIR=/crossrootfs/riscv64
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
-# Install the latest debootstrap
-RUN tdnf remove -y debootstrap && \
-    curl -fsL -o debootstrap.tar.gz https://deb.debian.org/debian/pool/main/d/debootstrap/debootstrap_1.0.140.tar.gz && \
-    echo "c95eb2aeb952b3fd09f4a07859115d40c4d04a8d551b3071b0a10fcd0db7ebc4 debootstrap.tar.gz" | sha256sum -c - && \
-    tar xzf debootstrap.tar.gz -C / && \
-    ln -s /debootstrap/debootstrap -t /usr/local/bin && \
-    rm -f debootstrap.tar.gz
-
-RUN /scripts/eng/common/cross/build-rootfs.sh riscv64 noble --skipunmount
+RUN rootfsEnv="/usr/local/share/rootfs" && \
+    python3 -m venv "$rootfsEnv" && \
+    "$rootfsEnv/bin/python" -m pip install aiohttp zstandard && \
+    PYTHON_EXECUTABLE="$rootfsEnv/bin/python" /scripts/eng/common/cross/build-rootfs.sh riscv64 noble --skipunmount --skipemulation
 
 RUN TARGET_TRIPLE="riscv64-linux-gnu" && \
     CLANG_MAJOR_VERSION=$(clang --version | grep -oP "(?<=version )\d+") && \


### PR DESCRIPTION
This bring riscv64 to the same plan as loongarch64, which uses new mechanism to create rootfs without debootstrap/qemu requirement.