### PR TITLE
Update LLVM install in Dockerfile for optimization net10

### DIFF
--- a/src/azurelinux/3.0/net10.0/opt/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/opt/Dockerfile
@@ -10,5 +10,43 @@ RUN tdnf update -y && \
         wget \
         # Runtime dependencies
         icu \
-        # Optimization dependencies (provides llvm-profdata)
-        llvm
+        # LLVM Build tools
+        binutils \
+        clang \
+        gcc \
+        make \
+        cmake \
+        diffutils \
+        glibc-devel \
+        kernel-headers \
+        texinfo \
+        zlib-devel
+
+# Steps copied (mostly, changed target archs) from crossdeps Dockerfile: https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/main/src/azurelinux/3.0/net10.0/crossdeps-builder/amd64/Dockerfile
+# 1. Obtain signing keys used to sign llvm sources
+RUN wget https://releases.llvm.org/release-keys.asc && \
+    echo "972d9449ebf7de947a1dff7f25edf8eea7963e4f7501b20d29328df55162f3b8 release-keys.asc" | sha256sum -c && \
+    gpg --import release-keys.asc && \
+    rm release-keys.asc && \
+# 2. Download llvm sources and signature, and verify signature
+    LLVM_VERSION=19.1.6 && \
+    wget -O llvm-project.src.tar.xz.sig https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/llvm-project-${LLVM_VERSION}.src.tar.xz.sig && \
+    echo "64ed72651676c260308358b9a6d38846eaaa99addc6af504b899fedc605d5a9c llvm-project.src.tar.xz.sig" | sha256sum -c && \
+    wget -O llvm-project.src.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/llvm-project-${LLVM_VERSION}.src.tar.xz && \
+    echo "e3f79317adaa9196d2cfffe1c869d7c100b7540832bc44fe0d3f44a12861fa34 llvm-project.src.tar.xz" | sha256sum -c && \
+    gpg --verify llvm-project.src.tar.xz.sig && \
+    rm llvm-project.src.tar.xz.sig
+
+# Build LLVM cross-toolchain (with support for targeting x86/x64, arm64, arm, s390x and ppc64le architectures)
+RUN mkdir llvm-project.src && \
+    tar -xf llvm-project.src.tar.xz --directory llvm-project.src --strip-components=1 && \
+    rm llvm-project.src.tar.xz && \
+    mkdir build && cd build && \
+    cmake ../llvm-project.src/llvm \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_C_COMPILER=clang \
+        -DCMAKE_CXX_COMPILER=clang++ \
+        -DLLVM_TARGETS_TO_BUILD="X86;AArch64;ARM" \
+        -Wno-dev && \
+    make -j $(getconf _NPROCESSORS_ONLN) && \
+    make install


### PR DESCRIPTION
Update LLVM install in Dockerfile for Opt net10 so that the llvm version available is 19.1.6, one compatible with the latest runtime changes.