### PR TITLE
Define root NuGet.config

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
The repo requires an explicit NuGet.config file now that it contains a .NET project from https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1359.