### PR TITLE
Update to clang 20.1.0

### DIFF
--- a/src/azurelinux/3.0/net10.0/crossdeps-builder/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/crossdeps-builder/amd64/Dockerfile
@@ -56,11 +56,11 @@ RUN wget https://releases.llvm.org/release-keys.asc && \
     gpg --import release-keys.asc && \
     rm release-keys.asc && \
 # 2. Download llvm sources and signature, and verify signature
-    LLVM_VERSION=20.1.0-rc2 && \
+    LLVM_VERSION=20.1.0 && \
     wget -O llvm-project.src.tar.xz.sig https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/llvm-project-${LLVM_VERSION}.src.tar.xz.sig && \
-    echo "1862ff5a20a4ec884bfec14dab5c84c766b0b894a9a826978d4f1a52863d5a3c llvm-project.src.tar.xz.sig" | sha256sum -c && \
+    echo "d59a826bd924580c4f186ec2d88774c7ca4ec78bfb6593f68793696f32d09ebb llvm-project.src.tar.xz.sig" | sha256sum -c && \
     wget -O llvm-project.src.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/llvm-project-${LLVM_VERSION}.src.tar.xz && \
-    echo "cc496b3d3670dfdd9a95cdb3e8412d9365e6dea8b3aac9e8564ff5991cd625fc llvm-project.src.tar.xz" | sha256sum -c && \
+    echo "4579051e3c255fb4bb795d54324f5a7f3ef79bd9181e44293d7ee9a7f62aad9a llvm-project.src.tar.xz" | sha256sum -c && \
     gpg --verify llvm-project.src.tar.xz.sig && \
     rm llvm-project.src.tar.xz.sig
 

--- a/src/azurelinux/3.0/net10.0/opt/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/opt/Dockerfile
@@ -29,11 +29,11 @@ RUN wget https://releases.llvm.org/release-keys.asc && \
     gpg --import release-keys.asc && \
     rm release-keys.asc && \
 # 2. Download llvm sources and signature, and verify signature
-    LLVM_VERSION=20.1.0-rc2 && \
+    LLVM_VERSION=20.1.0 && \
     wget -O llvm-project.src.tar.xz.sig https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/llvm-project-${LLVM_VERSION}.src.tar.xz.sig && \
-    echo "1862ff5a20a4ec884bfec14dab5c84c766b0b894a9a826978d4f1a52863d5a3c llvm-project.src.tar.xz.sig" | sha256sum -c && \
+    echo "d59a826bd924580c4f186ec2d88774c7ca4ec78bfb6593f68793696f32d09ebb llvm-project.src.tar.xz.sig" | sha256sum -c && \
     wget -O llvm-project.src.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/llvm-project-${LLVM_VERSION}.src.tar.xz && \
-    echo "cc496b3d3670dfdd9a95cdb3e8412d9365e6dea8b3aac9e8564ff5991cd625fc llvm-project.src.tar.xz" | sha256sum -c && \
+    echo "4579051e3c255fb4bb795d54324f5a7f3ef79bd9181e44293d7ee9a7f62aad9a llvm-project.src.tar.xz" | sha256sum -c && \
     gpg --verify llvm-project.src.tar.xz.sig && \
     rm llvm-project.src.tar.xz.sig
 


### PR DESCRIPTION
See https://github.com/dotnet/runtime/issues/109939#issuecomment-2651317376. The ppc64le build break has been fixed: https://github.com/dotnet/runtime/pull/112777.