### PR TITLE
Add git sha tags for net10.0 images

### DIFF
--- a/src/azurelinux/manifest.json
+++ b/src/azurelinux/manifest.json
@@ -648,7 +648,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-cross-riscv64": {}
+                "azurelinux-3.0-net10.0-cross-riscv64": {},
+                "azurelinux-3.0-net10.0-cross-riscv64-$(System:DockerfileGitCommitSha)": {}
               }
             }
           ]
@@ -660,7 +661,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-cross-riscv64-musl": {}
+                "azurelinux-3.0-net10.0-cross-riscv64-musl": {},
+                "azurelinux-3.0-net10.0-cross-riscv64-musl-$(System:DockerfileGitCommitSha)": {}
               }
             }
           ]
@@ -672,7 +674,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-cross-loongarch64": {}
+                "azurelinux-3.0-net10.0-cross-loongarch64": {},
+                "azurelinux-3.0-net10.0-cross-loongarch64-$(System:DockerfileGitCommitSha)": {},
               }
             }
           ]
@@ -684,7 +687,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-cross-loongarch64-musl": {}
+                "azurelinux-3.0-net10.0-cross-loongarch64-musl": {},
+                "azurelinux-3.0-net10.0-cross-loongarch64-musl-$(System:DockerfileGitCommitSha)": {}
               }
             }
           ]
@@ -696,7 +700,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-cross-amd64": {}
+                "azurelinux-3.0-net10.0-cross-amd64": {},
+                "azurelinux-3.0-net10.0-cross-amd64-$(System:DockerfileGitCommitSha)": {}
               }
             }
           ]
@@ -708,7 +713,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-cross-amd64-sanitizer": {}
+                "azurelinux-3.0-net10.0-cross-amd64-sanitizer": {},
+                "azurelinux-3.0-net10.0-cross-amd64-sanitizer-$(System:DockerfileGitCommitSha)": {}
               }
             }
           ]
@@ -720,7 +726,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-cross-amd64-musl": {}
+                "azurelinux-3.0-net10.0-cross-amd64-musl": {},
+                "azurelinux-3.0-net10.0-cross-amd64-musl-$(System:DockerfileGitCommitSha)": {}
               }
             }
           ]
@@ -732,7 +739,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-cross-arm": {}
+                "azurelinux-3.0-net10.0-cross-arm": {},
+                "azurelinux-3.0-net10.0-cross-arm-$(System:DockerfileGitCommitSha)": {}
               }
             }
           ]
@@ -744,7 +752,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-cross-arm-musl": {}
+                "azurelinux-3.0-net10.0-cross-arm-musl": {},
+                "azurelinux-3.0-net10.0-cross-arm-musl-$(System:DockerfileGitCommitSha)": {}
               }
             }
           ]
@@ -756,7 +765,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-cross-arm64": {}
+                "azurelinux-3.0-net10.0-cross-arm64": {},
+                "azurelinux-3.0-net10.0-cross-arm64-$(System:DockerfileGitCommitSha)": {}
               }
             }
           ]
@@ -768,7 +778,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-cross-arm64-musl": {}
+                "azurelinux-3.0-net10.0-cross-arm64-musl": {},
+                "azurelinux-3.0-net10.0-cross-arm64-musl-$(System:DockerfileGitCommitSha)": {}
               }
             }
           ]
@@ -780,7 +791,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-cross-x86": {}
+                "azurelinux-3.0-net10.0-cross-x86": {},
+                "azurelinux-3.0-net10.0-cross-x86-$(System:DockerfileGitCommitSha)": {}
               }
             }
           ]
@@ -792,7 +804,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-webassembly-amd64": {}
+                "azurelinux-3.0-net10.0-webassembly-amd64": {},
+                "azurelinux-3.0-net10.0-webassembly-amd64-$(System:DockerfileGitCommitSha)": {}
               }
             }
           ]
@@ -804,7 +817,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-android-amd64": {}
+                "azurelinux-3.0-net10.0-android-amd64": {},
+                "azurelinux-3.0-net10.0-android-amd64-$(System:DockerfileGitCommitSha)": {}
               }
             }
           ]
@@ -816,7 +830,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-cross-android-amd64": {}
+                "azurelinux-3.0-net10.0-cross-android-amd64": {},
+                "azurelinux-3.0-net10.0-cross-android-amd64-$(System:DockerfileGitCommitSha)": {}
               }
             }
           ]
@@ -828,7 +843,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-android-docker-amd64": {}
+                "azurelinux-3.0-net10.0-android-docker-amd64": {},
+                "azurelinux-3.0-net10.0-android-docker-amd64-$(System:DockerfileGitCommitSha)": {}
               }
             }
           ]
@@ -840,7 +856,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-cross-android-openssl-amd64": {}
+                "azurelinux-3.0-net10.0-cross-android-openssl-amd64": {},
+                "azurelinux-3.0-net10.0-cross-android-openssl-amd64-$(System:DockerfileGitCommitSha)": {}
               }
             }
           ]
@@ -852,7 +869,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-cross-freebsd-14-amd64": {}
+                "azurelinux-3.0-net10.0-cross-freebsd-14-amd64": {},
+                "azurelinux-3.0-net10.0-cross-freebsd-14-amd64-$(System:DockerfileGitCommitSha)": {}
               }
             }
           ]
@@ -864,7 +882,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-cross-freebsd-14-arm64": {}
+                "azurelinux-3.0-net10.0-cross-freebsd-14-arm64": {},
+                "azurelinux-3.0-net10.0-cross-freebsd-14-arm64-$(System:DockerfileGitCommitSha)": {}
               }
             }
           ]
@@ -876,7 +895,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-cross-s390x": {}
+                "azurelinux-3.0-net10.0-cross-s390x": {},
+                "azurelinux-3.0-net10.0-cross-s390x-$(System:DockerfileGitCommitSha)": {}
               }
             }
           ]
@@ -888,7 +908,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-cross-ppc64le": {}
+                "azurelinux-3.0-net10.0-cross-ppc64le": {},
+                "azurelinux-3.0-net10.0-cross-ppc64le-$(System:DockerfileGitCommitSha)": {}
               }
             }
           ]
@@ -900,7 +921,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-cross-armv6": {}
+                "azurelinux-3.0-net10.0-cross-armv6": {},
+                "azurelinux-3.0-net10.0-cross-armv6-$(System:DockerfileGitCommitSha)": {}
               }
             }
           ]
@@ -912,7 +934,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-opt-amd64": {}
+                "azurelinux-3.0-net10.0-opt-amd64": {},
+                "azurelinux-3.0-net10.0-opt-amd64-$(System:DockerfileGitCommitSha)": {}
               }
             }
           ]
@@ -925,7 +948,8 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-opt-arm64": {}
+                "azurelinux-3.0-net10.0-opt-arm64": {},
+                "azurelinux-3.0-net10.0-opt-arm64-$(System:DockerfileGitCommitSha)": {}
               }
             }
           ]

--- a/src/azurelinux/manifest.json
+++ b/src/azurelinux/manifest.json
@@ -675,7 +675,7 @@
               "osVersion": "azurelinux3.0",
               "tags": {
                 "azurelinux-3.0-net10.0-cross-loongarch64": {},
-                "azurelinux-3.0-net10.0-cross-loongarch64-$(System:DockerfileGitCommitSha)": {},
+                "azurelinux-3.0-net10.0-cross-loongarch64-$(System:DockerfileGitCommitSha)": {}
               }
             }
           ]


### PR DESCRIPTION
We need to update the LLVM version used in our build images. As discussed in https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/1371, we would like a long-term solution where dotnet/runtime references images by sha, and they get updated via dependency flow PRs. In the meantime, we can temporarily pin dotnet/runtime images to a specific version to avoid build instability while we roll out new images for https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1369.

This change adds back git sha based tags to make it easier to manually pin the images (not to a specific build, but to a specific sha - should be good enough for our purposes).