### PR TITLE
Provide a way to disable matrix trimming

### DIFF
--- a/eng/pipelines/dotnet-buildtools-prereqs-all.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-all.yml
@@ -7,6 +7,12 @@ trigger:
     - src/*
 pr: none
 
+parameters:
+- name: disableMatrixTrimming
+  displayName: Disable matrix trimming
+  type: boolean
+  default: false
+
 schedules:
 - cron: "0 5 1,15 * *"
   displayName: Monthly rebuild of all images
@@ -24,6 +30,8 @@ resources:
 
 variables:
 - template: /eng/pipelines/variables/common.yml@self
+  parameters: 
+    disableMatrixTrimming: ${{ parameters.disableMatrixTrimming }}
 - name: publishEolAnnotations
   value: true
 

--- a/eng/pipelines/variables/common.yml
+++ b/eng/pipelines/variables/common.yml
@@ -1,3 +1,8 @@
+parameters:
+- name: disableMatrixTrimming
+  type: boolean
+  default: false
+
 variables:
 - template: /eng/common/templates/variables/dotnet/build-test-publish.yml@self
 - name: officialBranches
@@ -21,8 +26,9 @@ variables:
   value: false
 - name: testScriptPath
   value: ""
-- name: trimCachedImagesForMatrix
-  value: true
+- ${{ if not(parameters.disableMatrixTrimming) }}:
+  - name: trimCachedImagesForMatrix
+    value: true
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - name: build.imageBuilderDockerRunExtraOptions
     value: -e DOCKER_REPO=$(acr.server)/$(stagingRepoPrefix)dotnet-buildtools/prereqs


### PR DESCRIPTION
This enables the pipeline to disable matrix trimming. This helps to workaround issues related to trimming such as https://github.com/dotnet/docker-tools/issues/1493, which we ran into from the changes in https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1375.