### PR TITLE
Revert "Add git sha tags for net10.0 images"

### DIFF
--- a/src/azurelinux/manifest.json
+++ b/src/azurelinux/manifest.json
@@ -648,8 +648,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-cross-riscv64": {},
-                "azurelinux-3.0-net10.0-cross-riscv64-$(System:DockerfileGitCommitSha)": {}
+                "azurelinux-3.0-net10.0-cross-riscv64": {}
               }
             }
           ]
@@ -661,8 +660,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-cross-riscv64-musl": {},
-                "azurelinux-3.0-net10.0-cross-riscv64-musl-$(System:DockerfileGitCommitSha)": {}
+                "azurelinux-3.0-net10.0-cross-riscv64-musl": {}
               }
             }
           ]
@@ -674,8 +672,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-cross-loongarch64": {},
-                "azurelinux-3.0-net10.0-cross-loongarch64-$(System:DockerfileGitCommitSha)": {}
+                "azurelinux-3.0-net10.0-cross-loongarch64": {}
               }
             }
           ]
@@ -687,8 +684,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-cross-loongarch64-musl": {},
-                "azurelinux-3.0-net10.0-cross-loongarch64-musl-$(System:DockerfileGitCommitSha)": {}
+                "azurelinux-3.0-net10.0-cross-loongarch64-musl": {}
               }
             }
           ]
@@ -700,8 +696,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-cross-amd64": {},
-                "azurelinux-3.0-net10.0-cross-amd64-$(System:DockerfileGitCommitSha)": {}
+                "azurelinux-3.0-net10.0-cross-amd64": {}
               }
             }
           ]
@@ -713,8 +708,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-cross-amd64-sanitizer": {},
-                "azurelinux-3.0-net10.0-cross-amd64-sanitizer-$(System:DockerfileGitCommitSha)": {}
+                "azurelinux-3.0-net10.0-cross-amd64-sanitizer": {}
               }
             }
           ]
@@ -726,8 +720,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-cross-amd64-musl": {},
-                "azurelinux-3.0-net10.0-cross-amd64-musl-$(System:DockerfileGitCommitSha)": {}
+                "azurelinux-3.0-net10.0-cross-amd64-musl": {}
               }
             }
           ]
@@ -739,8 +732,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-cross-arm": {},
-                "azurelinux-3.0-net10.0-cross-arm-$(System:DockerfileGitCommitSha)": {}
+                "azurelinux-3.0-net10.0-cross-arm": {}
               }
             }
           ]
@@ -752,8 +744,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-cross-arm-musl": {},
-                "azurelinux-3.0-net10.0-cross-arm-musl-$(System:DockerfileGitCommitSha)": {}
+                "azurelinux-3.0-net10.0-cross-arm-musl": {}
               }
             }
           ]
@@ -765,8 +756,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-cross-arm64": {},
-                "azurelinux-3.0-net10.0-cross-arm64-$(System:DockerfileGitCommitSha)": {}
+                "azurelinux-3.0-net10.0-cross-arm64": {}
               }
             }
           ]
@@ -778,8 +768,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-cross-arm64-musl": {},
-                "azurelinux-3.0-net10.0-cross-arm64-musl-$(System:DockerfileGitCommitSha)": {}
+                "azurelinux-3.0-net10.0-cross-arm64-musl": {}
               }
             }
           ]
@@ -791,8 +780,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-cross-x86": {},
-                "azurelinux-3.0-net10.0-cross-x86-$(System:DockerfileGitCommitSha)": {}
+                "azurelinux-3.0-net10.0-cross-x86": {}
               }
             }
           ]
@@ -804,8 +792,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-webassembly-amd64": {},
-                "azurelinux-3.0-net10.0-webassembly-amd64-$(System:DockerfileGitCommitSha)": {}
+                "azurelinux-3.0-net10.0-webassembly-amd64": {}
               }
             }
           ]
@@ -817,8 +804,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-android-amd64": {},
-                "azurelinux-3.0-net10.0-android-amd64-$(System:DockerfileGitCommitSha)": {}
+                "azurelinux-3.0-net10.0-android-amd64": {}
               }
             }
           ]
@@ -830,8 +816,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-cross-android-amd64": {},
-                "azurelinux-3.0-net10.0-cross-android-amd64-$(System:DockerfileGitCommitSha)": {}
+                "azurelinux-3.0-net10.0-cross-android-amd64": {}
               }
             }
           ]
@@ -843,8 +828,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-android-docker-amd64": {},
-                "azurelinux-3.0-net10.0-android-docker-amd64-$(System:DockerfileGitCommitSha)": {}
+                "azurelinux-3.0-net10.0-android-docker-amd64": {}
               }
             }
           ]
@@ -856,8 +840,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-cross-android-openssl-amd64": {},
-                "azurelinux-3.0-net10.0-cross-android-openssl-amd64-$(System:DockerfileGitCommitSha)": {}
+                "azurelinux-3.0-net10.0-cross-android-openssl-amd64": {}
               }
             }
           ]
@@ -869,8 +852,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-cross-freebsd-14-amd64": {},
-                "azurelinux-3.0-net10.0-cross-freebsd-14-amd64-$(System:DockerfileGitCommitSha)": {}
+                "azurelinux-3.0-net10.0-cross-freebsd-14-amd64": {}
               }
             }
           ]
@@ -882,8 +864,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-cross-freebsd-14-arm64": {},
-                "azurelinux-3.0-net10.0-cross-freebsd-14-arm64-$(System:DockerfileGitCommitSha)": {}
+                "azurelinux-3.0-net10.0-cross-freebsd-14-arm64": {}
               }
             }
           ]
@@ -895,8 +876,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-cross-s390x": {},
-                "azurelinux-3.0-net10.0-cross-s390x-$(System:DockerfileGitCommitSha)": {}
+                "azurelinux-3.0-net10.0-cross-s390x": {}
               }
             }
           ]
@@ -908,8 +888,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-cross-ppc64le": {},
-                "azurelinux-3.0-net10.0-cross-ppc64le-$(System:DockerfileGitCommitSha)": {}
+                "azurelinux-3.0-net10.0-cross-ppc64le": {}
               }
             }
           ]
@@ -921,8 +900,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-cross-armv6": {},
-                "azurelinux-3.0-net10.0-cross-armv6-$(System:DockerfileGitCommitSha)": {}
+                "azurelinux-3.0-net10.0-cross-armv6": {}
               }
             }
           ]
@@ -934,8 +912,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-opt-amd64": {},
-                "azurelinux-3.0-net10.0-opt-amd64-$(System:DockerfileGitCommitSha)": {}
+                "azurelinux-3.0-net10.0-opt-amd64": {}
               }
             }
           ]
@@ -948,8 +925,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-net10.0-opt-arm64": {},
-                "azurelinux-3.0-net10.0-opt-arm64-$(System:DockerfileGitCommitSha)": {}
+                "azurelinux-3.0-net10.0-opt-arm64": {}
               }
             }
           ]


### PR DESCRIPTION
Reverts dotnet/dotnet-buildtools-prereqs-docker#1375

Reverting because per https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1375#issuecomment-2698235002, the tags of dependent cross-* images won't be updated when we bump LLVM with this approach.