### PR TITLE
Remove jsvu after installing v8 engine

### DIFF
--- a/src/ubuntu/20.04/helix/wasm/amd64/Dockerfile
+++ b/src/ubuntu/20.04/helix/wasm/amd64/Dockerfile
@@ -27,7 +27,9 @@ USER helixbot
 
 # Install latest V8 engine
 ENV PATH="/home/helixbot/.jsvu/bin:${PATH}"
-RUN sudo npm install jsvu -g \
-    && jsvu --os=linux64 --engines=v8 \
+RUN npm install jsvu -g \
+    && su helixbot -c "jsvu --os=linux64 --engines=v8" \
     && v8 -e "console.log(version());quit();" \
-    && sudo npm uninstall jsvu -g
+    && npm uninstall jsvu -g
+
+USER helixbot

--- a/src/ubuntu/20.04/helix/wasm/amd64/Dockerfile
+++ b/src/ubuntu/20.04/helix/wasm/amd64/Dockerfile
@@ -23,8 +23,6 @@ RUN /tmp/setup-node-23.x.sh && apt-get -y install nodejs
 
 RUN npm install -g npm
 
-USER helixbot
-
 # Install latest V8 engine
 ENV PATH="/home/helixbot/.jsvu/bin:${PATH}"
 RUN npm install jsvu -g \

--- a/src/ubuntu/20.04/helix/wasm/amd64/Dockerfile
+++ b/src/ubuntu/20.04/helix/wasm/amd64/Dockerfile
@@ -22,11 +22,12 @@ COPY ./setup-node-23.x.sh /tmp
 RUN /tmp/setup-node-23.x.sh && apt-get -y install nodejs
 
 RUN npm install -g npm
-RUN npm install jsvu -g
 
 USER helixbot
 
 # Install latest V8 engine
-RUN jsvu --os=linux64 --engines=v8
 ENV PATH="/home/helixbot/.jsvu/bin:${PATH}"
-RUN v8 -e "console.log(version());quit();"
+RUN sudo npm install jsvu -g \
+    && jsvu --os=linux64 --engines=v8 \
+    && v8 -e "console.log(version());quit();" \
+    && sudo npm uninstall jsvu -g

--- a/src/ubuntu/22.04/helix/webassembly/amd64/Dockerfile
+++ b/src/ubuntu/22.04/helix/webassembly/amd64/Dockerfile
@@ -42,11 +42,11 @@ RUN /tmp/setup-node-23.x.sh && apt-get -y install nodejs
 
 RUN npm install -g npm
 
-USER helixbot
-
 # Install latest V8 engine
 ENV PATH="/home/helixbot/.jsvu/bin:${PATH}"
-RUN sudo npm install jsvu -g \
-    && jsvu --os=linux64 --engines=v8 \
+RUN npm install jsvu -g \
+    && su helixbot -c "jsvu --os=linux64 --engines=v8" \
     && v8 -e "console.log(version());quit();" \
-    && sudo npm uninstall jsvu -g
+    && npm uninstall jsvu -g
+
+USER helixbot

--- a/src/ubuntu/22.04/helix/webassembly/amd64/Dockerfile
+++ b/src/ubuntu/22.04/helix/webassembly/amd64/Dockerfile
@@ -41,11 +41,12 @@ COPY ./setup-node-23.x.sh /tmp
 RUN /tmp/setup-node-23.x.sh && apt-get -y install nodejs
 
 RUN npm install -g npm
-RUN npm install jsvu -g
 
 USER helixbot
 
 # Install latest V8 engine
-RUN jsvu --os=linux64 --engines=v8
 ENV PATH="/home/helixbot/.jsvu/bin:${PATH}"
-RUN v8 -e "console.log(version());quit();"
+RUN sudo npm install jsvu -g \
+    && jsvu --os=linux64 --engines=v8 \
+    && v8 -e "console.log(version());quit();" \
+    && sudo npm uninstall jsvu -g

--- a/src/windowsservercore/ltsc2022/helix/webassembly-net8/amd64/Dockerfile
+++ b/src/windowsservercore/ltsc2022/helix/webassembly-net8/amd64/Dockerfile
@@ -60,5 +60,6 @@ RUN powershell -Command " `
 # install latest jsvu and v8 engine
 RUN npm install jsvu -g `
     && npm exec -c "jsvu --os=win64 --engines=v8" `
-    && setx PATH "%PATH%;%USERPROFILE%\.jsvu\bin"
-RUN v8 -e "console.log(version());quit();"
+    && setx PATH "%PATH%;%USERPROFILE%\.jsvu\bin" `
+    && v8 -e "console.log(version());quit();" `
+    && npm uninstall jsvu -g

--- a/src/windowsservercore/ltsc2022/helix/webassembly-net8/amd64/Dockerfile
+++ b/src/windowsservercore/ltsc2022/helix/webassembly-net8/amd64/Dockerfile
@@ -61,5 +61,5 @@ RUN powershell -Command " `
 RUN npm install jsvu -g `
     && npm exec -c "jsvu --os=win64 --engines=v8" `
     && setx PATH "%PATH%;%USERPROFILE%\.jsvu\bin" `
-    && v8 -e "console.log(version());quit();" `
+    && %USERPROFILE%\.jsvu\bin\v8 -e "console.log(version());quit();" `
     && npm uninstall jsvu -g

--- a/src/windowsservercore/ltsc2022/helix/webassembly/amd64/Dockerfile
+++ b/src/windowsservercore/ltsc2022/helix/webassembly/amd64/Dockerfile
@@ -46,7 +46,7 @@ RUN powershell -Command " `
 RUN npm install jsvu -g `
     && npm exec -c "jsvu --os=win64 --engines=v8" `
     && setx PATH "%PATH%;%USERPROFILE%\.jsvu\bin" `
-    && v8 -e "console.log(version());quit();" `
+    && %USERPROFILE%\.jsvu\bin\v8 -e "console.log(version());quit();" `
     && npm uninstall jsvu -g
 
 # install vc redistributable for llvm 19

--- a/src/windowsservercore/ltsc2022/helix/webassembly/amd64/Dockerfile
+++ b/src/windowsservercore/ltsc2022/helix/webassembly/amd64/Dockerfile
@@ -45,8 +45,9 @@ RUN powershell -Command " `
 # install latest jsvu and v8 engine
 RUN npm install jsvu -g `
     && npm exec -c "jsvu --os=win64 --engines=v8" `
-    && setx PATH "%PATH%;%USERPROFILE%\.jsvu\bin"
-RUN v8 -e "console.log(version());quit();"
+    && setx PATH "%PATH%;%USERPROFILE%\.jsvu\bin" `
+    && v8 -e "console.log(version());quit();" `
+    && npm uninstall jsvu -g
 
 # install vc redistributable for llvm 19
 ENV VC_REDIST_VERSION 17

--- a/src/windowsservercore/ltsc2025/helix/webassembly-net8/amd64/Dockerfile
+++ b/src/windowsservercore/ltsc2025/helix/webassembly-net8/amd64/Dockerfile
@@ -60,5 +60,6 @@ RUN powershell -Command " `
 # install latest jsvu and v8 engine
 RUN npm install jsvu -g `
     && npm exec -c "jsvu --os=win64 --engines=v8" `
-    && setx PATH "%PATH%;%USERPROFILE%\.jsvu\bin"
-RUN v8 -e "console.log(version());quit();"
+    && setx PATH "%PATH%;%USERPROFILE%\.jsvu\bin" `
+    && v8 -e "console.log(version());quit();" `
+    && npm uninstall jsvu -g

--- a/src/windowsservercore/ltsc2025/helix/webassembly-net8/amd64/Dockerfile
+++ b/src/windowsservercore/ltsc2025/helix/webassembly-net8/amd64/Dockerfile
@@ -61,5 +61,5 @@ RUN powershell -Command " `
 RUN npm install jsvu -g `
     && npm exec -c "jsvu --os=win64 --engines=v8" `
     && setx PATH "%PATH%;%USERPROFILE%\.jsvu\bin" `
-    && v8 -e "console.log(version());quit();" `
+    && %USERPROFILE%\.jsvu\bin\v8 -e "console.log(version());quit();" `
     && npm uninstall jsvu -g

--- a/src/windowsservercore/ltsc2025/helix/webassembly/amd64/Dockerfile
+++ b/src/windowsservercore/ltsc2025/helix/webassembly/amd64/Dockerfile
@@ -46,7 +46,7 @@ RUN powershell -Command " `
 RUN npm install jsvu -g `
     && npm exec -c "jsvu --os=win64 --engines=v8" `
     && setx PATH "%PATH%;%USERPROFILE%\.jsvu\bin" `
-    && v8 -e "console.log(version());quit();" `
+    && %USERPROFILE%\.jsvu\bin\v8 -e "console.log(version());quit();" `
     && npm uninstall jsvu -g
 
 # install vc redistributable for llvm 19

--- a/src/windowsservercore/ltsc2025/helix/webassembly/amd64/Dockerfile
+++ b/src/windowsservercore/ltsc2025/helix/webassembly/amd64/Dockerfile
@@ -45,8 +45,9 @@ RUN powershell -Command " `
 # install latest jsvu and v8 engine
 RUN npm install jsvu -g `
     && npm exec -c "jsvu --os=win64 --engines=v8" `
-    && setx PATH "%PATH%;%USERPROFILE%\.jsvu\bin"
-RUN v8 -e "console.log(version());quit();"
+    && setx PATH "%PATH%;%USERPROFILE%\.jsvu\bin" `
+    && v8 -e "console.log(version());quit();" `
+    && npm uninstall jsvu -g
 
 # install vc redistributable for llvm 19
 ENV VC_REDIST_VERSION 17


### PR DESCRIPTION
Related to https://github.com/dotnet/dotnet-buildtools-prereqs-docker-internal/issues/240

The installation of the jsvu NPM package brings with it a vulnerable version of cross-spawn via a transitive dependency. It's not possible to force a newer version of cross-spawn to be installed due to the version dependencies of jsvu preventing upgrade to a newer major version.

This is what the graph looks like:

```
$ npm ls -g cross-spawn
/usr/lib
├─┬ jsvu@2.5.1
│ ├─┬ execa@2.1.0
│ │ └── cross-spawn@7.0.6
│ └─┬ update-notifier@3.0.1
│   └─┬ boxen@3.2.0
│     └─┬ term-size@1.2.0
│       └─┬ execa@0.7.0
│         └── cross-spawn@5.1.0
└─┬ npm@11.2.0
  └─┬ glob@10.4.5
    └─┬ foreground-child@3.3.1
      └── cross-spawn@7.0.6
```

The problem is that jsvu brings in a very old version of update-notifier and won't use a newer 4+ version.

There's very little that can be done here except to prevent the vulnerable package from being left in the container image. So I've restructured the Dockerfile to install jsvu, use jsvu to install the v8 engine, and then uninstall jsvu, all in the same layer. So this prevents the vulnerable cross-spawn from being written to a layer. But you're left with a usable v8 engine in the container.