### PR TITLE
Update Python version on Windows

### DIFF
--- a/src/nanoserver/1809/helix/amd64/Dockerfile
+++ b/src/nanoserver/1809/helix/amd64/Dockerfile
@@ -10,28 +10,31 @@ RUN $apiUrl = 'https://api.github.com/repos/PowerShell/PowerShell/releases/lates
     Expand-Archive -Path C:\powershell.zip -DestinationPath C:\powershell; `
     Remove-Item -Path C:\powershell.zip
 
+# Download latest stable version of Python
+RUN $apiUrl = 'https://api.nuget.org/v3-flatcontainer/python/index.json'; `
+    $response = Invoke-RestMethod -Uri $apiUrl; `
+    $versions = $response.versions | Where-Object { $_ -notmatch '-' } | Sort-Object { [version]$_ } -Descending; `
+    $latestVersion = $versions[0]; `
+    echo \"Downloading Python $latestVersion\"; `
+    Invoke-WebRequest -Uri https://www.nuget.org/api/v2/package/python/$latestVersion -OutFile $env:TEMP\python.zip; `
+    md C:\PythonTemp; `
+    tar -zxf  $env:TEMP\python.zip -C C:\PythonTemp;
+
 
 FROM mcr.microsoft.com/windows/nanoserver:1809
 
-SHELL ["cmd", "/S", "/C"]
 USER ContainerAdministrator
-ENTRYPOINT C:\Windows\System32\cmd.exe
 
 COPY --from=installer [ "C:\\powershell\\", "C:\\Program Files\\PowerShell\\" ]
+COPY --from=installer [ "C:\\PythonTemp\\tools", "C:\\Python\\" ]
 
-RUN curl -SL --output %TEMP%\python.zip https://www.nuget.org/api/v2/package/python/3.7.3 `
-    && md C:\Python C:\PythonTemp `
-    && tar -zxf %TEMP%\python.zip -C C:\PythonTemp `
-    && xcopy /s c:\PythonTemp\tools C:\Python `
-    && rd /s /q c:\PythonTemp `
-    && del /q %TEMP%\python.zip `
-    && setx /M PYTHONPATH "C:\Python\Lib;C:\Python\DLLs;"
+RUN setx /M PATH "%PATH%;C:\Program Files\PowerShell\;C:\Python;C:\python\scripts" && `
+    setx /M PYTHONPATH "C:\Python\Lib;C:\Python\DLLs;" && `
+    setx /M VIRTUAL_ENV "C:\Python-env"
 
-RUN setx /M PATH "%PATH%;C:\Program Files\PowerShell\;C:\Python;C:\python\scripts"
-
-RUN md c:\\helixtmp && pushd c:\\helixtmp &&`
-    python -m pip install --upgrade pip==20.2 && `
-    python -m pip install virtualenv==16.6.0 && `
+RUN md c:\\helixtmp && pushd c:\\helixtmp && `
+    python -m pip install --upgrade pip && `
+    python -m venv %VIRTUAL_ENV% && `
     pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && `
     for %f in (.\helix_scripts-*-py3-none-any.whl) do (pip install %f) && `
     popd && rd /s /q c:\\helixtmp && `
@@ -46,4 +49,3 @@ RUN md c:\\helixtmp && pushd c:\\helixtmp &&`
         Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\corerun.exe' -Value 2 -Name DumpCount -Force
 
 WORKDIR C:\\Work
-

--- a/src/windowsservercore/ltsc2019/helix/amd64/Dockerfile
+++ b/src/windowsservercore/ltsc2019/helix/amd64/Dockerfile
@@ -1,22 +1,32 @@
 # escape=`
 FROM mcr.microsoft.com/windows/servercore:ltsc2019
 
-SHELL ["cmd", "/S", "/C"]
-USER ContainerAdministrator
+# Install latest stable version of Python
+RUN powershell -Command "`
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        $apiUrl = 'https://api.nuget.org/v3-flatcontainer/python/index.json'; `
+        $response = Invoke-RestMethod -Uri $apiUrl; `
+        $versions = $response.versions | Where-Object { $_ -notmatch '-' } | Sort-Object { [version]$_ } -Descending; `
+        $latestVersion = $versions[0]; `
+        echo \"Downloading Python $latestVersion\"; `
+        Invoke-WebRequest -Uri https://www.nuget.org/api/v2/package/python/$latestVersion -OutFile $env:TEMP\python.zip; `
+        md C:\Python; `
+        md C:\PythonTemp; `
+        tar -zxf  $env:TEMP\python.zip -C C:\PythonTemp; `
+        xcopy /s c:\PythonTemp\tools C:\Python; `
+        Remove-Item -Recurse -Force C:\PythonTemp; `
+        Remove-Item -Force $env:TEMP\python.zip;"
 
-RUN curl -SL --output %TEMP%\python.zip https://www.nuget.org/api/v2/package/python/3.7.3 `
-    && md C:\Python C:\PythonTemp `
-    && tar -zxf %TEMP%\python.zip -C C:\PythonTemp `
-    && xcopy /s c:\PythonTemp\tools C:\Python `
-    && rd /s /q c:\PythonTemp `
-    && del /q %TEMP%\python.zip `
-    && setx /M PYTHONPATH "C:\Python\Lib;C:\Python\DLLs;"
+RUN setx /M PATH "%PATH%;C:\Python;C:\python\scripts" && `
+    setx /M PYTHONPATH "C:\Python\Lib;C:\Python\DLLs;" && `
+    setx /M VIRTUAL_ENV "C:\Python-env"
 
-RUN md c:\\helixtmp && pushd c:\\helixtmp &&`
-    C:\Python\python.exe -m pip install --upgrade pip==20.2 --no-warn-script-location && `
-    C:\Python\python.exe -m pip install virtualenv==16.6.0 --no-warn-script-location && `
-    C:\Python\python.exe -m pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && `
-    for %f in (.\helix_scripts-*-py3-none-any.whl) do (C:\Python\python.exe -m pip install %f  --no-warn-script-location) && `
+RUN md c:\\helixtmp && pushd c:\\helixtmp && `
+    python -m pip install --upgrade pip && `
+    python -m venv %VIRTUAL_ENV% && `
+    python -m pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && `
+    for %f in (.\helix_scripts-*-py3-none-any.whl) do (python -m pip install %f  --no-warn-script-location) && `
     popd && rd /s /q c:\\helixtmp && `
     powershell -Command `
         New-Item -Path 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\' -Name 'dotnet.exe' -Force -ErrorAction SilentlyContinue ; `
@@ -26,8 +36,6 @@ RUN md c:\\helixtmp && pushd c:\\helixtmp &&`
         New-Item -Path 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\' -Name 'corerun.exe' -Force -ErrorAction SilentlyContinue ; `
         Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\corerun.exe' -Value 2 -Name DumpType -Force ; `
         Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\corerun.exe' -Value 'C:\cores' -Name DumpFolder -Force ; `
-        Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\corerun.exe' -Value 2 -Name DumpCount -Force && `
-   setx /M PATH "%PATH%;C:\Python;C:\python\scripts"    
+        Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\corerun.exe' -Value 2 -Name DumpCount -Force
 
 WORKDIR C:\\Work
-

--- a/src/windowsservercore/ltsc2022/helix/amd64/Dockerfile
+++ b/src/windowsservercore/ltsc2022/helix/amd64/Dockerfile
@@ -1,22 +1,32 @@
 # escape=`
 FROM mcr.microsoft.com/windows/servercore:ltsc2022
 
-SHELL ["cmd", "/S", "/C"]
-USER ContainerAdministrator
+# Install latest stable version of Python
+RUN powershell -Command "`
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        $apiUrl = 'https://api.nuget.org/v3-flatcontainer/python/index.json'; `
+        $response = Invoke-RestMethod -Uri $apiUrl; `
+        $versions = $response.versions | Where-Object { $_ -notmatch '-' } | Sort-Object { [version]$_ } -Descending; `
+        $latestVersion = $versions[0]; `
+        echo \"Downloading Python $latestVersion\"; `
+        Invoke-WebRequest -Uri https://www.nuget.org/api/v2/package/python/$latestVersion -OutFile $env:TEMP\python.zip; `
+        md C:\Python; `
+        md C:\PythonTemp; `
+        tar -zxf  $env:TEMP\python.zip -C C:\PythonTemp; `
+        xcopy /s c:\PythonTemp\tools C:\Python; `
+        Remove-Item -Recurse -Force C:\PythonTemp; `
+        Remove-Item -Force $env:TEMP\python.zip;"
 
-RUN curl -SL --output %TEMP%\python.zip https://www.nuget.org/api/v2/package/python/3.7.3 `
-    && md C:\Python C:\PythonTemp `
-    && tar -zxf %TEMP%\python.zip -C C:\PythonTemp `
-    && xcopy /s c:\PythonTemp\tools C:\Python `
-    && rd /s /q c:\PythonTemp `
-    && del /q %TEMP%\python.zip `
-    && setx /M PYTHONPATH "C:\Python\Lib;C:\Python\DLLs;"
+RUN setx /M PATH "%PATH%;C:\Python;C:\python\scripts" && `
+    setx /M PYTHONPATH "C:\Python\Lib;C:\Python\DLLs;" && `
+    setx /M VIRTUAL_ENV "C:\Python-env"
 
-RUN md c:\\helixtmp && pushd c:\\helixtmp &&`
-    C:\Python\python.exe -m pip install --upgrade pip==20.2 --no-warn-script-location && `
-    C:\Python\python.exe -m pip install virtualenv==16.6.0 --no-warn-script-location && `
-    C:\Python\python.exe -m pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && `
-    for %f in (.\helix_scripts-*-py3-none-any.whl) do (C:\Python\python.exe -m pip install %f  --no-warn-script-location) && `
+RUN md c:\\helixtmp && pushd c:\\helixtmp && `
+    python -m pip install --upgrade pip && `
+    python -m venv %VIRTUAL_ENV% && `
+    python -m pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && `
+    for %f in (.\helix_scripts-*-py3-none-any.whl) do (python -m pip install %f  --no-warn-script-location) && `
     popd && rd /s /q c:\\helixtmp && `
     powershell -Command `
         New-Item -Path 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\' -Name 'dotnet.exe' -Force -ErrorAction SilentlyContinue ; `
@@ -26,7 +36,6 @@ RUN md c:\\helixtmp && pushd c:\\helixtmp &&`
         New-Item -Path 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\' -Name 'corerun.exe' -Force -ErrorAction SilentlyContinue ; `
         Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\corerun.exe' -Value 2 -Name DumpType -Force ; `
         Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\corerun.exe' -Value 'C:\cores' -Name DumpFolder -Force ; `
-        Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\corerun.exe' -Value 2 -Name DumpCount -Force && `
-   setx /M PATH "%PATH%;C:\Python;C:\python\scripts"
+        Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\corerun.exe' -Value 2 -Name DumpCount -Force
 
 WORKDIR C:\\Work

--- a/src/windowsservercore/ltsc2025/helix/amd64/Dockerfile
+++ b/src/windowsservercore/ltsc2025/helix/amd64/Dockerfile
@@ -1,22 +1,32 @@
 # escape=`
 FROM mcr.microsoft.com/windows/servercore:ltsc2025
 
-SHELL ["cmd", "/S", "/C"]
-USER ContainerAdministrator
+# Install latest stable version of Python
+RUN powershell -Command "`
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        $apiUrl = 'https://api.nuget.org/v3-flatcontainer/python/index.json'; `
+        $response = Invoke-RestMethod -Uri $apiUrl; `
+        $versions = $response.versions | Where-Object { $_ -notmatch '-' } | Sort-Object { [version]$_ } -Descending; `
+        $latestVersion = $versions[0]; `
+        echo \"Downloading Python $latestVersion\"; `
+        Invoke-WebRequest -Uri https://www.nuget.org/api/v2/package/python/$latestVersion -OutFile $env:TEMP\python.zip; `
+        md C:\Python; `
+        md C:\PythonTemp; `
+        tar -zxf  $env:TEMP\python.zip -C C:\PythonTemp; `
+        xcopy /s c:\PythonTemp\tools C:\Python; `
+        Remove-Item -Recurse -Force C:\PythonTemp; `
+        Remove-Item -Force $env:TEMP\python.zip;"
 
-RUN curl -SL --output %TEMP%\python.zip https://www.nuget.org/api/v2/package/python/3.7.3 `
-    && md C:\Python C:\PythonTemp `
-    && tar -zxf %TEMP%\python.zip -C C:\PythonTemp `
-    && xcopy /s c:\PythonTemp\tools C:\Python `
-    && rd /s /q c:\PythonTemp `
-    && del /q %TEMP%\python.zip `
-    && setx /M PYTHONPATH "C:\Python\Lib;C:\Python\DLLs;"
+RUN setx /M PATH "%PATH%;C:\Python;C:\python\scripts" && `
+    setx /M PYTHONPATH "C:\Python\Lib;C:\Python\DLLs;" && `
+    setx /M VIRTUAL_ENV "C:\Python-env"
 
-RUN md c:\\helixtmp && pushd c:\\helixtmp &&`
-    C:\Python\python.exe -m pip install --upgrade pip==20.2 --no-warn-script-location && `
-    C:\Python\python.exe -m pip install virtualenv==16.6.0 --no-warn-script-location && `
-    C:\Python\python.exe -m pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && `
-    for %f in (.\helix_scripts-*-py3-none-any.whl) do (C:\Python\python.exe -m pip install %f  --no-warn-script-location) && `
+RUN md c:\\helixtmp && pushd c:\\helixtmp && `
+    python -m pip install --upgrade pip && `
+    python -m venv %VIRTUAL_ENV% && `
+    python -m pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && `
+    for %f in (.\helix_scripts-*-py3-none-any.whl) do (python -m pip install %f  --no-warn-script-location) && `
     popd && rd /s /q c:\\helixtmp && `
     powershell -Command `
         New-Item -Path 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\' -Name 'dotnet.exe' -Force -ErrorAction SilentlyContinue ; `
@@ -26,7 +36,6 @@ RUN md c:\\helixtmp && pushd c:\\helixtmp &&`
         New-Item -Path 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\' -Name 'corerun.exe' -Force -ErrorAction SilentlyContinue ; `
         Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\corerun.exe' -Value 2 -Name DumpType -Force ; `
         Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\corerun.exe' -Value 'C:\cores' -Name DumpFolder -Force ; `
-        Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\corerun.exe' -Value 2 -Name DumpCount -Force && `
-   setx /M PATH "%PATH%;C:\Python;C:\python\scripts"
+        Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\corerun.exe' -Value 2 -Name DumpCount -Force
 
 WORKDIR C:\\Work


### PR DESCRIPTION
The Python version in the Windows Helix Dockerfiles is outdated. This ensures it gets the latest. This is a port of the changes that originally existed in https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1336.