### PR TITLE
Set correct base image for net10 cross freebsd image

### DIFF
--- a/src/azurelinux/3.0/net10.0/cross/freebsd/14/arm64/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/cross/freebsd/14/arm64/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROOTFS_DIR=/crossrootfs/arm64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-amd64 AS builder
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
 # Install packages needed by the FreeBSD bootstrap scripts
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 RUN /scripts/eng/common/cross/build-rootfs.sh freebsd14 arm64
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-amd64
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR
 
 COPY --from=builder "$ROOTFS_DIR" "$ROOTFS_DIR"


### PR DESCRIPTION
This was incorrectly referencing the 9.0 base images.