### PR TITLE
Move MSQuic installation placement for Fedora 41 Helix

### DIFF
--- a/src/fedora/41/helix/amd64/Dockerfile
+++ b/src/fedora/41/helix/amd64/Dockerfile
@@ -20,6 +20,12 @@ RUN python3 -m venv /venv \
 
 FROM library/fedora:41
 
+# Install MSQuic. Fedora 41 does not have it in the repositories, so use the Fedora 40 package
+
+RUN dnf config-manager addrepo --from-repofile=https://packages.microsoft.com/fedora/40/prod/config.repo \
+    && dnf install --setopt=install_weak_deps=False --setopt tsflags=nodocs -y \
+        libmsquic
+
 # Install Dependencies
 
 RUN dnf upgrade --refresh -y \
@@ -48,12 +54,6 @@ RUN dnf upgrade --refresh -y \
         openssl \
         sudo \
     && dnf clean all
-
-# Install MSQuic. Fedora 41 does not have it in the repositories, so use the Fedora 40 package
-
-RUN dnf config-manager addrepo --from-repofile=https://packages.microsoft.com/fedora/40/prod/config.repo \
-    && dnf install --setopt=install_weak_deps=False --setopt tsflags=nodocs -y \
-        libmsquic
 
 ENV \
     # Needed for .NET libraries tests to pass


### PR DESCRIPTION
Fixes https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/1394

I don't know why the error described in https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/1394 is occurring. I don't think it's caused by PMC. It doesn't happen when running in a Fedora 40 container. It only occurs when running `dnf upgrade` first. So I found that simply moving it above where that occurs fixes the issue.