### PR TITLE
Update package for Alma Linux 9 Helix image

### DIFF
--- a/src/almalinux/9/helix/amd64/Dockerfile
+++ b/src/almalinux/9/helix/amd64/Dockerfile
@@ -23,28 +23,12 @@ RUN dnf upgrade --refresh -y \
         dnf-plugins-core \
     && dnf config-manager --add-repo=https://packages.microsoft.com/rhel/9/prod/config.repo \
     && dnf install --setopt tsflags=nodocs -y --allowerasing \
-        autoconf \
-        automake \
-        curl \
+        cpio \
         file \
-        git-core \
-        iputils \
         libicu \
         libmsquic \
-        libtool \
-        lldb \
-        llvm \
-        make \
-        openssl \
-        openssl-devel \
-        perl \
         python3.12 \
-        python3.12-devel \
-        python3.12-pip \
         sudo \
-        tar \
-        wget \
-        which \
     && dnf clean all
 
 ENV LANG=en_US.utf8


### PR DESCRIPTION
The initial list of packages was wrong. Not sure where I found those. Should be based on the [Alma 8 Helix Dockerfile](https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/806a357c727fab070d4d44bfe46016f43168c127/src/almalinux/8/helix/amd64/Dockerfile).

PR failure due to this mixup: https://github.com/dotnet/arcade/pull/15790