### PR TITLE
Add cpio dependency for Debian Trixie

### DIFF
--- a/src/debian/13/helix/Dockerfile
+++ b/src/debian/13/helix/Dockerfile
@@ -35,6 +35,7 @@ RUN LIBCURL=libcurl4 \
         automake \
         at \
         build-essential \
+        cpio \
         gcc \
         gdb \
         git \


### PR DESCRIPTION
`cpio` is a required dependency for helix images used by Arcade

Context: https://github.com/dotnet/arcade/pull/15790#issuecomment-2845848255

/cc @richlander 