### PR TITLE
Downgrade click to 8.1.8

### DIFF
--- a/src/azurelinux/3.0/net10.0/source-build-test/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/source-build-test/amd64/Dockerfile
@@ -6,7 +6,8 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0-preview-azurelinux3.0-amd64 AS installer
 RUN SCANCODE_VERSION="32.3.3" \
     && python3 -m venv /venv \
     && source /venv/bin/activate \
-    && pip install scancode-toolkit==$SCANCODE_VERSION
+    && pip install scancode-toolkit==$SCANCODE_VERSION \
+    && pip install click==8.1.8
 
 FROM mcr.microsoft.com/dotnet/sdk:10.0-preview-azurelinux3.0-amd64
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/5159

License scan test failed due to an outdated attribute mapping in the scancode toolkit. The attribute is_hidden has been renamed to hidden, but this change has not yet been included in the latest version of the scancode toolkit.