### PR TITLE
Add shadow-utils to our AZL3 images

### DIFF
--- a/src/azurelinux/3.0/docker-testrunner/Dockerfile
+++ b/src/azurelinux/3.0/docker-testrunner/Dockerfile
@@ -13,4 +13,5 @@ RUN tdnf install -y \
         azure-cli \
         git \
         powershell \
+        shadow-utils \
     && tdnf clean all

--- a/src/azurelinux/3.0/net10.0/crossdeps-builder/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/crossdeps-builder/amd64/Dockerfile
@@ -4,6 +4,7 @@ RUN tdnf install -y \
         # Common utilities
         ca-certificates \
         git \
+        shadow-utils \
         tar \
         wget \
         # LLVM build dependencies

--- a/src/azurelinux/3.0/net10.0/crossdeps/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/crossdeps/amd64/Dockerfile
@@ -6,6 +6,7 @@ RUN tdnf update -y && \
         ca-certificates \
         git \
         pigz \
+        shadow-utils \
         util-linux \
         wget \
         # Common runtime build dependencies

--- a/src/azurelinux/3.0/net10.0/opt/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/opt/Dockerfile
@@ -61,6 +61,7 @@ RUN tdnf update -y && \
         tar \
         util-linux \
         wget \
+        shadow-utils \
         # Runtime dependencies
         icu
 

--- a/src/azurelinux/3.0/net8.0/crossdeps-builder/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/crossdeps-builder/amd64/Dockerfile
@@ -4,6 +4,7 @@ RUN tdnf install -y \
         # Common utilities
         ca-certificates \
         git \
+        shadow-utils \
         tar \
         wget \
         # LLVM build dependencies

--- a/src/azurelinux/3.0/net8.0/crossdeps/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/crossdeps/amd64/Dockerfile
@@ -4,6 +4,7 @@ RUN tdnf update -y && \
     tdnf install -y \
         ca-certificates \
         git \
+        shadow-utils \
         # Provides 'su', required by Azure DevOps
         util-linux \
         wget \

--- a/src/azurelinux/3.0/net9.0/crossdeps-builder/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/crossdeps-builder/amd64/Dockerfile
@@ -4,6 +4,7 @@ RUN tdnf install -y \
         # Common utilities
         ca-certificates \
         git \
+        shadow-utils \
         tar \
         wget \
         # LLVM build dependencies
@@ -84,4 +85,4 @@ ENV PATH="/opt/llvm/bin:$PATH"
 
 # Obtain arcade scripts used to build rootfs
 RUN git config --global user.email builder@dotnet-buildtools-prereqs-docker && \
-    git clone --depth 1 --single-branch https://github.com/dotnet/arcade /scripts 
+    git clone --depth 1 --single-branch https://github.com/dotnet/arcade /scripts

--- a/src/azurelinux/3.0/net9.0/crossdeps/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/crossdeps/amd64/Dockerfile
@@ -5,6 +5,7 @@ RUN tdnf update -y && \
         ca-certificates \
         git \
         pigz \
+        shadow-utils \
         # Provides 'su', required by Azure DevOps
         util-linux \
         wget \

--- a/src/azurelinux/3.0/net9.0/opt/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/opt/Dockerfile
@@ -5,6 +5,7 @@ RUN tdnf update -y && \
         # Common dependencies
         ca-certificates \
         git \
+        shadow-utils \
         tar \
         util-linux \
         wget \


### PR DESCRIPTION
https://github.com/microsoft/azurelinux/pull/13448 just rolled out today, which broke all of our AZL3 images.

The shadow-utils package provides the `useradd` command, which is used by Azure DevOps as part of our CI flow. The change in the dependencies for `git` removed the dependency path that caused shadow-utils to get pulled in for our images.

This PR adds the package to our images explicitly so AzDO can run our images.