### PR TITLE
Add shadow-utils to source-build-test image

### DIFF
--- a/src/azurelinux/3.0/net10.0/source-build-test/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/source-build-test/amd64/Dockerfile
@@ -17,6 +17,7 @@ COPY --from=installer /venv /venv
 RUN tdnf update -y \
     && tdnf install -y \
         libgomp \
+        shadow-utils \
         util-linux \
     && tdnf clean all
 


### PR DESCRIPTION
This change was missed as part of https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1439

Fixes https://github.com/dotnet/source-build/issues/5222