### PR TITLE
Add AlmaLinux 10 images

### DIFF
--- a/src/almalinux/10/helix/amd64/Dockerfile
+++ b/src/almalinux/10/helix/amd64/Dockerfile
@@ -1,0 +1,45 @@
+FROM library/almalinux:10 AS venv
+
+RUN dnf upgrade --refresh -y \
+    && dnf install --setopt tsflags=nodocs -y \
+        gcc \
+        gcc-c++ \
+        python3.12 \
+        python3.12-devel \
+        python3.12-pip
+
+RUN python3 -m venv /venv \
+    && . /venv/bin/activate \
+    && pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
+    && pip install ./helix_scripts-*-py3-none-any.whl \
+    && rm ./helix_scripts-*-py3-none-any.whl
+
+
+FROM library/almalinux:10
+
+# Install dependencies
+RUN dnf upgrade --refresh -y \
+    && dnf install --setopt tsflags=nodocs -y \
+        dnf-plugins-core \
+    && dnf config-manager --add-repo=https://packages.microsoft.com/rhel/9/prod/config.repo \
+    && dnf install --setopt tsflags=nodocs -y --allowerasing \
+        cpio \
+        file \
+        libicu \
+        libmsquic \
+        python3.12 \
+        sudo \
+    && dnf clean all
+
+# create helixbot user and give rights to sudo without password
+RUN adduser --uid 1000 --shell /bin/bash --gid adm helixbot \
+    && chmod 755 /root \
+    && echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot
+
+USER helixbot
+ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
+
+# Install Helix Dependencies
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+COPY --from=venv --chown=helixbot /venv $VIRTUAL_ENV

--- a/src/almalinux/10/source-build/amd64/Dockerfile
+++ b/src/almalinux/10/source-build/amd64/Dockerfile
@@ -1,0 +1,49 @@
+FROM library/almalinux:10
+
+# Install dependencies
+RUN dnf upgrade --refresh -y \
+    && dnf install --setopt tsflags=nodocs -y \
+        'dnf-command(config-manager)' \
+        epel-release \
+    && dnf config-manager --set-enabled crb \
+    && dnf config-manager --set-enabled epel \
+    && dnf install --setopt tsflags=nodocs -y \
+        "perl(Time::HiRes)" \
+        autoconf \
+        automake \
+        brotli-devel \
+        cmake \
+        cpio \
+        elfutils \
+        file \
+        gdb \
+        git \
+        glibc-langpack-en \
+        iproute \
+        jq \
+        krb5-devel \
+        libcurl-devel \
+        libicu-devel \
+        libtool \
+        # Requires epel
+        libunwind-devel \
+        libuuid-devel \
+        libxml2-devel \
+        llvm-toolset \
+        lld \
+        # Requires powertools
+        lttng-ust-devel \
+        make \
+        ncurses-devel \
+        nodejs \
+        numactl-devel \
+        openssl-devel \
+        readline-devel \
+        python3.12 \
+        sudo \
+        swig \
+        wget \
+        which \
+        xz \
+        zlib-devel \
+    && dnf clean all

--- a/src/almalinux/manifest.json
+++ b/src/almalinux/manifest.json
@@ -43,6 +43,26 @@
               }
             }
           ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/almalinux/10/source-build/amd64",
+              "os": "linux",
+              "osVersion": "almalinux10",
+              "tags": {
+                "almalinux-10-source-build-amd64": {}
+              }
+            },
+            {
+              "dockerfile": "src/almalinux/10/helix/amd64",
+              "os": "linux",
+              "osVersion": "almalinux10",
+              "tags": {
+                "almalinux-10-helix-amd64": {}
+              }
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
Naturally, these images follow RHEL 10. We should switch to these for SB everywhere, at least for .NET 11. The v10 ecosystem is the one we most want to follow.