### PR TITLE
Preserve llvm-project.src directory in crossdeps-builder

### DIFF
--- a/src/azurelinux/3.0/net10.0/crossdeps-builder/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/crossdeps-builder/amd64/Dockerfile
@@ -84,7 +84,8 @@ RUN \
     make install && \
     popd && \
     # Cleanup
-    rm -rf llvm-project.src build
+    # Don't clean llvm-project.src since it is used by derived images
+    rm -rf build
 
 ENV PATH="/opt/llvm/bin:$PATH"
 

--- a/src/azurelinux/3.0/net8.0/crossdeps-builder/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/crossdeps-builder/amd64/Dockerfile
@@ -84,7 +84,8 @@ RUN \
     make install && \
     popd && \
     # Cleanup
-    rm -rf llvm-project.src build
+    # Don't clean llvm-project.src since it is used by derived images
+    rm -rf build
 
 ENV PATH="/opt/llvm/bin:$PATH"
 

--- a/src/azurelinux/3.0/net9.0/crossdeps-builder/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/crossdeps-builder/amd64/Dockerfile
@@ -84,7 +84,8 @@ RUN \
     make install && \
     popd && \
     # Cleanup
-    rm -rf llvm-project.src build
+    # Don't clean llvm-project.src since it is used by derived images
+    rm -rf build
 
 ENV PATH="/opt/llvm/bin:$PATH"
 


### PR DESCRIPTION
Reverts part of the changes from https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1446. We can't clean the `llvm-project.src` directory because it's used by derived images. This is the quick fix to unblock the build. There may be a better longer-term fix here.