### PR TITLE
Upgrade scancode to 32.4.0 and revert pinning of click

### DIFF
--- a/src/azurelinux/3.0/net10.0/source-build-test/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/source-build-test/amd64/Dockerfile
@@ -3,11 +3,10 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0-preview-azurelinux3.0-amd64 AS installer
 # Install scancode
 # Install instructions: https://scancode-toolkit.readthedocs.io/en/latest/getting-started/install.html#installation-as-a-library-via-pip
 # See latest release at https://github.com/nexB/scancode-toolkit/releases
-RUN SCANCODE_VERSION="32.3.3" \
+RUN SCANCODE_VERSION="32.4.0" \
     && python3 -m venv /venv \
     && source /venv/bin/activate \
-    && pip install scancode-toolkit==$SCANCODE_VERSION \
-    && pip install click==8.1.8
+    && pip install scancode-toolkit==$SCANCODE_VERSION
 
 FROM mcr.microsoft.com/dotnet/sdk:10.0-preview-azurelinux3.0-amd64
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/1433

New release of scancode is available, revert pinning of click package.