### PR TITLE
Add rapidjson package to Fedora 41

### DIFF
--- a/src/fedora/41/amd64/Dockerfile
+++ b/src/fedora/41/amd64/Dockerfile
@@ -40,6 +40,7 @@ RUN dnf upgrade --refresh -y \
         libuuid-devel \
         lttng-ust-devel \
         openssl-devel \
+        rapidjson-devel \
         uuid-devel \
         zlib-devel \
         # Dependencies for VMR/source-build tests


### PR DESCRIPTION
Required for adding a source build leg to test w/system libraries.

Related to https://github.com/dotnet/source-build/issues/4626