### PR TITLE
Remove OPENSSL_ENABLE_SHA1_SIGNATURES from Fedora dockerfiles

### DIFF
--- a/src/fedora/41/helix/amd64/Dockerfile
+++ b/src/fedora/41/helix/amd64/Dockerfile
@@ -57,9 +57,7 @@ RUN dnf upgrade --refresh -y \
 
 ENV \
     # Needed for .NET libraries tests to pass
-    LANG=en-US.UTF-8 \
-    # Needed for WCF tests to pass (https://github.com/dotnet/wcf/pull/5744#issuecomment-2702201438)
-    OPENSSL_ENABLE_SHA1_SIGNATURES=1
+    LANG=en-US.UTF-8
 
 # create helixbot user and give rights to sudo without password
 # Fedora does not have all options as other Linux systems

--- a/src/fedora/42/helix/amd64/Dockerfile
+++ b/src/fedora/42/helix/amd64/Dockerfile
@@ -57,9 +57,7 @@ RUN dnf upgrade --refresh -y \
 
 ENV \
     # Needed for .NET libraries tests to pass
-    LANG=en-US.UTF-8 \
-    # Needed for WCF tests to pass (https://github.com/dotnet/wcf/pull/5744#issuecomment-2702201438)
-    OPENSSL_ENABLE_SHA1_SIGNATURES=1
+    LANG=en-US.UTF-8
 
 # create helixbot user and give rights to sudo without password
 # Fedora does not have all options as other Linux systems


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1391#issuecomment-3070128484

WCF is setting the env var in their build instead now.