### PR TITLE
Fix versions repo endpoint

### DIFF
--- a/eng/pipelines/dotnet-buildtools-prereqs-all.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-all.yml
@@ -42,7 +42,7 @@ resources:
   repositories:
   - repository: VersionsRepo
     type: github
-    endpoint: public
+    endpoint: dotnet
     name: dotnet/versions
     ref: ${{ variables['gitHubVersionsRepoInfo.branch'] }}
 


### PR DESCRIPTION
Getting the following error when trying to run an internal build: `Repository VersionsRepo references endpoint public which does not exist or is not authorized for use`.

This is caused by the updates made in https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1471. The `versions` repo endpoint was not set correctly for this pipeline.