### PR TITLE
Fix scancode install by including pyicu build deps

### DIFF
--- a/src/azurelinux/3.0/net10.0/source-build-test/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/source-build-test/amd64/Dockerfile
@@ -1,12 +1,24 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0-preview-azurelinux3.0-amd64 AS installer
 
-# Install scancode
+# Install dependencies for building pyicu wheel from source (dependency of scancode-toolkit)
+RUN tdnf update -y \
+    && tdnf install -y \
+        binutils \
+        gcc-c++ \
+        glibc-devel \
+        icu-devel \
+        kernel-headers \
+        python3-devel \
+    && tdnf clean all
+
+# Include scancode
 # Install instructions: https://scancode-toolkit.readthedocs.io/en/latest/getting-started/install.html#installation-as-a-library-via-pip
 # See latest release at https://github.com/nexB/scancode-toolkit/releases
 RUN SCANCODE_VERSION="32.4.0" \
     && python3 -m venv /venv \
     && source /venv/bin/activate \
     && pip install scancode-toolkit==$SCANCODE_VERSION
+
 
 FROM mcr.microsoft.com/dotnet/sdk:10.0-preview-azurelinux3.0-amd64
 


### PR DESCRIPTION
When attempting to install scancode, the following error occurs:

```
#6 10.88 Collecting pyicu>=2.10.0 (from normality<4.0.0,>=3.0.1->fingerprints>=0.6.0->scancode-toolkit==32.4.0)
#6 10.89   Downloading pyicu-2.15.2.tar.gz (267 kB)
#6 10.96   Installing build dependencies: started
#6 12.93   Installing build dependencies: finished with status 'done'
#6 12.93   Getting requirements to build wheel: started
#6 13.12   Getting requirements to build wheel: finished with status 'error'
#6 13.13   error: subprocess-exited-with-error
#6 13.13   
#6 13.13   × Getting requirements to build wheel did not run successfully.
#6 13.13   │ exit code: 1
#6 13.13   ╰─> [64 lines of output]
#6 13.13       ### icu-config: Can't find /usr/lib/libicuuc.so - ICU prefix is wrong.
#6 13.13       ###      Try the --prefix= option
#6 13.13       ###      or --detect-prefix
#6 13.13       ###      (If you want to disable this check, use  the --noverify option)
#6 13.13       ### icu-config: Exitting.
#6 13.13       (running 'icu-config --version')
#6 13.13       (running 'pkg-config --modversion icu-i18n')
#6 13.13       Traceback (most recent call last):
#6 13.13         File "<string>", line 89, in <module>
#6 13.13         File "<frozen os>", line 714, in __getitem__
#6 13.13       KeyError: 'ICU_VERSION'
#6 13.13       
#6 13.13       During handling of the above exception, another exception occurred:
#6 13.13       
#6 13.13       Traceback (most recent call last):
#6 13.13         File "<string>", line 92, in <module>
#6 13.13         File "<string>", line 19, in check_output
#6 13.13         File "/usr/lib/python3.12/subprocess.py", line 468, in check_output
#6 13.13           return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
#6 13.13                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#6 13.13         File "/usr/lib/python3.12/subprocess.py", line 573, in run
#6 13.13           raise CalledProcessError(retcode, process.args,
#6 13.13       subprocess.CalledProcessError: Command '('icu-config', '--version')' returned non-zero exit status 2.
```

A change occurred in scancode's dependency graph that now prevents prebuilt binaries for `pyicu` from being available for Azure Linux. This triggers logic that attempts to build `pyicu` from source. But the necessary build dependencies are not installed, leading to the error.

This is resolved by installing the necessary build dependencies.