### PR TITLE
Reference secrets variable template from build pipeline

### DIFF
--- a/eng/pipelines/dotnet-buildtools-prereqs-all.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-all.yml
@@ -35,6 +35,7 @@ variables:
   parameters: 
     disableMatrixTrimming: ${{ parameters.disableMatrixTrimming }}
     sourceBuildPipelineRunId: ${{ parameters.sourceBuildPipelineRunId }}
+- template: /eng/common/templates/variables/dotnet/secrets.yml@self
 - name: publishEolAnnotations
   value: true
 


### PR DESCRIPTION
This change was missed in https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1480. There was a breaking change to the templates introduced in https://github.com/dotnet/docker-tools/pull/1759.