### PR TITLE
Fix the vulnerability 7-Zip Denial of Service (DoS)

### DIFF
--- a/src/windowsservercore/ltsc2022/helix/webassembly-net8/amd64/Dockerfile
+++ b/src/windowsservercore/ltsc2022/helix/webassembly-net8/amd64/Dockerfile
@@ -3,7 +3,7 @@
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:windowsservercore-ltsc2022-helix-amd64
 
 # Install 7zip
-ENV ZIP7_VERSION=2409
+ENV ZIP7_VERSION=2501
 
 RUN curl -SL --output %TEMP%\7zip-x64.exe https://www.7-zip.org/a/7z%ZIP7_VERSION%-x64.exe `
     && mkdir C:\7z `

--- a/src/windowsservercore/ltsc2022/helix/webassembly/amd64/Dockerfile
+++ b/src/windowsservercore/ltsc2022/helix/webassembly/amd64/Dockerfile
@@ -3,7 +3,7 @@
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:windowsservercore-ltsc2022-helix-amd64
 
 # Install 7zip
-ENV ZIP7_VERSION=2409
+ENV ZIP7_VERSION=2501
 
 RUN curl -SL --output %TEMP%\7zip-x64.exe https://www.7-zip.org/a/7z%ZIP7_VERSION%-x64.exe `
     && mkdir C:\7z `


### PR DESCRIPTION
Update 7-Zip version in below Docker file:
https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/66743bc7ae672e5739b28b64fd322bc9583bfbe3/src/windowsservercore/ltsc2022/helix/webassembly/amd64/Dockerfile#L6
https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/66743bc7ae672e5739b28b64fd322bc9583bfbe3/src/windowsservercore/ltsc2022/helix/webassembly-net8/amd64/Dockerfile#L6

2409->2501