### PR TITLE
Remove ref to locale.alias

### DIFF
--- a/src/ubuntu/25.10/helix/Dockerfile
+++ b/src/ubuntu/25.10/helix/Dockerfile
@@ -66,7 +66,7 @@ RUN LIBCURL=libcurl4 \
         libnuma1 \
         libxdp1 \
     && rm -rf /var/lib/apt/lists/* \
-    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+    && localedef -i en_US -c -f UTF-8 en_US.UTF-8
 
 ENV LANG=en_US.utf8
 


### PR DESCRIPTION
Build of https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/main/src/ubuntu/25.10/helix/Dockerfile is failing with this error:

```
199.3 locale alias file `/usr/share/locale/locale.alias' not found: No such file or directory
```

This is due to this line: https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/12ba03595bd741194c1188ca7a965f41e00652ef/src/ubuntu/25.10/helix/Dockerfile#L69

It references the path `/usr/share/locale/locale.alias` which doesn't exist.

This is due to the breaking change of upgrading to `locales:2.42` which includes a [change that removes the `locale.alias` file](https://lists.debian.org/debian-glibc/2025/08/msg00024.html). 