### PR TITLE
Add packages required by AzureCLI AzDO task

### DIFF
--- a/src/azurelinux/3.0/net8.0/fpm/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/fpm/amd64/Dockerfile
@@ -14,5 +14,8 @@ RUN tdnf install -y \
         util-linux \
         # Provides sudo
         sudo \
+        # Provides functionality for AzureCLI AzDO task
+        azure-cli \
+        powershell \
     && tdnf clean all \
     && gem install fpm

--- a/src/azurelinux/3.0/net9.0/fpm/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/fpm/amd64/Dockerfile
@@ -14,5 +14,8 @@ RUN tdnf install -y \
         util-linux \
         # Provides sudo
         sudo \
+        # Provides functionality for AzureCLI AzDO task
+        azure-cli \
+        powershell \
     && tdnf clean all \
     && gem install fpm


### PR DESCRIPTION
https://github.com/dotnet/sdk/pull/49942 is blocked by this work. (Installer's 8.0 branches need similar change to move them off of CBL-Mariner 2.0 based images.)

SDK build of RPMs utilizes the following step:
https://github.com/dotnet/installer/blob/release/8.0.1xx/eng/common/templates/steps/get-delegation-sas.yml

It requires: `azure-cli` and `powershell` packages.

Same change was made for cbl-mariner 2.0 image with https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1111
