### PR TITLE
Switch to non-preview tags for 10.0

### DIFF
--- a/src/azurelinux/3.0/net10.0/build/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/build/amd64/Dockerfile
@@ -1,5 +1,4 @@
-# This should be switched to 10.0 stable and then non-preview
-FROM mcr.microsoft.com/dotnet/runtime-deps:10.0-preview-azurelinux3.0
+FROM mcr.microsoft.com/dotnet/runtime-deps:10.0-azurelinux3.0
 
 RUN tdnf install -y \
         awk \

--- a/src/azurelinux/3.0/net10.0/source-build-test/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/source-build-test/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:10.0-preview-azurelinux3.0-amd64 AS installer
+FROM mcr.microsoft.com/dotnet/sdk:10.0-azurelinux3.0-amd64 AS installer
 
 # Install dependencies for building pyicu wheel from source (dependency of scancode-toolkit)
 RUN tdnf update -y \
@@ -20,7 +20,7 @@ RUN SCANCODE_VERSION="32.4.0" \
     && pip install scancode-toolkit==$SCANCODE_VERSION
 
 
-FROM mcr.microsoft.com/dotnet/sdk:10.0-preview-azurelinux3.0-amd64
+FROM mcr.microsoft.com/dotnet/sdk:10.0-azurelinux3.0-amd64
 
 COPY --from=installer /venv /venv
 


### PR DESCRIPTION
Now that 10.0 RC 1 is released, we can switch to the non-preview tags.