### PR TITLE
Override notifications repo

### DIFF
--- a/eng/pipelines/variables/common.yml
+++ b/eng/pipelines/variables/common.yml
@@ -36,3 +36,5 @@ variables:
 - ${{ if not(parameters.disableMatrixTrimming) }}:
   - name: trimCachedImagesForMatrix
     value: true
+- name: gitHubNotificationsRepoInfo.repo
+  value: dotnet-buildtools-prereqs-docker-internal


### PR DESCRIPTION
This overrides the notifications that are published by this repo so that they get created in the `dotnet-buildtools-prereqs-docker-internal` repo instead of the default repo of `dotnet-docker-internal`.