### PR TITLE
Exclude tests directory from CodeQL

### DIFF
--- a/eng/pipelines/dotnet-buildtools-prereqs-all.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-all.yml
@@ -38,6 +38,8 @@ variables:
 - template: /eng/common/templates/variables/dotnet/secrets.yml@self
 - name: publishEolAnnotations
   value: true
+- name: Codeql.ExcludePathPatterns
+  value: tests
 
 resources:
   repositories:


### PR DESCRIPTION
The following CodeQL warnings show up in the pipeline for this repo:

```
##[warning]No source code was built for csharp
##[warning]Creating the database failed for at least one language.
##[warning]Database failed to finalize or no source code was built!
```

This also shows up in the S360 report.

This is because C# code exists in the `tests` directory but is never built in the pipeline (it's only used in the [GitHub workflow](https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/main/.github/workflows/run-tests.yml)).

We need to exclude this directory from CodeQL scanning to prevent this.