### PR TITLE
Pin click package version for scancode installation

### DIFF
--- a/src/azurelinux/3.0/net10.0/source-build-test/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/source-build-test/amd64/Dockerfile
@@ -17,7 +17,8 @@ RUN tdnf update -y \
 RUN SCANCODE_VERSION="32.4.1" \
     && python3 -m venv /venv \
     && source /venv/bin/activate \
-    && pip install scancode-toolkit==$SCANCODE_VERSION
+    && pip install scancode-toolkit==$SCANCODE_VERSION \
+    && pip install click==8.2.2
 
 
 FROM mcr.microsoft.com/dotnet/sdk:10.0-azurelinux3.0-amd64


### PR DESCRIPTION
Contributes to https://github.com/dotnet/source-build/issues/5346

Works around the incompatibility issue of scancode and click by pinning the offending `click` package version.