### PR TITLE
Port scancode version bump to net11 image

### DIFF
--- a/src/azurelinux/3.0/net11.0/source-build-test/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net11.0/source-build-test/amd64/Dockerfile
@@ -14,10 +14,11 @@ RUN tdnf update -y \
 # Include scancode
 # Install instructions: https://scancode-toolkit.readthedocs.io/en/latest/getting-started/install.html#installation-as-a-library-via-pip
 # See latest release at https://github.com/nexB/scancode-toolkit/releases
-RUN SCANCODE_VERSION="32.4.0" \
+RUN SCANCODE_VERSION="32.4.1" \
     && python3 -m venv /venv \
     && source /venv/bin/activate \
-    && pip install scancode-toolkit==$SCANCODE_VERSION
+    && pip install scancode-toolkit==$SCANCODE_VERSION \
+    && pip install click==8.2.2
 
 
 FROM mcr.microsoft.com/dotnet/sdk:10.0-preview-azurelinux3.0-amd64


### PR DESCRIPTION
Ports https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1503 and https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1510

These got done after the net11 PR was opened.