### PR TITLE
Set security protocol for python download

### DIFF
--- a/src/nanoserver/1809/helix/amd64/Dockerfile
+++ b/src/nanoserver/1809/helix/amd64/Dockerfile
@@ -23,6 +23,7 @@ RUN setx /M VIRTUAL_ENV "C:\Python-env" && `
 
 # Install latest stable version of Python
 RUN pwsh -Command " `
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
         $apiUrl = 'https://api.nuget.org/v3-flatcontainer/python/index.json'; `
         $response = Invoke-RestMethod -Uri $apiUrl; `
         $versions = $response.versions | Where-Object { $_ -notmatch '-' } | Sort-Object { [version]$_ } -Descending; `

--- a/src/windowsservercore/ltsc2019/helix/amd64/Dockerfile
+++ b/src/windowsservercore/ltsc2019/helix/amd64/Dockerfile
@@ -7,6 +7,7 @@ RUN setx /M VIRTUAL_ENV "C:\Python-env" && `
 
 # Install latest stable version of Python
 RUN powershell -Command " `
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
         $apiUrl = 'https://api.nuget.org/v3-flatcontainer/python/index.json'; `
         $response = Invoke-RestMethod -Uri $apiUrl; `
         $versions = $response.versions | Where-Object { $_ -notmatch '-' } | Sort-Object { [version]$_ } -Descending; `

--- a/src/windowsservercore/ltsc2022/helix/amd64/Dockerfile
+++ b/src/windowsservercore/ltsc2022/helix/amd64/Dockerfile
@@ -7,6 +7,7 @@ RUN setx /M VIRTUAL_ENV "C:\Python-env" && `
 
 # Install latest stable version of Python
 RUN powershell -Command " `
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
         $apiUrl = 'https://api.nuget.org/v3-flatcontainer/python/index.json'; `
         $response = Invoke-RestMethod -Uri $apiUrl; `
         $versions = $response.versions | Where-Object { $_ -notmatch '-' } | Sort-Object { [version]$_ } -Descending; `

--- a/src/windowsservercore/ltsc2025/helix/amd64/Dockerfile
+++ b/src/windowsservercore/ltsc2025/helix/amd64/Dockerfile
@@ -7,6 +7,7 @@ RUN setx /M VIRTUAL_ENV "C:\Python-env" && `
 
 # Install latest stable version of Python
 RUN powershell -Command " `
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
         $apiUrl = 'https://api.nuget.org/v3-flatcontainer/python/index.json'; `
         $response = Invoke-RestMethod -Uri $apiUrl; `
         $versions = $response.versions | Where-Object { $_ -notmatch '-' } | Sort-Object { [version]$_ } -Descending; `


### PR DESCRIPTION
Windows builds are failing with the following error when attempting to connect to `api.nuget.org`:

`Invoke-RestMethod: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.`

This is fixed by explicitly setting the TLS version.