### PR TITLE
Update tag for azurelinux 3.0 SB image to net9.0

### DIFF
--- a/src/azurelinux/manifest.json
+++ b/src/azurelinux/manifest.json
@@ -1370,7 +1370,7 @@
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
-                "azurelinux-3.0-9.0-source-build-test-amd64": {}
+                "azurelinux-3.0-net9.0-source-build-test-amd64": {}
               },
               "buildArgs": {
                 "DOTNET_VERSION": "9.0"


### PR DESCRIPTION
This was a mistake made in https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1508