### PR TITLE
Remove preview from runtime-deps tag

### DIFF
--- a/src/azurelinux/3.0/net11.0/build/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net11.0/build/amd64/Dockerfile
@@ -1,5 +1,4 @@
-# This should be switched to 10.0 stable and then non-preview
-FROM mcr.microsoft.com/dotnet/runtime-deps:10.0-preview-azurelinux3.0
+FROM mcr.microsoft.com/dotnet/runtime-deps:10.0-azurelinux3.0
 
 RUN tdnf install -y \
         awk \


### PR DESCRIPTION
The `preview` tags are no longer in support since RCs became available.