### PR TITLE
Install az CLI for source build

### DIFF
--- a/src/almalinux/8/source-build/amd64/Dockerfile
+++ b/src/almalinux/8/source-build/amd64/Dockerfile
@@ -7,10 +7,12 @@ RUN dnf upgrade --refresh -y \
         epel-release \
     && dnf config-manager --set-enabled powertools \
     && dnf config-manager --set-enabled epel \
+    && dnf config-manager --add-repo=https://packages.microsoft.com/rhel/8/prod/config.repo \
     && dnf install --setopt tsflags=nodocs -y \
         "perl(Time::HiRes)" \
         autoconf \
         automake \
+        azure-cli \
         brotli-devel \
         cmake \
         cpio \

--- a/src/centos-stream/10/amd64/Dockerfile
+++ b/src/centos-stream/10/amd64/Dockerfile
@@ -11,6 +11,7 @@ RUN dnf upgrade --refresh -y \
         "perl(Time::HiRes)" \
         autoconf \
         automake \
+        azure-cli \
         brotli-devel \
         clang \
         cmake \

--- a/src/ubuntu/24.04/Dockerfile
+++ b/src/ubuntu/24.04/Dockerfile
@@ -30,6 +30,23 @@ RUN apt-get update \
 # .NET SDK MSBuild requires US.UTF-8 locale to execute tasks
 RUN locale-gen en_US.UTF-8
 
+# Install Azure CLI - https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt#option-2-step-by-step-installation-instructions
+# We cannot use the helper script to install the CLI with one command as the script
+# gets an amd64-only DEB package while this image needs to support both amd64 and arm64.
+RUN apt-get update \
+    && apt-get install -y \
+        apt-transport-https \
+        ca-certificates \
+        lsb-release \
+        gnupg \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -sLS https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/keyrings/microsoft.gpg > /dev/null \ 
+    && chmod go+r /etc/apt/keyrings/microsoft.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/azure-cli.list \
+    && apt-get update \
+    && apt-get install -y azure-cli \
+    && rm -rf /var/lib/apt/lists/*
+
 # Runtime dependencies
 RUN apt-get update \
     && apt-get install -y \


### PR DESCRIPTION
In order to support https://github.com/dotnet/source-build/issues/5342, it's necessary to dynamically generate a SAS token for which there is an Arcade pipeline step for this. But it requires that `az` CLI exist. There are a few images that source build relies upon which do not have that installed.