### PR TITLE
Disable OpenSUSE Dockerfile from being built

### DIFF
--- a/src/opensuse/manifest.json
+++ b/src/opensuse/manifest.json
@@ -5,15 +5,6 @@
       "images": [
         {
           "platforms": [
-            {
-              "architecture": "amd64",
-              "dockerfile": "src/opensuse/15.6/helix/amd64",
-              "os": "linux",
-              "osVersion": "leap15.6",
-              "tags": {
-                "opensuse-15.6-helix-amd64": {}
-              }
-            }
           ]
         }
       ]


### PR DESCRIPTION
Related to https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/1529

Because the build of this Dockerfile isn't working, I'm disabling it from being built. We can re-enable it once the underlying issue is fixed.