### PR TITLE
Azurelinux 3.0 .NET 11.0 source-build-test image

### DIFF
--- a/src/azurelinux/3.0/net11.0/source-build-test/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net11.0/source-build-test/amd64/Dockerfile
@@ -1,0 +1,39 @@
+ARG DOTNET_VERSION
+FROM mcr.microsoft.com/dotnet/nightly/sdk:$DOTNET_VERSION-azurelinux3.0-amd64 AS installer
+
+# Install dependencies for building pyicu wheel from source (dependency of scancode-toolkit)
+RUN tdnf update -y \
+    && tdnf install -y \
+        binutils \
+        gcc-c++ \
+        glibc-devel \
+        icu-devel \
+        kernel-headers \
+        python3-devel \
+    && tdnf clean all
+
+# Include scancode
+# Install instructions: https://scancode-toolkit.readthedocs.io/en/latest/getting-started/install.html#installation-as-a-library-via-pip
+# See latest release at https://github.com/nexB/scancode-toolkit/releases
+RUN SCANCODE_VERSION="32.4.1" \
+    && python3 -m venv /venv \
+    && source /venv/bin/activate \
+    && pip install scancode-toolkit==$SCANCODE_VERSION \
+    && pip install click==8.2.2
+
+
+FROM mcr.microsoft.com/dotnet/nightly/sdk:$DOTNET_VERSION-azurelinux3.0-amd64
+
+COPY --from=installer /venv /venv
+
+# Install necessary dependencies
+RUN tdnf update -y \
+    && tdnf install -y \
+        libgomp \
+        shadow-utils \
+        util-linux \
+    && tdnf clean all
+
+# Setup a script which executes scancode in the virtual environment
+COPY ./run-scancode.sh /usr/local/bin/scancode
+RUN chmod +x /usr/local/bin/scancode

--- a/src/azurelinux/3.0/net11.0/source-build-test/amd64/run-scancode.sh
+++ b/src/azurelinux/3.0/net11.0/source-build-test/amd64/run-scancode.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+source /venv/bin/activate
+scancode "$@"
+deactivate

--- a/src/azurelinux/manifest.json
+++ b/src/azurelinux/manifest.json
@@ -1402,15 +1402,14 @@
           "platforms": [
             {
               "architecture": "amd64",
-              "dockerfile": "src/azurelinux/3.0/net8.0/source-build-test/amd64",
+              "dockerfile": "src/azurelinux/3.0/net11.0/source-build-test/amd64",
               "os": "linux",
               "osVersion": "azurelinux3.0",
               "tags": {
                 "azurelinux-3.0-net11.0-source-build-test-amd64": {}
               },
               "buildArgs": {
-                // TODO: Update to 11 once images are available
-                "DOTNET_VERSION": "10.0"
+                "DOTNET_VERSION": "11.0-preview"
               }
             }
           ]


### PR DESCRIPTION
Fixes: https://github.com/dotnet/dotnet/issues/4177

Updates `azurelinux/3.0/net11.0/source-build-test/amd64` to use .NET 11 preview base image from `nightly` repo.

Will create a tracking issue to switch back to main repo after .NET 11 preview ships.