### PR TITLE
Downgrade SymCrypt-OpenSSL

### DIFF
--- a/src/azurelinux/3.0/helix/Dockerfile
+++ b/src/azurelinux/3.0/helix/Dockerfile
@@ -32,6 +32,7 @@ RUN tdnf install --setopt tsflags=nodocs --refresh -y \
         tar \
         tzdata \
         which \
+    && tdnf downgrade SymCrypt-OpenSSL-1.9.3 \
     && tdnf clean all
 
 # create helixbot user and give rights to sudo without password

--- a/src/azurelinux/3.0/helix/Dockerfile
+++ b/src/azurelinux/3.0/helix/Dockerfile
@@ -32,7 +32,7 @@ RUN tdnf install --setopt tsflags=nodocs --refresh -y \
         tar \
         tzdata \
         which \
-    && tdnf downgrade SymCrypt-OpenSSL-1.9.3 \
+    && tdnf downgrade -y SymCrypt-OpenSSL-1.9.3 \
     && tdnf clean all
 
 # create helixbot user and give rights to sudo without password


### PR DESCRIPTION
The latest SymCrypt-OpenSSL on AzureLinux 3 is broken.

https://github.com/dotnet/runtime/issues/123216