### PR TITLE
Update scancode to 32.5.0 for net11 Dockerfile

### DIFF
--- a/src/azurelinux/3.0/net11.0/source-build-test/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net11.0/source-build-test/amd64/Dockerfile
@@ -15,11 +15,10 @@ RUN tdnf update -y \
 # Include scancode
 # Install instructions: https://scancode-toolkit.readthedocs.io/en/latest/getting-started/install.html#installation-as-a-library-via-pip
 # See latest release at https://github.com/nexB/scancode-toolkit/releases
-RUN SCANCODE_VERSION="32.4.1" \
+RUN SCANCODE_VERSION="32.5.0" \
     && python3 -m venv /venv \
     && source /venv/bin/activate \
-    && pip install scancode-toolkit==$SCANCODE_VERSION \
-    && pip install click==8.2.2
+    && pip install scancode-toolkit==$SCANCODE_VERSION
 
 
 FROM mcr.microsoft.com/dotnet/nightly/sdk:$DOTNET_VERSION-azurelinux3.0-amd64

--- a/src/azurelinux/3.0/net8.0/source-build-test/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/source-build-test/amd64/Dockerfile
@@ -18,8 +18,7 @@ RUN tdnf update -y \
 RUN SCANCODE_VERSION="32.5.0" \
     && python3 -m venv /venv \
     && source /venv/bin/activate \
-    && pip install scancode-toolkit==$SCANCODE_VERSION \
-    && pip install click==8.2.2
+    && pip install scancode-toolkit==$SCANCODE_VERSION
 
 
 FROM mcr.microsoft.com/dotnet/sdk:$DOTNET_VERSION-azurelinux3.0-amd64


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/5467
Fixes https://github.com/dotnet/source-build/issues/5384

The net11.0 Dockerfile was never updated to 32.5.0. Fixing that here. Also, the updated version should have the fix that avoids the need to downgrade the `click` package.