### PR TITLE
Add ninja-build to ubuntu-22.04-crossdeps

### DIFF
--- a/src/ubuntu/22.04/crossdeps/amd64/Dockerfile
+++ b/src/ubuntu/22.04/crossdeps/amd64/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update \
         gdb \
         make \
         nasm \
+        ninja-build \
         pigz \
         qemu \
         qemu-user-static \


### PR DESCRIPTION
This adds ninja-build to the ubuntu-22.04-crossdeps Docker image.

   ## Why

   dotnet/runtime PR https://github.com/dotnet/runtime/pull/124041 is switching to ninja as the default build system on Linux and macOS. The linux-armel build fails with: Unable to locate ninja!

   ## What

   Adds ninja-build to the apt-get install list in src/ubuntu/22.04/crossdeps/amd64/Dockerfile.