### PR TITLE
Add powershell to renovate image to support more types of tooling for postUpgradeTasks

### DIFF
--- a/src/azurelinux/3.0/renovate/amd64/Dockerfile
+++ b/src/azurelinux/3.0/renovate/amd64/Dockerfile
@@ -8,6 +8,7 @@ RUN tdnf install -y \
         jq \
         nodejs24 \
         nodejs24-npm \
+        powershell \
         \
         # Requirements for Azure DevOps container jobs
         shadow-utils \


### PR DESCRIPTION
In order for [dotnet-docker](https://github.com/dotnet/dotnet-docker) to use arcade's [renovate](https://github.com/dotnet/arcade/blob/main/Documentation/Renovate.md) support, we need to regenerate Dockerfiles from templates using renovate's `postUpgradeTasks`. dotnet-docker's tooling relies on PowerShell, so this pull request adds it.