### PR TITLE
Don't install node through apt-get

### DIFF
--- a/src/ubuntu/22.04/amd64/Dockerfile
+++ b/src/ubuntu/22.04/amd64/Dockerfile
@@ -25,7 +25,6 @@ RUN mkdir -p /usr/lib/local/lib/python3.10/dist-packages/lldb \
 RUN apt-get update \
     && apt-get install -y \
         git \
-        npm \
         zip \
         curl \
     && rm -rf /var/lib/apt/lists/*
@@ -78,22 +77,15 @@ RUN apt-get update \
         file \
     && rm -rf /var/lib/apt/lists/*
 
-# Remove older version of node & install node 20
-RUN cd /etc/apt/sources.list.d  && \
+# Install Node 20 from NodeSource and use the patched npm ip module.
+RUN cd /etc/apt/sources.list.d && \
     rm -f nodesource.list && \
-    apt --fix-broken install && \
-    apt update && \
-    apt-get remove nodejs -y && \
-    apt-get remove nodejs-doc -y && \
-    apt-get remove libnode-dev -y
-
-RUN cd ~ && \
+    cd ~ && \
     curl -sL https://deb.nodesource.com/setup_20.x -o nodesource_setup.sh && \
     bash nodesource_setup.sh && \
     apt-get install nodejs -y && \
     rm -rf /var/lib/apt/lists/* && \
     rm -f nodesource_setup.sh && \
-    # npm installs a vulnerable node-ip pkg. Upgrading the node-ip pkg requires Ubuntu PRO subscription. Workaround by using NPM.
     npm install -g ip@latest
 
 ENV NO_UPDATE_NOTIFIER=true

--- a/src/ubuntu/22.04/coredeps/amd64/Dockerfile
+++ b/src/ubuntu/22.04/coredeps/amd64/Dockerfile
@@ -5,8 +5,6 @@ RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y \
         git \
-        nodejs \
-        npm \
         tar \
         zip \
     && curl -sL https://aka.ms/InstallAzureCLIDeb | bash \
@@ -33,3 +31,14 @@ RUN apt-get update \
         python3-pip \
         uuid-dev \
     && rm -rf /var/lib/apt/lists/*
+
+# Install Node 20 from NodeSource and use the patched npm ip module.
+RUN cd /etc/apt/sources.list.d && \
+    rm -f nodesource.list && \
+    cd ~ && \
+    curl -sL https://deb.nodesource.com/setup_20.x -o nodesource_setup.sh && \
+    bash nodesource_setup.sh && \
+    apt-get install nodejs -y && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -f nodesource_setup.sh && \
+    npm install -g ip@latest

--- a/src/ubuntu/24.04/Dockerfile
+++ b/src/ubuntu/24.04/Dockerfile
@@ -26,7 +26,6 @@ RUN apt-get update \
         curl \
         git \
         iproute2 \
-        npm \
         zip \
     && rm -rf /var/lib/apt/lists/*
 
@@ -79,14 +78,6 @@ RUN apt-get update \
         file \
     && rm -rf /var/lib/apt/lists/*
 
-# Remove older version of node & install node 20
-RUN rm -f /etc/apt/sources.list.d/nodesource.list && \
-    apt-get --fix-broken install && \
-    apt-get update && \
-    apt-get remove nodejs -y && \
-    apt-get remove nodejs-doc -y && \
-    apt-get remove libnode-dev -y
-
 # Install PowerShell
 RUN ARCH=$(dpkg --print-architecture) \
     && case "$ARCH" in \
@@ -101,11 +92,14 @@ RUN ARCH=$(dpkg --print-architecture) \
     && ln -s /opt/microsoft/powershell/pwsh /usr/bin/pwsh \
     && rm -f /tmp/powershell.tar.gz
 
-RUN cd ~ && \
+# Install node 20 and use its bundled npm so we don't pull in distro npm dependencies unnecessarily.
+RUN rm -f /etc/apt/sources.list.d/nodesource.list && \
+    cd ~ && \
     curl -sL https://deb.nodesource.com/setup_20.x -o nodesource_setup.sh && \
     bash nodesource_setup.sh && \
     apt-get install nodejs -y && \
     rm -rf /var/lib/apt/lists/* && \
-    rm -f nodesource_setup.sh
+    rm -f nodesource_setup.sh && \
+    npm install -g ip@latest
 
 ENV NO_UPDATE_NOTIFIER=true

--- a/src/ubuntu/26.04/Dockerfile
+++ b/src/ubuntu/26.04/Dockerfile
@@ -26,7 +26,6 @@ RUN apt-get update \
         curl \
         git \
         iproute2 \
-        npm \
         zip \
     && rm -rf /var/lib/apt/lists/*
 
@@ -80,14 +79,6 @@ RUN apt-get update \
         file \
     && rm -rf /var/lib/apt/lists/*
 
-# Remove older version of node & install node 20
-RUN rm -f /etc/apt/sources.list.d/nodesource.list && \
-    apt-get --fix-broken install && \
-    apt-get update && \
-    apt-get remove nodejs -y && \
-    apt-get remove nodejs-doc -y && \
-    apt-get remove libnode-dev -y
-
 # Install PowerShell
 RUN ARCH=$(dpkg --print-architecture) \
     && case "$ARCH" in \
@@ -102,11 +93,14 @@ RUN ARCH=$(dpkg --print-architecture) \
     && ln -s /opt/microsoft/powershell/pwsh /usr/bin/pwsh \
     && rm -f /tmp/powershell.tar.gz
 
-RUN cd ~ && \
+# Install node 20 and use its bundled npm so we don't pull in distro npm dependencies unnecessarily.
+RUN rm -f /etc/apt/sources.list.d/nodesource.list && \
+    cd ~ && \
     curl -sL https://deb.nodesource.com/setup_20.x -o nodesource_setup.sh && \
     bash nodesource_setup.sh && \
     apt-get install nodejs -y && \
     rm -rf /var/lib/apt/lists/* && \
-    rm -f nodesource_setup.sh
+    rm -f nodesource_setup.sh && \
+    npm install -g ip@latest
 
 ENV NO_UPDATE_NOTIFIER=true


### PR DESCRIPTION
https://github.com/dotnet/dotnet-buildtools-prereqs-docker-internal/issues/1186
we were installing node through apt-get, and even tho we were installing it manully afterwards, the old version was still on the image, getting flagged