### PR TITLE
Add nodejs24-npm to AZL build images

### DIFF
--- a/src/azurelinux/3.0/net10.0/build/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/build/amd64/Dockerfile
@@ -8,6 +8,7 @@ RUN tdnf install -y \
         curl \
         git \
         nodejs24 \
+        nodejs24-npm \
         powershell \
         # provides 'useradd', required by Azure DevOps
         shadow-utils \

--- a/src/azurelinux/3.0/net11.0/build/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net11.0/build/amd64/Dockerfile
@@ -8,6 +8,7 @@ RUN tdnf install -y \
         curl \
         git \
         nodejs24 \
+        nodejs24-npm \
         powershell \
         # provides 'useradd', required by Azure DevOps
         shadow-utils \


### PR DESCRIPTION
The -build images were missing the npm package compared to the -crossdeps images.