### PR TITLE
[AzL3] Remove SymCrypt downgrade

### DIFF
--- a/src/azurelinux/3.0/helix/Dockerfile
+++ b/src/azurelinux/3.0/helix/Dockerfile
@@ -32,7 +32,6 @@ RUN tdnf install --setopt tsflags=nodocs --refresh -y \
         tar \
         tzdata \
         which \
-    && tdnf downgrade -y SymCrypt-OpenSSL-1.9.3 \
     && tdnf clean all
 
 # create helixbot user and give rights to sudo without password


### PR DESCRIPTION
The fixed package 1.9.5 is out: https://packages.microsoft.com/azurelinux/3.0/prod/base/x86_64/Packages/s/
For a reference: https://github.com/dotnet/runtime/issues/123216