### PR TITLE
Move haiku image to Azure Linux

### DIFF
--- a/src/azurelinux/3.0/net11.0/cross/haiku/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net11.0/cross/haiku/amd64/Dockerfile
@@ -1,0 +1,11 @@
+ARG ROOTFS_DIR=/crossrootfs/x64
+
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-crossdeps-builder-amd64 AS builder
+ARG ROOTFS_DIR
+
+RUN /scripts/eng/common/cross/build-rootfs.sh haiku x64
+
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-crossdeps-llvm-amd64
+ARG ROOTFS_DIR
+
+COPY --from=builder "$ROOTFS_DIR" "$ROOTFS_DIR"

--- a/src/azurelinux/3.0/net11.0/crossdeps-builder/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net11.0/crossdeps-builder/amd64/Dockerfile
@@ -4,8 +4,10 @@ RUN tdnf install -y \
         # Common utilities
         ca-certificates \
         git \
+        jq \
         shadow-utils \
         tar \
+        unzip \
         wget \
         # LLVM build dependencies
         binutils \

--- a/src/azurelinux/manifest.json
+++ b/src/azurelinux/manifest.json
@@ -1212,6 +1212,18 @@
         {
           "platforms": [
             {
+              "dockerfile": "src/azurelinux/3.0/net11.0/cross/haiku/amd64",
+              "os": "linux",
+              "osVersion": "azurelinux3.0",
+              "tags": {
+                "azurelinux-3.0-net11.0-cross-haiku-amd64": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
               "dockerfile": "src/azurelinux/3.0/net11.0/cross/s390x",
               "os": "linux",
               "osVersion": "azurelinux3.0",


### PR DESCRIPTION
It was initially added to ubuntu https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/669 and later got cleaned up.