### PR TITLE
Add Azure Linux 4.0 helix test images

### DIFF
--- a/src/azurelinux/4.0/helix/Dockerfile
+++ b/src/azurelinux/4.0/helix/Dockerfile
@@ -1,6 +1,6 @@
 FROM azlpubstagingacroxz2o4gw.azurecr.io/azurelinux/base/core:4.0 AS venv
 
-RUN tdnf install --refresh -y \
+RUN dnf install --refresh -y \
     ca-certificates \
     iputils \
     python3 \
@@ -16,7 +16,7 @@ RUN python3 -m venv /venv && \
 FROM azlpubstagingacroxz2o4gw.azurecr.io/azurelinux/base/core:4.0
 
 # Install .NET and test dependencies
-RUN tdnf install --setopt tsflags=nodocs --refresh -y \
+RUN dnf install --setopt tsflags=nodocs --refresh -y \
         ca-certificates \
         icu \
         iputils \
@@ -29,7 +29,7 @@ RUN tdnf install --setopt tsflags=nodocs --refresh -y \
         tar \
         tzdata \
         which \
-    && tdnf clean all
+    && dnf clean all
 
 # create helixbot user and give rights to sudo without password
 RUN /usr/sbin/useradd -c '' --uid 1000 --shell /bin/bash --groups adm helixbot && \

--- a/src/azurelinux/4.0/helix/Dockerfile
+++ b/src/azurelinux/4.0/helix/Dockerfile
@@ -1,0 +1,46 @@
+FROM azlpubstagingacroxz2o4gw.azurecr.io/azurelinux/base/core:4.0 AS venv
+
+RUN tdnf install --refresh -y \
+    ca-certificates \
+    iputils \
+    python3 \
+    python3-devel \
+    python3-pip
+
+RUN python3 -m venv /venv && \
+        source /venv/bin/activate && \
+        pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+        pip install ./helix_scripts-*-py3-none-any.whl && \
+        rm ./helix_scripts-*-py3-none-any.whl
+
+FROM azlpubstagingacroxz2o4gw.azurecr.io/azurelinux/base/core:4.0
+
+# Install .NET and test dependencies
+RUN tdnf install --setopt tsflags=nodocs --refresh -y \
+        ca-certificates \
+        icu \
+        iputils \
+        libatomic \
+        llvm \
+        python3 \
+        python3-pip \
+        shadow-utils \
+        sudo \
+        tar \
+        tzdata \
+        which \
+    && tdnf clean all
+
+# create helixbot user and give rights to sudo without password
+RUN /usr/sbin/useradd -c '' --uid 1000 --shell /bin/bash --groups adm helixbot && \
+    chmod 755 /root && \
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot && \
+    mkdir -p /home/helixbot/ && chown -R helixbot /home/helixbot/
+
+USER helixbot
+
+# Install Helix Dependencies
+ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+COPY --from=venv --chown=helixbot /venv $VIRTUAL_ENV

--- a/src/azurelinux/manifest.json
+++ b/src/azurelinux/manifest.json
@@ -1313,6 +1313,33 @@
           "platforms": [
             {
               "architecture": "amd64",
+              "dockerfile": "src/azurelinux/4.0/helix",
+              "os": "linux",
+              "osVersion": "azurelinux4.0",
+              "tags": {
+                "azurelinux-4.0-helix-amd64": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "architecture": "arm64",
+              "dockerfile": "src/azurelinux/4.0/helix",
+              "os": "linux",
+              "osVersion": "azurelinux4.0",
+              "tags": {
+                "azurelinux-4.0-helix-arm64v8": {}
+              },
+              "variant": "v8"
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "architecture": "amd64",
               "dockerfile": "src/azurelinux/3.0/renovate/amd64",
               "os": "linux",
               "osVersion": "azurelinux3.0",


### PR DESCRIPTION
## Summary

Adds helix test images for Azure Linux 4.0 (amd64 and arm64v8) using the staging ACR base image (`azlpubstagingacroxz2o4gw.azurecr.io/azurelinux/base/core:4.0`).

## Changes

- **New Dockerfile:** `src/azurelinux/4.0/helix/Dockerfile`
- **Manifest entries:** Added `azurelinux-4.0-helix-amd64` and `azurelinux-4.0-helix-arm64v8` to `src/azurelinux/manifest.json`

## Package changes from Azure Linux 3.0

Azure Linux 4.0 is based on Fedora 44, which changes several package names:

| AzL 3.0 | AzL 4.0 | Reason |
|---|---|---|
| `build-essential` | removed | Not needed; helix-scripts is a pure Python wheel |
| `ca-certificates-microsoft` | `ca-certificates` | Package renamed |
| `libgcc-atomic` | `libatomic` | Package renamed |
| `libmsquic` | removed | Not available in AzL 4.0 repos |

Also changed `mkdir` → `mkdir -p` for the helixbot home directory since `useradd` in AzL 4.0 auto-creates it.

## Validation

- ✅ amd64 Docker build verified locally
- ✅ arm64 base image confirmed available; Dockerfile is arch-agnostic
- ✅ manifest.json validated as valid JSON