### PR TITLE
Reduce the scope of libbsd requirement

### DIFF
--- a/src/azurelinux/3.0/net11.0/cross/freebsd/14/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net11.0/cross/freebsd/14/amd64/Dockerfile
@@ -5,11 +5,32 @@ ARG ROOTFS_DIR
 
 # Install packages needed by the FreeBSD bootstrap scripts
 RUN tdnf install -y \
-    awk \
-    m4 && \
+        automake \
+        autoconf \
+        awk \
+        libtool \
+        m4 && \
     # The xz package in Azure Linux 3.0 doesn't provide liblzma.so, so we need to create a symlink to liblzma.so.5
     # so the FreeBSD bootstrap can find it. See https://github.com/microsoft/azurelinux/issues/9217
     ln -s /usr/lib/liblzma.so.5 /usr/lib/liblzma.so
+
+RUN wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x4F3E74F436050C10F5696574B972BF3EA4AE57A3" | \
+        gpg --batch --import && \
+    echo "4F3E74F436050C10F5696574B972BF3EA4AE57A3:6:" | gpg --import-ownertrust
+
+RUN cd /tmp && wget -O libmd-1.2.0.tar.xz "https://libbsd.freedesktop.org/releases/libmd-1.2.0.tar.xz" && \
+    wget -O libmd-1.2.0.tar.xz.asc "https://libbsd.freedesktop.org/releases/libmd-1.2.0.tar.xz.asc" && \
+    gpg --batch --verify libmd-1.2.0.tar.xz.asc libmd-1.2.0.tar.xz && \
+    mkdir libmd && tar -xJf libmd-1.2.0.tar.xz -C libmd --strip-components=1 && \
+    cd libmd && ./configure && make -j install
+
+RUN cd /tmp && wget -O libbsd-0.12.2.tar.xz "https://libbsd.freedesktop.org/releases/libbsd-0.12.2.tar.xz" && \
+    wget -O libbsd-0.12.2.tar.xz.asc "https://libbsd.freedesktop.org/releases/libbsd-0.12.2.tar.xz.asc" && \
+    gpg --batch --verify libbsd-0.12.2.tar.xz.asc libbsd-0.12.2.tar.xz && \
+    mkdir libbsd && tar -xJf libbsd-0.12.2.tar.xz -C libbsd --strip-components=1 && \
+    cd libbsd && ./configure && make -j install
+
+RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/usr-local.conf && ldconfig
 
 RUN /scripts/eng/common/cross/build-rootfs.sh freebsd14 x64
 

--- a/src/azurelinux/3.0/net11.0/cross/freebsd/14/arm64/Dockerfile
+++ b/src/azurelinux/3.0/net11.0/cross/freebsd/14/arm64/Dockerfile
@@ -5,11 +5,32 @@ ARG ROOTFS_DIR
 
 # Install packages needed by the FreeBSD bootstrap scripts
 RUN tdnf install -y \
+      automake \
+      autoconf \
       awk \
-      m4 \
+      libtool \
+      m4 && \
     # The xz package in Azure Linux 3.0 doesn't provide liblzma.so, so we need to create a symlink to liblzma.so.5
     # so the FreeBSD bootstrap can find it. See https://github.com/microsoft/azurelinux/issues/9217
-    && ln -s /usr/lib/liblzma.so.5 /usr/lib/liblzma.so
+    ln -s /usr/lib/liblzma.so.5 /usr/lib/liblzma.so
+
+RUN wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x4F3E74F436050C10F5696574B972BF3EA4AE57A3" | \
+        gpg --batch --import && \
+    echo "4F3E74F436050C10F5696574B972BF3EA4AE57A3:6:" | gpg --import-ownertrust
+
+RUN cd /tmp && wget -O libmd-1.2.0.tar.xz "https://libbsd.freedesktop.org/releases/libmd-1.2.0.tar.xz" && \
+    wget -O libmd-1.2.0.tar.xz.asc "https://libbsd.freedesktop.org/releases/libmd-1.2.0.tar.xz.asc" && \
+    gpg --batch --verify libmd-1.2.0.tar.xz.asc libmd-1.2.0.tar.xz && \
+    mkdir libmd && tar -xJf libmd-1.2.0.tar.xz -C libmd --strip-components=1 && \
+    cd libmd && ./configure && make -j install
+
+RUN cd /tmp && wget -O libbsd-0.12.2.tar.xz "https://libbsd.freedesktop.org/releases/libbsd-0.12.2.tar.xz" && \
+    wget -O libbsd-0.12.2.tar.xz.asc "https://libbsd.freedesktop.org/releases/libbsd-0.12.2.tar.xz.asc" && \
+    gpg --batch --verify libbsd-0.12.2.tar.xz.asc libbsd-0.12.2.tar.xz && \
+    mkdir libbsd && tar -xJf libbsd-0.12.2.tar.xz -C libbsd --strip-components=1 && \
+    cd libbsd && ./configure && make -j install
+
+RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/usr-local.conf && ldconfig
 
 RUN /scripts/eng/common/cross/build-rootfs.sh freebsd14 arm64
 

--- a/src/azurelinux/3.0/net11.0/crossdeps-builder/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net11.0/crossdeps-builder/amd64/Dockerfile
@@ -47,12 +47,6 @@ RUN python3 -m venv "$ROOTFS_PIP_HOME" && \
     "$ROOTFS_PIP_HOME/bin/python" -m pip install --disable-pip-version-check --no-cache-dir --only-binary=:all: --require-hashes --no-deps -r /tmp/rootfs-pip-requirements.txt && \
     rm /tmp/rootfs-pip-requirements.txt
 
-# dependencies which are installed from extended repo require additional setup
-RUN wget https://packages.microsoft.com/azurelinux/3.0/prod/extended/x86_64/config.repo -O /etc/yum.repos.d/azurelinux-extended.repo && \
-    tdnf makecache && \
-    tdnf install -y \
-        libbsd-devel
-
 # Obtain ubuntu package signing key (to obtain target arch .deb files)
 # 1. Add public key used to sign the ubuntu keyring
 COPY dimitri_john_ledkov.asc .


### PR DESCRIPTION
See #<span/>2 in https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/1646. Lets build libbsd and its dep libmd from source in images which actually require it.