### PR TITLE
Temporarily disable eol annotation generations

### DIFF
--- a/eng/pipelines/dotnet-buildtools-prereqs-official.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-official.yml
@@ -45,8 +45,10 @@ variables:
     disableMatrixTrimming: ${{ parameters.disableMatrixTrimming }}
     sourceBuildPipelineRunId: ${{ parameters.sourceBuildPipelineRunId }}
 - template: /eng/docker-tools/templates/variables/dotnet/secrets.yml@self
+# Temporarily disable EOL annotation generation due to
+# https://github.com/dotnet/docker-tools/issues/2066
 - name: publishEolAnnotations
-  value: true
+  value: false
 - name: Codeql.ExcludePathPatterns
   value: tests
   readonly: true

--- a/eng/pipelines/dotnet-buildtools-prereqs-official.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-official.yml
@@ -47,6 +47,7 @@ variables:
 - template: /eng/docker-tools/templates/variables/dotnet/secrets.yml@self
 # Temporarily disable EOL annotation generation due to
 # https://github.com/dotnet/docker-tools/issues/2066
+# as well as https://github.com/dotnet/docker-tools/issues/2056
 - name: publishEolAnnotations
   value: false
 - name: Codeql.ExcludePathPatterns

--- a/eng/pipelines/dotnet-buildtools-prereqs-unofficial.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-unofficial.yml
@@ -31,8 +31,10 @@ variables:
     disableMatrixTrimming: ${{ parameters.disableMatrixTrimming }}
     sourceBuildPipelineRunId: ${{ parameters.sourceBuildPipelineRunId }}
 - template: /eng/docker-tools/templates/variables/dotnet/secrets-unofficial.yml@self
+# Temporarily disable EOL annotation generation due to
+# https://github.com/dotnet/docker-tools/issues/2066
 - name: publishEolAnnotations
-  value: true
+  value: false
 
 resources:
   repositories:

--- a/eng/pipelines/dotnet-buildtools-prereqs-unofficial.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-unofficial.yml
@@ -33,6 +33,7 @@ variables:
 - template: /eng/docker-tools/templates/variables/dotnet/secrets-unofficial.yml@self
 # Temporarily disable EOL annotation generation due to
 # https://github.com/dotnet/docker-tools/issues/2066
+# as well as https://github.com/dotnet/docker-tools/issues/2056
 - name: publishEolAnnotations
   value: false
 


### PR DESCRIPTION
Disables EOL annotation generation that is failing in [latest runs](https://dev.azure.com/dnceng/internal/_build/results?buildId=2983977&view=results) of the build pipeline due to issues described in https://github.com/dotnet/docker-tools/issues/2066