### PR TITLE
Add binlog-mcp container image (azurelinux 3.0, amd64, distroless)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,6 +15,7 @@ src/alpine/**/amd64/ @dotnet/source-build @dotnet/dotnet-docker-reviewers
 
 # azurelinux
 src/azurelinux/**/android/ @dotnet/runtime-infrastructure @dotnet/dotnet-docker-reviewers
+src/azurelinux/**/binlog-mcp/ @JanKrivanek @YuliiaKovalova @dotnet/dotnet-docker-reviewers
 src/azurelinux/**/build/ @dotnet/aspnet-build @dotnet/dotnet-docker-reviewers
 src/azurelinux/**/docker-testrunner/ @dotnet/dotnet-docker-reviewers
 src/azurelinux/**/fpm/ @dotnet/runtime-infrastructure @dotnet/dotnet-docker-reviewers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,7 +15,7 @@ src/alpine/**/amd64/ @dotnet/source-build @dotnet/dotnet-docker-reviewers
 
 # azurelinux
 src/azurelinux/**/android/ @dotnet/runtime-infrastructure @dotnet/dotnet-docker-reviewers
-src/azurelinux/**/binlog-mcp/ @JanKrivanek @YuliiaKovalova @dotnet/dotnet-docker-reviewers
+src/azurelinux/**/binlog-mcp/ @dotnet/dnceng @dotnet/dotnet-docker-reviewers
 src/azurelinux/**/build/ @dotnet/aspnet-build @dotnet/dotnet-docker-reviewers
 src/azurelinux/**/docker-testrunner/ @dotnet/dotnet-docker-reviewers
 src/azurelinux/**/fpm/ @dotnet/runtime-infrastructure @dotnet/dotnet-docker-reviewers

--- a/eng/renovate.json
+++ b/eng/renovate.json
@@ -83,6 +83,19 @@
       "datasourceTemplate": "npm",
       "extractVersionTemplate": "^(?<version>\\d+)",
       "versioningTemplate": "loose"
+    },
+    {
+      "description": "Updates Microsoft.AITools.BinlogMcp tool version in binlog-mcp Dockerfiles",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "src/azurelinux/**/binlog-mcp/**/Dockerfile"
+      ],
+      "matchStrings": [
+        "ARG BINLOG_MCP_VERSION=(?<currentValue>\\S+)"
+      ],
+      "depNameTemplate": "Microsoft.AITools.BinlogMcp",
+      "datasourceTemplate": "nuget",
+      "registryUrlTemplate": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json"
     }
   ],
   "packageRules": [
@@ -108,6 +121,13 @@
         "**/net11.0/**"
       ],
       "enabled": true
+    },
+    {
+      "description": "Allow pre-release updates for Microsoft.AITools.BinlogMcp (only preview versions are currently published)",
+      "matchDepNames": [
+        "Microsoft.AITools.BinlogMcp"
+      ],
+      "ignoreUnstable": false
     }
   ],
   "postUpgradeTasks": {

--- a/src/azurelinux/3.0/binlog-mcp/amd64/Dockerfile
+++ b/src/azurelinux/3.0/binlog-mcp/amd64/Dockerfile
@@ -11,7 +11,9 @@ ARG DOTNET_TOOLS_FEED=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet
 
 # Stage 1: Use the .NET SDK to install the tool. The SDK is required because
 # `dotnet tool install` is not available in distroless runtime images.
-FROM mcr.microsoft.com/dotnet/sdk:10.0-azurelinux3.0 AS builder
+# Note: the SDK TFM must match the tool's `tools/netX.Y/` folder. The pinned
+# version above must be a net8.0-targeted build of Microsoft.AITools.BinlogMcp.
+FROM mcr.microsoft.com/dotnet/sdk:8.0-azurelinux3.0 AS builder
 
 ARG BINLOG_MCP_VERSION
 ARG DOTNET_TOOLS_FEED
@@ -24,7 +26,7 @@ RUN dotnet tool install \
 
 # Stage 2: Copy the installed tool into a distroless runtime image to minimise
 # attack surface (no shell, no package manager). Per maintainer guidance on #1659.
-FROM mcr.microsoft.com/dotnet/runtime:10.0-azurelinux3.0-distroless
+FROM mcr.microsoft.com/dotnet/runtime:8.0-azurelinux3.0-distroless
 
 COPY --from=builder /tools /tools
 

--- a/src/azurelinux/3.0/binlog-mcp/amd64/Dockerfile
+++ b/src/azurelinux/3.0/binlog-mcp/amd64/Dockerfile
@@ -1,0 +1,33 @@
+# Dockerfile for binlog-mcp: a Model Context Protocol (MCP) server that exposes
+# MSBuild binary log (binlog) inspection tools to AI agents. Intended for use by
+# the .NET engineering team's gh-aw agentic CI workflows (build-failure analysis,
+# binlog diagnosis). See: https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/1659
+#
+# Usage:  docker run --rm -i -v /path/to/binlogs:/binlogs \
+#             mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-binlog-mcp-amd64
+
+ARG BINLOG_MCP_VERSION=1.0.0-preview.26272.1
+ARG DOTNET_TOOLS_FEED=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
+
+# Stage 1: Use the .NET SDK to install the tool. The SDK is required because
+# `dotnet tool install` is not available in distroless runtime images.
+FROM mcr.microsoft.com/dotnet/sdk:10.0-azurelinux3.0 AS builder
+
+ARG BINLOG_MCP_VERSION
+ARG DOTNET_TOOLS_FEED
+
+RUN dotnet tool install \
+        --tool-path /tools \
+        Microsoft.AITools.BinlogMcp \
+        --version ${BINLOG_MCP_VERSION} \
+        --add-source ${DOTNET_TOOLS_FEED}
+
+# Stage 2: Copy the installed tool into a distroless runtime image to minimise
+# attack surface (no shell, no package manager). Per maintainer guidance on #1659.
+FROM mcr.microsoft.com/dotnet/runtime:10.0-azurelinux3.0-distroless
+
+COPY --from=builder /tools /tools
+
+ENV PATH="/tools:${PATH}"
+
+ENTRYPOINT ["binlog-mcp"]

--- a/src/azurelinux/3.0/binlog-mcp/amd64/Dockerfile
+++ b/src/azurelinux/3.0/binlog-mcp/amd64/Dockerfile
@@ -6,14 +6,14 @@
 # Usage:  docker run --rm -i -v /path/to/binlogs:/binlogs \
 #             mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-binlog-mcp-amd64
 
-ARG BINLOG_MCP_VERSION=1.0.0-preview.26272.1
+ARG BINLOG_MCP_VERSION=1.0.0-preview.26301.7
 ARG DOTNET_TOOLS_FEED=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
 
 # Stage 1: Use the .NET SDK to install the tool. The SDK is required because
 # `dotnet tool install` is not available in distroless runtime images.
-# Note: the SDK TFM must match the tool's `tools/netX.Y/` folder. The pinned
-# version above must be a net8.0-targeted build of Microsoft.AITools.BinlogMcp.
-FROM mcr.microsoft.com/dotnet/sdk:8.0-azurelinux3.0 AS builder
+# The SDK TFM must match the tool's `tools/netX.Y/` folder — the published
+# Microsoft.AITools.BinlogMcp package targets net10.0.
+FROM mcr.microsoft.com/dotnet/sdk:10.0-azurelinux3.0 AS builder
 
 ARG BINLOG_MCP_VERSION
 ARG DOTNET_TOOLS_FEED
@@ -26,7 +26,7 @@ RUN dotnet tool install \
 
 # Stage 2: Copy the installed tool into a distroless runtime image to minimise
 # attack surface (no shell, no package manager). Per maintainer guidance on #1659.
-FROM mcr.microsoft.com/dotnet/runtime:8.0-azurelinux3.0-distroless
+FROM mcr.microsoft.com/dotnet/runtime:10.0-azurelinux3.0-distroless
 
 COPY --from=builder /tools /tools
 

--- a/src/azurelinux/manifest.json
+++ b/src/azurelinux/manifest.json
@@ -7,6 +7,18 @@
       "name": "dotnet-buildtools/prereqs",
       "images": [
         {
+          "platforms": [
+            {
+              "dockerfile": "src/azurelinux/3.0/binlog-mcp/amd64",
+              "os": "linux",
+              "osVersion": "azurelinux3.0",
+              "tags": {
+                "azurelinux-3.0-binlog-mcp-amd64": {}
+              }
+            }
+          ]
+        },
+        {
           "sharedTags": {
             "azurelinux3.0-docker-testrunner": {}
           },


### PR DESCRIPTION
> **Draft** — opening early for visibility per @mthalman's "self-service" guidance in dotnet/dotnet-buildtools-prereqs-docker#1659. Please review the shape; happy to iterate on base image / tag pattern / arch before marking ready.

Closes #1659 (once merged).

## What

Adds a new container image `mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-binlog-mcp-amd64` that packages the [`Microsoft.AITools.BinlogMcp`](https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-tools/NuGet/Microsoft.AITools.BinlogMcp) .NET tool — an MCP server exposing ~29 binlog inspection tools (overview, errors, warnings, diagnose, search, task-details, …).

## Why

Consumed by the gh-aw MCP Gateway in .NET team agentic CI workflows (`microsoft/testfx`, `dotnet/msbuild`, `dotnet/sdk`, `dotnet/dotnet`) for build-failure analysis. The Gateway Specification v1.0.0 §3.2.1 requires stdio MCP servers to be containerized — `command:` execution is rejected at runtime, so a container image is the only viable distribution shape for this consumer.

Replaces a brittle `DumpBinlog/` JSON-shim workaround currently copy-pasted across consumer repos.

## Design choices (per #1659 review)

| Decision | Rationale (Matt Thalman, [#1659 comment](https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/1659#issuecomment-4574877102)) |
|---|---|
| **Multi-stage Dockerfile** | `dotnet tool install` requires the SDK, which distroless does not have. SDK stage installs into `/tools`; distroless stage copies the result. |
| **Distroless runtime base** (`runtime:10.0-azurelinux3.0-distroless`) | Smaller attack surface; explicitly recommended. |
| **.NET 10 base** | `Microsoft.AITools.BinlogMcp` targets `net10.0` (verified from package's `DotnetToolSettings.xml`). |
| **amd64 only** | Initial consumers are GitHub-hosted Linux CI runners. `arm64v8` can be added later if dev-machine use materialises. |
| **`ARG BINLOG_MCP_VERSION`** | Tool version is parameterised so the image tag can roll forward without Dockerfile edits. Default pinned to current latest preview (`1.0.0-preview.26272.1`). |

## Licensing

`Microsoft.AITools.BinlogMcp` is a Microsoft-owned tool published under standard Microsoft proprietary terms via the public `dnceng-public/dotnet-tools` Azure DevOps NuGet feed (anonymous read). Already validated as a public consumer artifact by [dotnet/arcade-skills#37](https://github.com/dotnet/arcade-skills/pull/37) and [#38](https://github.com/dotnet/arcade-skills/pull/38) (both merged).

## Test plan

- [ ] Local: `docker build -t binlog-mcp src/azurelinux/3.0/binlog-mcp/amd64/`
- [ ] Local: `docker run --rm -i binlog-mcp` responds to MCP `initialize` JSON-RPC over stdio
- [ ] CI: image build via repo's existing build pipeline
- [ ] Consumer smoke test: wire image into one gh-aw workflow (likely `microsoft/testfx`) and verify gateway can launch it

## Open questions for reviewers

1. Is `binlog-mcp` (no .NET version suffix in the tag) the right naming, or should it be e.g. `binlog-mcp-10.0` to match how net8/9/10 variants are tagged elsewhere in this repo?
2. Should the entry live in `images:` block as I've placed it, or be grouped differently (it's not tied to a specific .NET build flavour like the `crossdeps`/`helix` entries)?

CC: @mthalman @richlander @JanKrivanek
