### PR TITLE
Bump Microsoft.AITools.BinlogMcp to 1.0.0-preview.26303.12

### DIFF
--- a/src/azurelinux/3.0/binlog-mcp/amd64/Dockerfile
+++ b/src/azurelinux/3.0/binlog-mcp/amd64/Dockerfile
@@ -6,7 +6,7 @@
 # Usage:  docker run --rm -i -v /path/to/binlogs:/binlogs \
 #             mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-binlog-mcp-amd64
 
-ARG BINLOG_MCP_VERSION=1.0.0-preview.26301.7
+ARG BINLOG_MCP_VERSION=1.0.0-preview.26303.12
 ARG DOTNET_TOOLS_FEED=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
 
 # Stage 1: Use the .NET SDK to install the tool. The SDK is required because


### PR DESCRIPTION
Bumps the `Microsoft.AITools.BinlogMcp` tool version in the binlog-mcp Dockerfile from `1.0.0-preview.26301.7` (the version that landed with #1660) to the newest available preview on the [dnceng-public/dotnet-tools feed](https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json).

### Why a manual bump
The currently published MCR image (`mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-binlog-mcp-amd64`, built 2026-06-02) still embeds `26301.7`. Five newer previews have shipped since:

```
26301.7  ← currently in image
26302.3
26303.2
26303.6
26303.8
26303.9
26303.12 ← this PR
```

Renovate (configured in #1660 via `eng/renovate.json`) will eventually open an equivalent PR on its next scheduled scan, but this manual bump:

1. Smoke-tests the end-to-end publish flow against a real version change
2. Gets the latest fixes into the MCR image for downstream consumers (gh-aw MCP Gateway in `microsoft/testfx`) sooner

### Diff
One line change in `src/azurelinux/3.0/binlog-mcp/amd64/Dockerfile`:

```diff
- ARG BINLOG_MCP_VERSION=1.0.0-preview.26301.7
+ ARG BINLOG_MCP_VERSION=1.0.0-preview.26303.12
```

Renovate's later PR (if any open versions are newer at that point) will be additive and harmless.