### PR TITLE
Add Alpine 3.24 prereq images

### DIFF
--- a/src/alpine/3.24/amd64/Dockerfile
+++ b/src/alpine/3.24/amd64/Dockerfile
@@ -1,0 +1,80 @@
+FROM amd64/alpine:3.24
+
+ENV POWERSHELL_VERSION=7.6.1
+
+RUN apk add --upgrade --no-cache \
+        # Install .NET and test dependencies
+        autoconf \
+        automake \
+        bash \
+        build-base \
+        brotli-dev \
+        ca-certificates \
+        clang \
+        clang-dev \
+        cmake \
+        coreutils \
+        cpio \
+        curl \
+        elfutils \
+        file \
+        gcc \
+        gettext-dev \
+        git \
+        icu-data-full \
+        icu-dev \
+        icu-libs \
+        iproute2 \
+        jq \
+        krb5-dev \
+        less \
+        libgcc \
+        libintl \
+        libssl3 \
+        libstdc++ \
+        libtool \
+        libunwind-dev \
+        linux-headers \
+        lld \
+        lldb-dev \
+        llvm \
+        lttng-ust-dev \
+        ncurses-terminfo-base \
+        make \
+        ninja \
+        openssl \
+        openssl-dev \
+        paxctl \
+        pigz \
+        py3-lldb \
+        py3-pip \
+        python3-dev \
+        shadow \
+        sudo \
+        tzdata \
+        userspace-rcu \
+        util-linux-dev \
+        which \
+        zlib-dev \
+        \
+        # Azure DevOps container job requirements
+        nodejs
+
+# Install PowerShell
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust \
+    && curl -L https://github.com/PowerShell/PowerShell/releases/download/v${POWERSHELL_VERSION}/powershell-${POWERSHELL_VERSION}-linux-musl-x64.tar.gz -o /tmp/powershell.tar.gz \
+    && mkdir -p /opt/microsoft/powershell \
+    && tar zxf /tmp/powershell.tar.gz -C /opt/microsoft/powershell \
+    && chmod +x /opt/microsoft/powershell/pwsh \
+    && ln -s /opt/microsoft/powershell/pwsh /usr/bin/pwsh \
+    && rm -f /tmp/powershell.tar.gz
+
+# Install azurecli from PIP
+RUN azureEnv="/usr/local/share/azure-cli-env" \
+    && python3 -m venv "$azureEnv" \
+    && "$azureEnv/bin/python" -m pip install --upgrade setuptools \
+    && "$azureEnv/bin/python" -m pip install azure-cli \
+    && ln -s "$azureEnv/bin/az" /usr/local/bin/az
+
+# Add label for bring your own node in azure devops
+LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/bin/node"

--- a/src/alpine/3.24/helix/Dockerfile
+++ b/src/alpine/3.24/helix/Dockerfile
@@ -1,0 +1,53 @@
+FROM library/alpine:3.24 AS venv
+
+RUN apk add --upgrade --no-cache \
+        cargo \
+        python3-dev \
+        build-base \
+        libffi-dev \
+        openssl-dev \
+        gcc \
+        linux-headers
+
+RUN python3 -m venv /venv && \
+        source /venv/bin/activate && \
+        pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+        pip install ./helix_scripts-*-py3-none-any.whl && \
+        rm ./helix_scripts-*-py3-none-any.whl
+
+FROM library/alpine:3.24
+
+# Install .NET and test dependencies
+RUN apk add --upgrade --no-cache \
+        bash \
+        coreutils \
+        curl \
+        icu-data-full \
+        icu-libs \
+        iputils \
+        krb5-libs \
+        libmsquic \
+        lldb \
+        llvm \
+        lttng-ust \
+        musl-locales \
+        openssl \
+        python3 \
+        python3-dev \
+        py3-pip \
+        sudo \
+        tzdata
+
+# create helixbot user and give rights to sudo without password
+# Alpine does not support long options
+RUN /usr/sbin/adduser -D -g '' -G adm -s /bin/bash -u 1000 helixbot && \
+    chmod 755 /root && \
+    echo "helixbot ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/helixbot
+
+USER helixbot
+
+# Install Helix Dependencies
+ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+COPY --from=venv --chown=helixbot /venv $VIRTUAL_ENV

--- a/src/alpine/manifest.json
+++ b/src/alpine/manifest.json
@@ -59,6 +59,59 @@
         {
           "platforms": [
             {
+              "dockerfile": "src/alpine/3.24/amd64",
+              "os": "linux",
+              "osVersion": "alpine3.24",
+              "tags": {
+                "alpine-3.24-amd64": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "architecture": "amd64",
+              "dockerfile": "src/alpine/3.24/helix",
+              "os": "linux",
+              "osVersion": "alpine3.24",
+              "tags": {
+                "alpine-3.24-helix-amd64": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "architecture": "arm",
+              "dockerfile": "src/alpine/3.24/helix",
+              "os": "linux",
+              "osVersion": "alpine3.24",
+              "tags": {
+                "alpine-3.24-helix-arm32v7": {}
+              },
+              "variant": "v7"
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "architecture": "arm64",
+              "dockerfile": "src/alpine/3.24/helix",
+              "os": "linux",
+              "osVersion": "alpine3.24",
+              "tags": {
+                "alpine-3.24-helix-arm64v8": {}
+              },
+              "variant": "v8"
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
               "architecture": "amd64",
               "dockerfile": "src/alpine/edge/helix",
               "os": "linux",


### PR DESCRIPTION
## Summary
- Add Alpine 3.24 amd64 prereq Dockerfile
- Add Alpine 3.24 Helix Dockerfile for amd64, arm32v7, and arm64v8
- Register Alpine 3.24 tags and osVersion entries in the Alpine manifest

## Validation
- pwsh ./run-tests.ps1