### PR TITLE
Test Azure Linux 4.0 .NET 11 build image

### DIFF
--- a/src/azurelinux/4.0/net11.0/build/amd64/Dockerfile
+++ b/src/azurelinux/4.0/net11.0/build/amd64/Dockerfile
@@ -1,0 +1,30 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0-azurelinux3.0 AS sdk
+FROM mcr.microsoft.com/dotnet/runtime:10.0-azurelinux3.0 AS runtime
+
+FROM mcr.microsoft.com/azurelinux-beta/base/core:4.0
+
+# Install .NET runtime dependencies (inlined from runtime-deps) and build tools
+RUN dnf install -y \
+        azure-cli \
+        ca-certificates \
+        # added to ensure latest patches over the base image
+        curl \
+        gawk \
+        git \
+        icu \
+        nodejs24 \
+        nodejs24-npm \
+        # provides 'useradd', required by Azure DevOps
+        shadow-utils \
+        tar \
+        # Provides 'su', required by Azure DevOps
+        util-linux \
+    && dnf clean all
+
+# Copy .NET runtime and PowerShell from Azure Linux 3.0 images
+COPY --from=runtime /usr/share/dotnet /usr/share/dotnet
+COPY --from=sdk /usr/share/powershell /usr/share/powershell
+RUN ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet && \
+    ln -s /usr/share/powershell/pwsh /usr/bin/pwsh && \
+    ln -s /usr/bin/node-24 /usr/bin/node && \
+    ln -s /usr/bin/npm-24 /usr/bin/npm

--- a/src/azurelinux/manifest.json
+++ b/src/azurelinux/manifest.json
@@ -1460,6 +1460,19 @@
               }
             }
           ]
+        },
+        {
+          "platforms": [
+            {
+              "architecture": "amd64",
+              "dockerfile": "src/azurelinux/4.0/net11.0/build/amd64",
+              "os": "linux",
+              "osVersion": "azurelinux4.0",
+              "tags": {
+                "azurelinux-4.0-net11.0-build-amd64": {}
+              }
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
## Summary
- Replays the Azure Linux 4.0 .NET 11 build image branch on current main
- Uses the current Azure Linux 4.0 beta MCR base image
- Adds node/npm compatibility symlinks for the AzL 4.0 nodejs24 package layout

## Context
- Test PR for #1646
- am11's #1655 removed the debootstrap dependency from the rootfs path
- libbsd-devel, libbsd, libmd, and libmd-devel are now available from the current AzL 4.0 repo

## Validation
- docker build --pull -t azl4-net11-build-replay -f src/azurelinux/4.0/net11.0/build/amd64/Dockerfile src/azurelinux/4.0/net11.0/build/amd64
- docker run smoke test for dotnet, pwsh, node, npm, and az
- pwsh ./run-tests.ps1