### PR TITLE
Define python feeds used via env variables

### DIFF
--- a/eng/pipelines/steps/pip-authenticate.yml
+++ b/eng/pipelines/steps/pip-authenticate.yml
@@ -9,3 +9,5 @@ steps:
     $options += " --build-arg PIP_INDEX_URL=$env:PIP_INDEX_URL --build-arg NPM_TOKEN=$(System.AccessToken)"
     echo "##vso[task.setvariable variable=imageBuilderBuildArgs]$options"
   displayName: Set PIP and NPM Build Args
+  env:
+    PIP_INDEX_URL: https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple

--- a/eng/pipelines/steps/pip-authenticate.yml
+++ b/eng/pipelines/steps/pip-authenticate.yml
@@ -1,9 +1,11 @@
-# The pip index used to install helix-scripts is hardcoded as `ENV PIP_INDEX_URL=...` inside each
-# helix Dockerfile (pointing at the public, unauthenticated `helix-client-prod` Azure Artifacts feed).
-# This step only forwards the NPM token consumed by the WebAssembly Dockerfiles.
 steps:
+- task: PipAuthenticate@1
+  displayName: 'Pip Authenticate'
+  inputs:
+    artifactFeeds: public/dotnet-public-pypi
+    onlyAddExtraIndex: false
 - powershell: |
     $options = "$(imageBuilderBuildArgs)"
-    $options += " --build-arg NPM_TOKEN=$(System.AccessToken)"
+    $options += " --build-arg PIP_INDEX_URL=$env:PIP_INDEX_URL --build-arg NPM_TOKEN=$(System.AccessToken)"
     echo "##vso[task.setvariable variable=imageBuilderBuildArgs]$options"
-  displayName: Set NPM Build Arg
+  displayName: Set PIP and NPM Build Args

--- a/eng/pipelines/steps/pip-authenticate.yml
+++ b/eng/pipelines/steps/pip-authenticate.yml
@@ -1,11 +1,9 @@
+# The pip index used to install helix-scripts is hardcoded as `ENV PIP_INDEX_URL=...` inside each
+# helix Dockerfile (pointing at the public, unauthenticated `helix-client-prod` Azure Artifacts feed).
+# This step only forwards the NPM token consumed by the WebAssembly Dockerfiles.
 steps:
-- task: PipAuthenticate@1
-  displayName: 'Pip Authenticate'
-  inputs:
-    artifactFeeds: public/dotnet-public-pypi
-    onlyAddExtraIndex: false
 - powershell: |
     $options = "$(imageBuilderBuildArgs)"
-    $options += " --build-arg PIP_INDEX_URL=$env:PIP_INDEX_URL --build-arg NPM_TOKEN=$(System.AccessToken)"
+    $options += " --build-arg NPM_TOKEN=$(System.AccessToken)"
     echo "##vso[task.setvariable variable=imageBuilderBuildArgs]$options"
-  displayName: Set PIP and NPM Build Args
+  displayName: Set NPM Build Arg

--- a/src/almalinux/10/helix/amd64/Dockerfile
+++ b/src/almalinux/10/helix/amd64/Dockerfile
@@ -1,5 +1,7 @@
 FROM library/almalinux:10 AS venv
 
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+
 RUN dnf upgrade --refresh -y \
     && dnf install --setopt tsflags=nodocs -y \
         gcc \
@@ -10,12 +12,14 @@ RUN dnf upgrade --refresh -y \
 
 RUN python3 -m venv /venv \
     && . /venv/bin/activate \
-    && pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
-    && pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
+    && pip download --no-deps helix-scripts \
+    && pip install ./helix_scripts-*-py3-none-any.whl \
     && rm ./helix_scripts-*-py3-none-any.whl
 
 
 FROM library/almalinux:10
+
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
 
 # Install dependencies
 RUN dnf upgrade --refresh -y \

--- a/src/almalinux/10/helix/amd64/Dockerfile
+++ b/src/almalinux/10/helix/amd64/Dockerfile
@@ -11,7 +11,7 @@ RUN dnf upgrade --refresh -y \
 RUN python3 -m venv /venv \
     && . /venv/bin/activate \
     && pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
-    && pip install ./helix_scripts-*-py3-none-any.whl \
+    && pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
     && rm ./helix_scripts-*-py3-none-any.whl
 
 

--- a/src/almalinux/10/helix/amd64/Dockerfile
+++ b/src/almalinux/10/helix/amd64/Dockerfile
@@ -1,6 +1,7 @@
 FROM library/almalinux:10 AS venv
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 RUN dnf upgrade --refresh -y \
     && dnf install --setopt tsflags=nodocs -y \
@@ -19,7 +20,8 @@ RUN python3 -m venv /venv \
 
 FROM library/almalinux:10
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 # Install dependencies
 RUN dnf upgrade --refresh -y \

--- a/src/almalinux/8/helix/amd64/Dockerfile
+++ b/src/almalinux/8/helix/amd64/Dockerfile
@@ -36,6 +36,6 @@ ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
 RUN python -m venv $VIRTUAL_ENV && \
     ${VIRTUAL_ENV}/bin/pip install --upgrade pip setuptools && \
     ${VIRTUAL_ENV}/bin/pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    ${VIRTUAL_ENV}/bin/pip install ./helix_scripts-*-py3-none-any.whl && \
+    ${VIRTUAL_ENV}/bin/pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
     rm ./helix_scripts-*-py3-none-any.whl
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"

--- a/src/almalinux/8/helix/amd64/Dockerfile
+++ b/src/almalinux/8/helix/amd64/Dockerfile
@@ -1,5 +1,7 @@
 FROM library/almalinux:8
 
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+
 RUN dnf upgrade --refresh -y \
     && dnf install --setopt tsflags=nodocs -y  \
         'dnf-command(config-manager)' \
@@ -35,7 +37,7 @@ ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
 
 RUN python -m venv $VIRTUAL_ENV && \
     ${VIRTUAL_ENV}/bin/pip install --upgrade pip setuptools && \
-    ${VIRTUAL_ENV}/bin/pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    ${VIRTUAL_ENV}/bin/pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    ${VIRTUAL_ENV}/bin/pip download --no-deps helix-scripts && \
+    ${VIRTUAL_ENV}/bin/pip install ./helix_scripts-*-py3-none-any.whl && \
     rm ./helix_scripts-*-py3-none-any.whl
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"

--- a/src/almalinux/8/helix/amd64/Dockerfile
+++ b/src/almalinux/8/helix/amd64/Dockerfile
@@ -1,6 +1,7 @@
 FROM library/almalinux:8
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 RUN dnf upgrade --refresh -y \
     && dnf install --setopt tsflags=nodocs -y  \

--- a/src/almalinux/9/helix/amd64/Dockerfile
+++ b/src/almalinux/9/helix/amd64/Dockerfile
@@ -1,5 +1,7 @@
 FROM library/almalinux:9 AS venv
 
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+
 RUN dnf upgrade --refresh -y \
     && dnf install --setopt tsflags=nodocs -y \
         gcc \
@@ -11,12 +13,14 @@ RUN dnf upgrade --refresh -y \
 RUN python3 -m venv /venv \
     && . /venv/bin/activate \
     && pip install --upgrade pip setuptools \
-    && pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
-    && pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
+    && pip download --no-deps helix-scripts \
+    && pip install ./helix_scripts-*-py3-none-any.whl \
     && rm ./helix_scripts-*-py3-none-any.whl
 
 
 FROM library/almalinux:9
+
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
 
 # Install dependencies
 RUN dnf upgrade --refresh -y \

--- a/src/almalinux/9/helix/amd64/Dockerfile
+++ b/src/almalinux/9/helix/amd64/Dockerfile
@@ -1,6 +1,7 @@
 FROM library/almalinux:9 AS venv
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 RUN dnf upgrade --refresh -y \
     && dnf install --setopt tsflags=nodocs -y \
@@ -20,7 +21,8 @@ RUN python3 -m venv /venv \
 
 FROM library/almalinux:9
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 # Install dependencies
 RUN dnf upgrade --refresh -y \

--- a/src/almalinux/9/helix/amd64/Dockerfile
+++ b/src/almalinux/9/helix/amd64/Dockerfile
@@ -12,7 +12,7 @@ RUN python3 -m venv /venv \
     && . /venv/bin/activate \
     && pip install --upgrade pip setuptools \
     && pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
-    && pip install ./helix_scripts-*-py3-none-any.whl \
+    && pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
     && rm ./helix_scripts-*-py3-none-any.whl
 
 

--- a/src/alpine/3.23/helix/Dockerfile
+++ b/src/alpine/3.23/helix/Dockerfile
@@ -1,5 +1,7 @@
 FROM library/alpine:3.23 AS venv
 
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+
 RUN apk add --upgrade --no-cache \
         cargo \
         python3-dev \
@@ -11,11 +13,13 @@ RUN apk add --upgrade --no-cache \
 
 RUN python3 -m venv /venv && \
         source /venv/bin/activate && \
-        pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-        pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+        pip download --no-deps helix-scripts && \
+        pip install ./helix_scripts-*-py3-none-any.whl && \
         rm ./helix_scripts-*-py3-none-any.whl
 
 FROM library/alpine:3.23
+
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
 
 # Install .NET and test dependencies
 RUN apk add --upgrade --no-cache \

--- a/src/alpine/3.23/helix/Dockerfile
+++ b/src/alpine/3.23/helix/Dockerfile
@@ -1,6 +1,7 @@
 FROM library/alpine:3.23 AS venv
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 RUN apk add --upgrade --no-cache \
         cargo \
@@ -19,7 +20,8 @@ RUN python3 -m venv /venv && \
 
 FROM library/alpine:3.23
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 # Install .NET and test dependencies
 RUN apk add --upgrade --no-cache \

--- a/src/alpine/3.23/helix/Dockerfile
+++ b/src/alpine/3.23/helix/Dockerfile
@@ -12,7 +12,7 @@ RUN apk add --upgrade --no-cache \
 RUN python3 -m venv /venv && \
         source /venv/bin/activate && \
         pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-        pip install ./helix_scripts-*-py3-none-any.whl && \
+        pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
         rm ./helix_scripts-*-py3-none-any.whl
 
 FROM library/alpine:3.23

--- a/src/alpine/edge/helix/Dockerfile
+++ b/src/alpine/edge/helix/Dockerfile
@@ -12,7 +12,7 @@ RUN apk add --upgrade --no-cache \
 RUN python3 -m venv /venv && \
         source /venv/bin/activate && \
         pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-        pip install ./helix_scripts-*-py3-none-any.whl && \
+        pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
         rm ./helix_scripts-*-py3-none-any.whl
 
 FROM library/alpine:edge

--- a/src/alpine/edge/helix/Dockerfile
+++ b/src/alpine/edge/helix/Dockerfile
@@ -1,6 +1,7 @@
 FROM library/alpine:edge AS venv
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 RUN apk add --upgrade --no-cache \
         cargo \
@@ -19,7 +20,8 @@ RUN python3 -m venv /venv && \
 
 FROM library/alpine:edge
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 # Install .NET and test dependencies
 RUN apk add --upgrade --no-cache \

--- a/src/alpine/edge/helix/Dockerfile
+++ b/src/alpine/edge/helix/Dockerfile
@@ -1,5 +1,7 @@
 FROM library/alpine:edge AS venv
 
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+
 RUN apk add --upgrade --no-cache \
         cargo \
         python3-dev \
@@ -11,11 +13,13 @@ RUN apk add --upgrade --no-cache \
 
 RUN python3 -m venv /venv && \
         source /venv/bin/activate && \
-        pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-        pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+        pip download --no-deps helix-scripts && \
+        pip install ./helix_scripts-*-py3-none-any.whl && \
         rm ./helix_scripts-*-py3-none-any.whl
 
 FROM library/alpine:edge
+
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
 
 # Install .NET and test dependencies
 RUN apk add --upgrade --no-cache \

--- a/src/azurelinux/3.0/helix/Dockerfile
+++ b/src/azurelinux/3.0/helix/Dockerfile
@@ -1,6 +1,7 @@
 FROM mcr.microsoft.com/azurelinux/base/core:3.0 as venv
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 RUN tdnf install --refresh -y \
     build-essential \
@@ -19,7 +20,8 @@ RUN python3 -m venv /venv && \
 
 FROM mcr.microsoft.com/azurelinux/base/core:3.0
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 # Install .NET and test dependencies
 RUN tdnf update -y && \

--- a/src/azurelinux/3.0/helix/Dockerfile
+++ b/src/azurelinux/3.0/helix/Dockerfile
@@ -1,5 +1,7 @@
 FROM mcr.microsoft.com/azurelinux/base/core:3.0 as venv
 
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+
 RUN tdnf install --refresh -y \
     build-essential \
     ca-certificates-microsoft \
@@ -11,11 +13,13 @@ RUN tdnf install --refresh -y \
 
 RUN python3 -m venv /venv && \
         source /venv/bin/activate && \
-        pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-        pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+        pip download --no-deps helix-scripts && \
+        pip install ./helix_scripts-*-py3-none-any.whl && \
         rm ./helix_scripts-*-py3-none-any.whl
 
 FROM mcr.microsoft.com/azurelinux/base/core:3.0
+
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
 
 # Install .NET and test dependencies
 RUN tdnf update -y && \

--- a/src/azurelinux/3.0/helix/Dockerfile
+++ b/src/azurelinux/3.0/helix/Dockerfile
@@ -12,7 +12,7 @@ RUN tdnf install --refresh -y \
 RUN python3 -m venv /venv && \
         source /venv/bin/activate && \
         pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-        pip install ./helix_scripts-*-py3-none-any.whl && \
+        pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
         rm ./helix_scripts-*-py3-none-any.whl
 
 FROM mcr.microsoft.com/azurelinux/base/core:3.0

--- a/src/azurelinux/4.0/helix/Dockerfile
+++ b/src/azurelinux/4.0/helix/Dockerfile
@@ -10,7 +10,7 @@ RUN dnf install --refresh -y \
 RUN python3 -m venv /venv && \
         source /venv/bin/activate && \
         pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-        pip install ./helix_scripts-*-py3-none-any.whl && \
+        pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
         rm ./helix_scripts-*-py3-none-any.whl
 
 FROM mcr.microsoft.com/azurelinux-beta/base/core:4.0

--- a/src/azurelinux/4.0/helix/Dockerfile
+++ b/src/azurelinux/4.0/helix/Dockerfile
@@ -1,6 +1,7 @@
 FROM mcr.microsoft.com/azurelinux-beta/base/core:4.0 AS venv
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 RUN dnf install --refresh -y \
     ca-certificates \
@@ -17,7 +18,8 @@ RUN python3 -m venv /venv && \
 
 FROM mcr.microsoft.com/azurelinux-beta/base/core:4.0
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 # Install .NET and test dependencies
 RUN dnf install --setopt tsflags=nodocs --refresh -y \

--- a/src/azurelinux/4.0/helix/Dockerfile
+++ b/src/azurelinux/4.0/helix/Dockerfile
@@ -1,5 +1,7 @@
 FROM mcr.microsoft.com/azurelinux-beta/base/core:4.0 AS venv
 
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+
 RUN dnf install --refresh -y \
     ca-certificates \
     iputils \
@@ -9,11 +11,13 @@ RUN dnf install --refresh -y \
 
 RUN python3 -m venv /venv && \
         source /venv/bin/activate && \
-        pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-        pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+        pip download --no-deps helix-scripts && \
+        pip install ./helix_scripts-*-py3-none-any.whl && \
         rm ./helix_scripts-*-py3-none-any.whl
 
 FROM mcr.microsoft.com/azurelinux-beta/base/core:4.0
+
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
 
 # Install .NET and test dependencies
 RUN dnf install --setopt tsflags=nodocs --refresh -y \

--- a/src/centos-stream/10/helix/Dockerfile
+++ b/src/centos-stream/10/helix/Dockerfile
@@ -11,7 +11,7 @@ RUN dnf upgrade --refresh -y \
 RUN python3 -m venv /venv \
     && . /venv/bin/activate \
     && pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
-    && pip install ./helix_scripts-*-py3-none-any.whl \
+    && pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
     && rm ./helix_scripts-*-py3-none-any.whl
 
 FROM quay.io/centos/centos:stream10

--- a/src/centos-stream/10/helix/Dockerfile
+++ b/src/centos-stream/10/helix/Dockerfile
@@ -1,6 +1,7 @@
 FROM quay.io/centos/centos:stream10 AS venv
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 RUN dnf upgrade --refresh -y \
     && dnf install --setopt tsflags=nodocs -y \
@@ -18,7 +19,8 @@ RUN python3 -m venv /venv \
 
 FROM quay.io/centos/centos:stream10
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 # Install dependencies
 RUN dnf upgrade --refresh -y \

--- a/src/centos-stream/10/helix/Dockerfile
+++ b/src/centos-stream/10/helix/Dockerfile
@@ -1,5 +1,7 @@
 FROM quay.io/centos/centos:stream10 AS venv
 
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+
 RUN dnf upgrade --refresh -y \
     && dnf install --setopt tsflags=nodocs -y \
         gcc \
@@ -10,11 +12,13 @@ RUN dnf upgrade --refresh -y \
 
 RUN python3 -m venv /venv \
     && . /venv/bin/activate \
-    && pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
-    && pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
+    && pip download --no-deps helix-scripts \
+    && pip install ./helix_scripts-*-py3-none-any.whl \
     && rm ./helix_scripts-*-py3-none-any.whl
 
 FROM quay.io/centos/centos:stream10
+
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
 
 # Install dependencies
 RUN dnf upgrade --refresh -y \

--- a/src/centos-stream/9/helix/amd64/Dockerfile
+++ b/src/centos-stream/9/helix/amd64/Dockerfile
@@ -1,6 +1,7 @@
 FROM quay.io/centos/centos:stream9
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 # Install dependencies
 RUN dnf upgrade --refresh -y \

--- a/src/centos-stream/9/helix/amd64/Dockerfile
+++ b/src/centos-stream/9/helix/amd64/Dockerfile
@@ -1,5 +1,7 @@
 FROM quay.io/centos/centos:stream9
 
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+
 # Install dependencies
 RUN dnf upgrade --refresh -y \
     # Required to install libunwind from the EPEL repo
@@ -52,7 +54,7 @@ ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
 
 RUN python -m venv $VIRTUAL_ENV && \
     ${VIRTUAL_ENV}/bin/pip install --upgrade pip setuptools && \
-    ${VIRTUAL_ENV}/bin/pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    ${VIRTUAL_ENV}/bin/pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    ${VIRTUAL_ENV}/bin/pip download --no-deps helix-scripts && \
+    ${VIRTUAL_ENV}/bin/pip install ./helix_scripts-*-py3-none-any.whl && \
     rm ./helix_scripts-*-py3-none-any.whl
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"

--- a/src/centos-stream/9/helix/amd64/Dockerfile
+++ b/src/centos-stream/9/helix/amd64/Dockerfile
@@ -53,6 +53,6 @@ ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
 RUN python -m venv $VIRTUAL_ENV && \
     ${VIRTUAL_ENV}/bin/pip install --upgrade pip setuptools && \
     ${VIRTUAL_ENV}/bin/pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    ${VIRTUAL_ENV}/bin/pip install ./helix_scripts-*-py3-none-any.whl && \
+    ${VIRTUAL_ENV}/bin/pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
     rm ./helix_scripts-*-py3-none-any.whl
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"

--- a/src/centos-stream/9/mlnet/helix/amd64/Dockerfile
+++ b/src/centos-stream/9/mlnet/helix/amd64/Dockerfile
@@ -1,6 +1,7 @@
 FROM quay.io/centos/centos:stream9
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 # Install dependencies
 RUN dnf upgrade --refresh -y \

--- a/src/centos-stream/9/mlnet/helix/amd64/Dockerfile
+++ b/src/centos-stream/9/mlnet/helix/amd64/Dockerfile
@@ -98,6 +98,6 @@ ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
 RUN python -m venv $VIRTUAL_ENV && \
     ${VIRTUAL_ENV}/bin/pip install --upgrade pip setuptools && \
     ${VIRTUAL_ENV}/bin/pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    ${VIRTUAL_ENV}/bin/pip install ./helix_scripts-*-py3-none-any.whl && \
+    ${VIRTUAL_ENV}/bin/pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
     rm ./helix_scripts-*-py3-none-any.whl
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"

--- a/src/centos-stream/9/mlnet/helix/amd64/Dockerfile
+++ b/src/centos-stream/9/mlnet/helix/amd64/Dockerfile
@@ -1,5 +1,7 @@
 FROM quay.io/centos/centos:stream9
 
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+
 # Install dependencies
 RUN dnf upgrade --refresh -y \
     && dnf install --setopt tsflags=nodocs -y \
@@ -97,7 +99,7 @@ ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
 
 RUN python -m venv $VIRTUAL_ENV && \
     ${VIRTUAL_ENV}/bin/pip install --upgrade pip setuptools && \
-    ${VIRTUAL_ENV}/bin/pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    ${VIRTUAL_ENV}/bin/pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    ${VIRTUAL_ENV}/bin/pip download --no-deps helix-scripts && \
+    ${VIRTUAL_ENV}/bin/pip install ./helix_scripts-*-py3-none-any.whl && \
     rm ./helix_scripts-*-py3-none-any.whl
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"

--- a/src/debian/12/helix/amd64/Dockerfile
+++ b/src/debian/12/helix/amd64/Dockerfile
@@ -1,5 +1,7 @@
 FROM library/debian:bookworm AS venv
 
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+
 RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y \
@@ -12,11 +14,13 @@ RUN apt-get update \
 RUN python3 -m venv /venv \
     && . /venv/bin/activate \
     && pip install --upgrade pip setuptools \
-    && pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
-    && pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
+    && pip download --no-deps helix-scripts \
+    && pip install ./helix_scripts-*-py3-none-any.whl \
     && rm ./helix_scripts-*-py3-none-any.whl
 
 FROM library/debian:bookworm
+
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
 
 # Install Helix Dependencies
 RUN apt-get update \

--- a/src/debian/12/helix/amd64/Dockerfile
+++ b/src/debian/12/helix/amd64/Dockerfile
@@ -1,6 +1,7 @@
 FROM library/debian:bookworm AS venv
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 RUN apt-get update \
     && apt-get upgrade -y \
@@ -20,7 +21,8 @@ RUN python3 -m venv /venv \
 
 FROM library/debian:bookworm
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 # Install Helix Dependencies
 RUN apt-get update \

--- a/src/debian/12/helix/amd64/Dockerfile
+++ b/src/debian/12/helix/amd64/Dockerfile
@@ -13,7 +13,7 @@ RUN python3 -m venv /venv \
     && . /venv/bin/activate \
     && pip install --upgrade pip setuptools \
     && pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
-    && pip install ./helix_scripts-*-py3-none-any.whl \
+    && pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
     && rm ./helix_scripts-*-py3-none-any.whl
 
 FROM library/debian:bookworm

--- a/src/debian/12/helix/arm32v7/Dockerfile
+++ b/src/debian/12/helix/arm32v7/Dockerfile
@@ -1,6 +1,7 @@
 FROM library/debian:bookworm AS venv
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 RUN apt-get update \
     && apt-get upgrade -y \
@@ -29,7 +30,8 @@ RUN python3 -m venv /venv \
 
 FROM library/debian:bookworm
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 RUN apt-get update \
     && apt-get upgrade -y \

--- a/src/debian/12/helix/arm32v7/Dockerfile
+++ b/src/debian/12/helix/arm32v7/Dockerfile
@@ -1,5 +1,7 @@
 FROM library/debian:bookworm AS venv
 
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+
 RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y \
@@ -21,11 +23,13 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 RUN python3 -m venv /venv \
     && . /venv/bin/activate \
     && pip install --upgrade pip setuptools \
-    && pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
-    && pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
+    && pip download --no-deps helix-scripts \
+    && pip install ./helix_scripts-*-py3-none-any.whl \
     && rm ./helix_scripts-*-py3-none-any.whl
 
 FROM library/debian:bookworm
+
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
 
 RUN apt-get update \
     && apt-get upgrade -y \

--- a/src/debian/12/helix/arm32v7/Dockerfile
+++ b/src/debian/12/helix/arm32v7/Dockerfile
@@ -22,7 +22,7 @@ RUN python3 -m venv /venv \
     && . /venv/bin/activate \
     && pip install --upgrade pip setuptools \
     && pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
-    && pip install ./helix_scripts-*-py3-none-any.whl \
+    && pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
     && rm ./helix_scripts-*-py3-none-any.whl
 
 FROM library/debian:bookworm

--- a/src/debian/12/helix/arm64v8/Dockerfile
+++ b/src/debian/12/helix/arm64v8/Dockerfile
@@ -1,5 +1,7 @@
 FROM library/debian:bookworm AS venv
 
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+
 RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y \
@@ -12,11 +14,13 @@ RUN apt-get update \
 RUN python3 -m venv /venv \
     && . /venv/bin/activate \
     && pip install --upgrade pip setuptools \
-    && pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
-    && pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
+    && pip download --no-deps helix-scripts \
+    && pip install ./helix_scripts-*-py3-none-any.whl \
     && rm ./helix_scripts-*-py3-none-any.whl
 
 FROM library/debian:bookworm
+
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
 
 # Install Helix Dependencies
 RUN apt-get update \

--- a/src/debian/12/helix/arm64v8/Dockerfile
+++ b/src/debian/12/helix/arm64v8/Dockerfile
@@ -1,6 +1,7 @@
 FROM library/debian:bookworm AS venv
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 RUN apt-get update \
     && apt-get upgrade -y \
@@ -20,7 +21,8 @@ RUN python3 -m venv /venv \
 
 FROM library/debian:bookworm
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 # Install Helix Dependencies
 RUN apt-get update \

--- a/src/debian/12/helix/arm64v8/Dockerfile
+++ b/src/debian/12/helix/arm64v8/Dockerfile
@@ -13,7 +13,7 @@ RUN python3 -m venv /venv \
     && . /venv/bin/activate \
     && pip install --upgrade pip setuptools \
     && pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
-    && pip install ./helix_scripts-*-py3-none-any.whl \
+    && pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
     && rm ./helix_scripts-*-py3-none-any.whl
 
 FROM library/debian:bookworm

--- a/src/debian/13/helix/Dockerfile
+++ b/src/debian/13/helix/Dockerfile
@@ -1,6 +1,7 @@
 FROM library/debian:trixie AS venv
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 RUN apt-get update \
     && apt-get install -y \
@@ -22,7 +23,8 @@ RUN python3 -m venv /venv \
 
 FROM library/debian:trixie
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 ARG TARGETARCH
 
 # Install Helix Dependencies

--- a/src/debian/13/helix/Dockerfile
+++ b/src/debian/13/helix/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update \
 RUN python3 -m venv /venv \
     && . /venv/bin/activate \
     && pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
-    && pip install ./helix_scripts-*-py3-none-any.whl \
+    && pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
     && rm ./helix_scripts-*-py3-none-any.whl
 
 FROM library/debian:trixie

--- a/src/debian/13/helix/Dockerfile
+++ b/src/debian/13/helix/Dockerfile
@@ -1,5 +1,7 @@
 FROM library/debian:trixie AS venv
 
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+
 RUN apt-get update \
     && apt-get install -y \
         cargo \
@@ -14,11 +16,13 @@ RUN apt-get update \
 
 RUN python3 -m venv /venv \
     && . /venv/bin/activate \
-    && pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
-    && pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
+    && pip download --no-deps helix-scripts \
+    && pip install ./helix_scripts-*-py3-none-any.whl \
     && rm ./helix_scripts-*-py3-none-any.whl
 
 FROM library/debian:trixie
+
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
 ARG TARGETARCH
 
 # Install Helix Dependencies

--- a/src/fedora/42/helix/amd64/Dockerfile
+++ b/src/fedora/42/helix/amd64/Dockerfile
@@ -1,6 +1,7 @@
 FROM library/fedora:42 AS venv
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 RUN dnf upgrade --refresh -y \
     && dnf install --setopt tsflags=nodocs -y \
@@ -22,7 +23,8 @@ RUN python3 -m venv /venv \
 
 FROM library/fedora:42
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 # Install Dependencies
 

--- a/src/fedora/42/helix/amd64/Dockerfile
+++ b/src/fedora/42/helix/amd64/Dockerfile
@@ -15,7 +15,7 @@ RUN dnf upgrade --refresh -y \
 RUN python3 -m venv /venv \
     && source /venv/bin/activate \
     && pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
-    && pip install ./helix_scripts-*-py3-none-any.whl \
+    && pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
     && rm ./helix_scripts-*-py3-none-any.whl
 
 FROM library/fedora:42

--- a/src/fedora/42/helix/amd64/Dockerfile
+++ b/src/fedora/42/helix/amd64/Dockerfile
@@ -1,5 +1,7 @@
 FROM library/fedora:42 AS venv
 
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+
 RUN dnf upgrade --refresh -y \
     && dnf install --setopt tsflags=nodocs -y \
         dnf-plugins-core \
@@ -14,11 +16,13 @@ RUN dnf upgrade --refresh -y \
 
 RUN python3 -m venv /venv \
     && source /venv/bin/activate \
-    && pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
-    && pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
+    && pip download --no-deps helix-scripts \
+    && pip install ./helix_scripts-*-py3-none-any.whl \
     && rm ./helix_scripts-*-py3-none-any.whl
 
 FROM library/fedora:42
+
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
 
 # Install Dependencies
 

--- a/src/fedora/43/helix/amd64/Dockerfile
+++ b/src/fedora/43/helix/amd64/Dockerfile
@@ -1,5 +1,7 @@
 FROM library/fedora:43 AS venv
 
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+
 RUN dnf upgrade --refresh -y \
     && dnf install --setopt tsflags=nodocs -y \
         dnf-plugins-core \
@@ -14,11 +16,13 @@ RUN dnf upgrade --refresh -y \
 
 RUN python3 -m venv /venv \
     && source /venv/bin/activate \
-    && pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
-    && pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
+    && pip download --no-deps helix-scripts \
+    && pip install ./helix_scripts-*-py3-none-any.whl \
     && rm ./helix_scripts-*-py3-none-any.whl
 
 FROM library/fedora:43
+
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
 
 # Install MSQuic
 

--- a/src/fedora/43/helix/amd64/Dockerfile
+++ b/src/fedora/43/helix/amd64/Dockerfile
@@ -1,6 +1,7 @@
 FROM library/fedora:43 AS venv
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 RUN dnf upgrade --refresh -y \
     && dnf install --setopt tsflags=nodocs -y \
@@ -22,7 +23,8 @@ RUN python3 -m venv /venv \
 
 FROM library/fedora:43
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 # Install MSQuic
 

--- a/src/fedora/43/helix/amd64/Dockerfile
+++ b/src/fedora/43/helix/amd64/Dockerfile
@@ -15,7 +15,7 @@ RUN dnf upgrade --refresh -y \
 RUN python3 -m venv /venv \
     && source /venv/bin/activate \
     && pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
-    && pip install ./helix_scripts-*-py3-none-any.whl \
+    && pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
     && rm ./helix_scripts-*-py3-none-any.whl
 
 FROM library/fedora:43

--- a/src/fedora/44/helix/amd64/Dockerfile
+++ b/src/fedora/44/helix/amd64/Dockerfile
@@ -1,5 +1,7 @@
 FROM library/fedora:44 AS venv
 
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+
 RUN dnf upgrade --refresh -y \
     && dnf install --setopt tsflags=nodocs -y \
         dnf-plugins-core \
@@ -14,11 +16,13 @@ RUN dnf upgrade --refresh -y \
 
 RUN python3 -m venv /venv \
     && source /venv/bin/activate \
-    && pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
-    && pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
+    && pip download --no-deps helix-scripts \
+    && pip install ./helix_scripts-*-py3-none-any.whl \
     && rm ./helix_scripts-*-py3-none-any.whl
 
 FROM library/fedora:44
+
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
 
 # Install MSQuic. Fedora 44 does not have it in the repositories, so use the Fedora 43 package
 

--- a/src/fedora/44/helix/amd64/Dockerfile
+++ b/src/fedora/44/helix/amd64/Dockerfile
@@ -1,6 +1,7 @@
 FROM library/fedora:44 AS venv
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 RUN dnf upgrade --refresh -y \
     && dnf install --setopt tsflags=nodocs -y \
@@ -22,7 +23,8 @@ RUN python3 -m venv /venv \
 
 FROM library/fedora:44
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 # Install MSQuic. Fedora 44 does not have it in the repositories, so use the Fedora 43 package
 

--- a/src/fedora/44/helix/amd64/Dockerfile
+++ b/src/fedora/44/helix/amd64/Dockerfile
@@ -15,7 +15,7 @@ RUN dnf upgrade --refresh -y \
 RUN python3 -m venv /venv \
     && source /venv/bin/activate \
     && pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
-    && pip install ./helix_scripts-*-py3-none-any.whl \
+    && pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
     && rm ./helix_scripts-*-py3-none-any.whl
 
 FROM library/fedora:44

--- a/src/fedora/45/helix/amd64/Dockerfile
+++ b/src/fedora/45/helix/amd64/Dockerfile
@@ -1,6 +1,7 @@
 FROM library/fedora:45 AS venv
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 RUN dnf upgrade --refresh -y \
     && dnf install --setopt tsflags=nodocs -y \
@@ -22,7 +23,8 @@ RUN python3 -m venv /venv \
 
 FROM library/fedora:45
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 # Install MSQuic. Fedora 45 does not have it in the repositories, so use the Fedora 43 package
 

--- a/src/fedora/45/helix/amd64/Dockerfile
+++ b/src/fedora/45/helix/amd64/Dockerfile
@@ -15,7 +15,7 @@ RUN dnf upgrade --refresh -y \
 RUN python3 -m venv /venv \
     && source /venv/bin/activate \
     && pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
-    && pip install ./helix_scripts-*-py3-none-any.whl \
+    && pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
     && rm ./helix_scripts-*-py3-none-any.whl
 
 FROM library/fedora:45

--- a/src/fedora/45/helix/amd64/Dockerfile
+++ b/src/fedora/45/helix/amd64/Dockerfile
@@ -1,5 +1,7 @@
 FROM library/fedora:45 AS venv
 
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+
 RUN dnf upgrade --refresh -y \
     && dnf install --setopt tsflags=nodocs -y \
         dnf-plugins-core \
@@ -14,11 +16,13 @@ RUN dnf upgrade --refresh -y \
 
 RUN python3 -m venv /venv \
     && source /venv/bin/activate \
-    && pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
-    && pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
+    && pip download --no-deps helix-scripts \
+    && pip install ./helix_scripts-*-py3-none-any.whl \
     && rm ./helix_scripts-*-py3-none-any.whl
 
 FROM library/fedora:45
+
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
 
 # Install MSQuic. Fedora 45 does not have it in the repositories, so use the Fedora 43 package
 

--- a/src/fedora/rawhide/helix/amd64/Dockerfile
+++ b/src/fedora/rawhide/helix/amd64/Dockerfile
@@ -15,7 +15,7 @@ RUN dnf upgrade --refresh -y \
 RUN python3 -m venv /venv \
     && source /venv/bin/activate \
     && pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
-    && pip install ./helix_scripts-*-py3-none-any.whl \
+    && pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
     && rm ./helix_scripts-*-py3-none-any.whl
 
 FROM library/fedora:rawhide

--- a/src/fedora/rawhide/helix/amd64/Dockerfile
+++ b/src/fedora/rawhide/helix/amd64/Dockerfile
@@ -1,6 +1,7 @@
 FROM library/fedora:rawhide AS venv
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 RUN dnf upgrade --refresh -y \
     && dnf install --setopt tsflags=nodocs -y \
@@ -22,7 +23,8 @@ RUN python3 -m venv /venv \
 
 FROM library/fedora:rawhide
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 # Install MSQuic. Fedora rawhide does not have it in the repositories, so use the Fedora 43 package
 

--- a/src/fedora/rawhide/helix/amd64/Dockerfile
+++ b/src/fedora/rawhide/helix/amd64/Dockerfile
@@ -1,5 +1,7 @@
 FROM library/fedora:rawhide AS venv
 
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+
 RUN dnf upgrade --refresh -y \
     && dnf install --setopt tsflags=nodocs -y \
         dnf-plugins-core \
@@ -14,11 +16,13 @@ RUN dnf upgrade --refresh -y \
 
 RUN python3 -m venv /venv \
     && source /venv/bin/activate \
-    && pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
-    && pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
+    && pip download --no-deps helix-scripts \
+    && pip install ./helix_scripts-*-py3-none-any.whl \
     && rm ./helix_scripts-*-py3-none-any.whl
 
 FROM library/fedora:rawhide
+
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
 
 # Install MSQuic. Fedora rawhide does not have it in the repositories, so use the Fedora 43 package
 

--- a/src/nanoserver/1809/helix/amd64/Dockerfile
+++ b/src/nanoserver/1809/helix/amd64/Dockerfile
@@ -43,7 +43,7 @@ RUN pwsh -Command " `
         Remove-Item -Recurse -Force $pythonTemp; `
         Remove-Item -Force $pythonZip;"
 
-ARG PIP_INDEX_URL=https://pypi.org/simple
+ARG PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
 
 # Install Helix
 RUN pwsh -Command " `
@@ -62,7 +62,7 @@ RUN pwsh -Command " `
         } `
         Get-ChildItem -Path $helixTemp -Filter 'helix_scripts-*-py3-none-any.whl' | `
             ForEach-Object { `
-                & pip install $_.FullName --no-cache-dir; `
+                & pip install $_.FullName --no-cache-dir --index-url $env:PIP_INDEX_URL; `
                 if ($LASTEXITCODE -ne 0) { `
                     echo \"Failed to install Helix script: $($_.Name)\"; `
                     exit 1; `

--- a/src/nanoserver/1809/helix/amd64/Dockerfile
+++ b/src/nanoserver/1809/helix/amd64/Dockerfile
@@ -43,7 +43,7 @@ RUN pwsh -Command " `
         Remove-Item -Recurse -Force $pythonTemp; `
         Remove-Item -Force $pythonZip;"
 
-ARG PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
 
 # Install Helix
 RUN pwsh -Command " `
@@ -55,14 +55,14 @@ RUN pwsh -Command " `
             echo \"Failed to create Python virtual environment\"; `
             exit 1; `
         } `
-        & pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple; `
+        & pip download --no-deps helix-scripts; `
         if ($LASTEXITCODE -ne 0) { `
             echo \"Failed to download Helix scripts\"; `
             exit 1; `
         } `
         Get-ChildItem -Path $helixTemp -Filter 'helix_scripts-*-py3-none-any.whl' | `
             ForEach-Object { `
-                & pip install $_.FullName --no-cache-dir --index-url $env:PIP_INDEX_URL; `
+                & pip install $_.FullName --no-cache-dir; `
                 if ($LASTEXITCODE -ne 0) { `
                     echo \"Failed to install Helix script: $($_.Name)\"; `
                     exit 1; `
@@ -72,6 +72,8 @@ RUN pwsh -Command " `
         Remove-Item -Recurse -Force $helixTemp;"
 
 FROM mcr.microsoft.com/windows/nanoserver:1809
+
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
 
 USER ContainerAdministrator
 

--- a/src/nanoserver/1809/helix/amd64/Dockerfile
+++ b/src/nanoserver/1809/helix/amd64/Dockerfile
@@ -43,7 +43,8 @@ RUN pwsh -Command " `
         Remove-Item -Recurse -Force $pythonTemp; `
         Remove-Item -Force $pythonZip;"
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 # Install Helix
 RUN pwsh -Command " `
@@ -73,7 +74,8 @@ RUN pwsh -Command " `
 
 FROM mcr.microsoft.com/windows/nanoserver:1809
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 USER ContainerAdministrator
 

--- a/src/opensuse/16.0/helix/amd64/Dockerfile
+++ b/src/opensuse/16.0/helix/amd64/Dockerfile
@@ -1,6 +1,7 @@
 FROM opensuse/leap:16.0
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 # Install Helix Dependencies
 RUN zypper ref \

--- a/src/opensuse/16.0/helix/amd64/Dockerfile
+++ b/src/opensuse/16.0/helix/amd64/Dockerfile
@@ -1,5 +1,7 @@
 FROM opensuse/leap:16.0
 
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+
 # Install Helix Dependencies
 RUN zypper ref \
     && zypper update -y \
@@ -54,7 +56,7 @@ WORKDIR /home/helixbot
 ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
 
 RUN python -m venv $VIRTUAL_ENV && \
-    ${VIRTUAL_ENV}/bin/pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    ${VIRTUAL_ENV}/bin/pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    ${VIRTUAL_ENV}/bin/pip download --no-deps helix-scripts && \
+    ${VIRTUAL_ENV}/bin/pip install ./helix_scripts-*-py3-none-any.whl && \
     rm ./helix_scripts-*-py3-none-any.whl
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"

--- a/src/opensuse/16.0/helix/amd64/Dockerfile
+++ b/src/opensuse/16.0/helix/amd64/Dockerfile
@@ -55,6 +55,6 @@ ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
 
 RUN python -m venv $VIRTUAL_ENV && \
     ${VIRTUAL_ENV}/bin/pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    ${VIRTUAL_ENV}/bin/pip install ./helix_scripts-*-py3-none-any.whl && \
+    ${VIRTUAL_ENV}/bin/pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
     rm ./helix_scripts-*-py3-none-any.whl
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"

--- a/src/ubuntu/22.04/helix/Dockerfile
+++ b/src/ubuntu/22.04/helix/Dockerfile
@@ -63,6 +63,6 @@ ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
 RUN python -m venv /home/helixbot/.vsts-env && \
     ${VIRTUAL_ENV}/bin/pip install --upgrade pip setuptools && \
     ${VIRTUAL_ENV}/bin/pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    ${VIRTUAL_ENV}/bin/pip install ./helix_scripts-*-py3-none-any.whl && \
+    ${VIRTUAL_ENV}/bin/pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
     rm ./helix_scripts-*-py3-none-any.whl
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"

--- a/src/ubuntu/22.04/helix/Dockerfile
+++ b/src/ubuntu/22.04/helix/Dockerfile
@@ -2,7 +2,8 @@ FROM ubuntu.azurecr.io/ubuntu:22.04
 
 # Install Helix Dependencies
 ENV DEBIAN_FRONTEND=noninteractive
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 RUN apt-get update && \
     apt-get install -qq -y \

--- a/src/ubuntu/22.04/helix/Dockerfile
+++ b/src/ubuntu/22.04/helix/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu.azurecr.io/ubuntu:22.04
 
 # Install Helix Dependencies
 ENV DEBIAN_FRONTEND=noninteractive
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
 
 RUN apt-get update && \
     apt-get install -qq -y \
@@ -62,7 +63,7 @@ ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
 
 RUN python -m venv /home/helixbot/.vsts-env && \
     ${VIRTUAL_ENV}/bin/pip install --upgrade pip setuptools && \
-    ${VIRTUAL_ENV}/bin/pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    ${VIRTUAL_ENV}/bin/pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    ${VIRTUAL_ENV}/bin/pip download --no-deps helix-scripts && \
+    ${VIRTUAL_ENV}/bin/pip install ./helix_scripts-*-py3-none-any.whl && \
     rm ./helix_scripts-*-py3-none-any.whl
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"

--- a/src/ubuntu/22.04/mlnet/helix/amd64/Dockerfile
+++ b/src/ubuntu/22.04/mlnet/helix/amd64/Dockerfile
@@ -21,6 +21,6 @@ ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
 RUN python -m venv $VIRTUAL_ENV && \
     ${VIRTUAL_ENV}/bin/pip install --upgrade pip setuptools && \
     ${VIRTUAL_ENV}/bin/pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    ${VIRTUAL_ENV}/bin/pip install ./helix_scripts-*-py3-none-any.whl && \
+    ${VIRTUAL_ENV}/bin/pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
     rm ./helix_scripts-*-py3-none-any.whl
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"

--- a/src/ubuntu/22.04/mlnet/helix/amd64/Dockerfile
+++ b/src/ubuntu/22.04/mlnet/helix/amd64/Dockerfile
@@ -1,5 +1,7 @@
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-mlnet
 
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+
 # Install Helix Dependencies
 RUN apt-get update \
     && apt-get install -y \
@@ -20,7 +22,7 @@ ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
 
 RUN python -m venv $VIRTUAL_ENV && \
     ${VIRTUAL_ENV}/bin/pip install --upgrade pip setuptools && \
-    ${VIRTUAL_ENV}/bin/pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    ${VIRTUAL_ENV}/bin/pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    ${VIRTUAL_ENV}/bin/pip download --no-deps helix-scripts && \
+    ${VIRTUAL_ENV}/bin/pip install ./helix_scripts-*-py3-none-any.whl && \
     rm ./helix_scripts-*-py3-none-any.whl
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"

--- a/src/ubuntu/22.04/mlnet/helix/amd64/Dockerfile
+++ b/src/ubuntu/22.04/mlnet/helix/amd64/Dockerfile
@@ -1,6 +1,7 @@
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-mlnet
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 # Install Helix Dependencies
 RUN apt-get update \

--- a/src/ubuntu/24.04/helix/Dockerfile
+++ b/src/ubuntu/24.04/helix/Dockerfile
@@ -1,5 +1,6 @@
 FROM ubuntu.azurecr.io/ubuntu:noble AS venv
 ENV DEBIAN_FRONTEND=noninteractive
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
 
 RUN apt-get update && \
     apt-get install -y \
@@ -15,11 +16,13 @@ RUN apt-get update && \
 
 RUN python3 -m venv /venv && \
     . /venv/bin/activate && \
-    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    pip download --no-deps helix-scripts && \
+    pip install ./helix_scripts-*-py3-none-any.whl && \
     rm ./helix_scripts-*-py3-none-any.whl
 
 FROM ubuntu.azurecr.io/ubuntu:noble
+
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
 ARG TARGETARCH
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/src/ubuntu/24.04/helix/Dockerfile
+++ b/src/ubuntu/24.04/helix/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && \
 RUN python3 -m venv /venv && \
     . /venv/bin/activate && \
     pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    pip install ./helix_scripts-*-py3-none-any.whl && \
+    pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
     rm ./helix_scripts-*-py3-none-any.whl
 
 FROM ubuntu.azurecr.io/ubuntu:noble

--- a/src/ubuntu/24.04/helix/Dockerfile
+++ b/src/ubuntu/24.04/helix/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu.azurecr.io/ubuntu:noble AS venv
 ENV DEBIAN_FRONTEND=noninteractive
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 RUN apt-get update && \
     apt-get install -y \
@@ -22,7 +23,8 @@ RUN python3 -m venv /venv && \
 
 FROM ubuntu.azurecr.io/ubuntu:noble
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 ARG TARGETARCH
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/src/ubuntu/24.04/helix/android/amd64/Dockerfile
+++ b/src/ubuntu/24.04/helix/android/amd64/Dockerfile
@@ -1,5 +1,6 @@
 FROM ubuntu.azurecr.io/ubuntu:noble AS venv
 ENV DEBIAN_FRONTEND=noninteractive
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
 
 RUN apt-get update && \
     apt-get install -y \
@@ -15,13 +16,14 @@ RUN apt-get update && \
 
 RUN python3 -m venv /venv && \
     . /venv/bin/activate && \
-    pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
+    pip download --no-deps helix-scripts && \
+    pip install ./helix_scripts-*-py3-none-any.whl && \
     rm ./helix_scripts-*-py3-none-any.whl
 
 FROM ubuntu.azurecr.io/ubuntu:noble
 ARG TARGETARCH
 ENV DEBIAN_FRONTEND=noninteractive
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
 
 RUN apt-get update && \
     apt-get install -qq -y \

--- a/src/ubuntu/24.04/helix/android/amd64/Dockerfile
+++ b/src/ubuntu/24.04/helix/android/amd64/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && \
 RUN python3 -m venv /venv && \
     . /venv/bin/activate && \
     pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
-    pip install ./helix_scripts-*-py3-none-any.whl && \
+    pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple && \
     rm ./helix_scripts-*-py3-none-any.whl
 
 FROM ubuntu.azurecr.io/ubuntu:noble

--- a/src/ubuntu/24.04/helix/android/amd64/Dockerfile
+++ b/src/ubuntu/24.04/helix/android/amd64/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu.azurecr.io/ubuntu:noble AS venv
 ENV DEBIAN_FRONTEND=noninteractive
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 RUN apt-get update && \
     apt-get install -y \
@@ -23,7 +24,8 @@ RUN python3 -m venv /venv && \
 FROM ubuntu.azurecr.io/ubuntu:noble
 ARG TARGETARCH
 ENV DEBIAN_FRONTEND=noninteractive
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 RUN apt-get update && \
     apt-get install -qq -y \

--- a/src/ubuntu/26.04/helix/Dockerfile
+++ b/src/ubuntu/26.04/helix/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update \
 RUN python3 -m venv /venv \
     && . /venv/bin/activate \
     && pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
-    && pip install ./helix_scripts-*-py3-none-any.whl \
+    && pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
     && rm ./helix_scripts-*-py3-none-any.whl
 
 FROM ubuntu.azurecr.io/ubuntu:26.04

--- a/src/ubuntu/26.04/helix/Dockerfile
+++ b/src/ubuntu/26.04/helix/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu.azurecr.io/ubuntu:26.04 AS venv
 ENV DEBIAN_FRONTEND=noninteractive
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 RUN apt-get update \
     && apt-get install -y \
@@ -22,7 +23,8 @@ RUN python3 -m venv /venv \
 
 FROM ubuntu.azurecr.io/ubuntu:26.04
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 ARG TARGETARCH
 ARG LIBMSQUIC_VERSION=2.5.6
 ENV DEBIAN_FRONTEND=noninteractive

--- a/src/ubuntu/26.04/helix/Dockerfile
+++ b/src/ubuntu/26.04/helix/Dockerfile
@@ -1,5 +1,6 @@
 FROM ubuntu.azurecr.io/ubuntu:26.04 AS venv
 ENV DEBIAN_FRONTEND=noninteractive
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
 
 RUN apt-get update \
     && apt-get install -y \
@@ -15,11 +16,13 @@ RUN apt-get update \
 
 RUN python3 -m venv /venv \
     && . /venv/bin/activate \
-    && pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
-    && pip install ./helix_scripts-*-py3-none-any.whl --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple \
+    && pip download --no-deps helix-scripts \
+    && pip install ./helix_scripts-*-py3-none-any.whl \
     && rm ./helix_scripts-*-py3-none-any.whl
 
 FROM ubuntu.azurecr.io/ubuntu:26.04
+
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
 ARG TARGETARCH
 ARG LIBMSQUIC_VERSION=2.5.6
 ENV DEBIAN_FRONTEND=noninteractive

--- a/src/windowsservercore/ltsc2019/helix/amd64/Dockerfile
+++ b/src/windowsservercore/ltsc2019/helix/amd64/Dockerfile
@@ -28,7 +28,8 @@ RUN powershell -Command " `
         Remove-Item -Recurse -Force $pythonTemp; `
         Remove-Item -Force $pythonZip;"
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 # Install Helix
 RUN powershell -Command " `
@@ -58,7 +59,8 @@ RUN powershell -Command " `
 
 FROM mcr.microsoft.com/windows/servercore:ltsc2019
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 USER ContainerAdministrator
 

--- a/src/windowsservercore/ltsc2019/helix/amd64/Dockerfile
+++ b/src/windowsservercore/ltsc2019/helix/amd64/Dockerfile
@@ -28,7 +28,7 @@ RUN powershell -Command " `
         Remove-Item -Recurse -Force $pythonTemp; `
         Remove-Item -Force $pythonZip;"
 
-ARG PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
 
 # Install Helix
 RUN powershell -Command " `
@@ -40,14 +40,14 @@ RUN powershell -Command " `
             echo \"Failed to create Python virtual environment\"; `
             exit 1; `
         } `
-        & pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple; `
+        & pip download --no-deps helix-scripts; `
         if ($LASTEXITCODE -ne 0) { `
             echo \"Failed to download Helix scripts\"; `
             exit 1; `
         } `
         Get-ChildItem -Path $helixTemp -Filter 'helix_scripts-*-py3-none-any.whl' | `
             ForEach-Object { `
-                & pip install $_.FullName --no-cache-dir --index-url $env:PIP_INDEX_URL; `
+                & pip install $_.FullName --no-cache-dir; `
                 if ($LASTEXITCODE -ne 0) { `
                     echo \"Failed to install Helix script: $($_.Name)\"; `
                     exit 1; `
@@ -57,6 +57,8 @@ RUN powershell -Command " `
         Remove-Item -Recurse -Force $helixTemp;"
 
 FROM mcr.microsoft.com/windows/servercore:ltsc2019
+
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
 
 USER ContainerAdministrator
 

--- a/src/windowsservercore/ltsc2019/helix/amd64/Dockerfile
+++ b/src/windowsservercore/ltsc2019/helix/amd64/Dockerfile
@@ -28,7 +28,7 @@ RUN powershell -Command " `
         Remove-Item -Recurse -Force $pythonTemp; `
         Remove-Item -Force $pythonZip;"
 
-ARG PIP_INDEX_URL=https://pypi.org/simple
+ARG PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
 
 # Install Helix
 RUN powershell -Command " `
@@ -47,7 +47,7 @@ RUN powershell -Command " `
         } `
         Get-ChildItem -Path $helixTemp -Filter 'helix_scripts-*-py3-none-any.whl' | `
             ForEach-Object { `
-                & pip install $_.FullName --no-cache-dir; `
+                & pip install $_.FullName --no-cache-dir --index-url $env:PIP_INDEX_URL; `
                 if ($LASTEXITCODE -ne 0) { `
                     echo \"Failed to install Helix script: $($_.Name)\"; `
                     exit 1; `

--- a/src/windowsservercore/ltsc2022/helix/amd64/Dockerfile
+++ b/src/windowsservercore/ltsc2022/helix/amd64/Dockerfile
@@ -28,7 +28,7 @@ RUN powershell -Command " `
         Remove-Item -Recurse -Force $pythonTemp; `
         Remove-Item -Force $pythonZip;"
 
-ARG PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
 
 # Install Helix
 RUN powershell -Command " `
@@ -40,14 +40,14 @@ RUN powershell -Command " `
             echo \"Failed to create Python virtual environment\"; `
             exit 1; `
         } `
-        & pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple; `
+        & pip download --no-deps helix-scripts; `
         if ($LASTEXITCODE -ne 0) { `
             echo \"Failed to download Helix scripts\"; `
             exit 1; `
         } `
         Get-ChildItem -Path $helixTemp -Filter 'helix_scripts-*-py3-none-any.whl' | `
             ForEach-Object { `
-                & pip install $_.FullName --no-cache-dir --index-url $env:PIP_INDEX_URL; `
+                & pip install $_.FullName --no-cache-dir; `
                 if ($LASTEXITCODE -ne 0) { `
                     echo \"Failed to install Helix script: $($_.Name)\"; `
                     exit 1; `
@@ -57,6 +57,8 @@ RUN powershell -Command " `
         Remove-Item -Recurse -Force $helixTemp;"
 
 FROM mcr.microsoft.com/windows/servercore:ltsc2022
+
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
 
 USER ContainerAdministrator
 

--- a/src/windowsservercore/ltsc2022/helix/amd64/Dockerfile
+++ b/src/windowsservercore/ltsc2022/helix/amd64/Dockerfile
@@ -28,7 +28,8 @@ RUN powershell -Command " `
         Remove-Item -Recurse -Force $pythonTemp; `
         Remove-Item -Force $pythonZip;"
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 # Install Helix
 RUN powershell -Command " `
@@ -58,7 +59,8 @@ RUN powershell -Command " `
 
 FROM mcr.microsoft.com/windows/servercore:ltsc2022
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 USER ContainerAdministrator
 

--- a/src/windowsservercore/ltsc2022/helix/amd64/Dockerfile
+++ b/src/windowsservercore/ltsc2022/helix/amd64/Dockerfile
@@ -28,7 +28,7 @@ RUN powershell -Command " `
         Remove-Item -Recurse -Force $pythonTemp; `
         Remove-Item -Force $pythonZip;"
 
-ARG PIP_INDEX_URL=https://pypi.org/simple
+ARG PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
 
 # Install Helix
 RUN powershell -Command " `
@@ -47,7 +47,7 @@ RUN powershell -Command " `
         } `
         Get-ChildItem -Path $helixTemp -Filter 'helix_scripts-*-py3-none-any.whl' | `
             ForEach-Object { `
-                & pip install $_.FullName --no-cache-dir; `
+                & pip install $_.FullName --no-cache-dir --index-url $env:PIP_INDEX_URL; `
                 if ($LASTEXITCODE -ne 0) { `
                     echo \"Failed to install Helix script: $($_.Name)\"; `
                     exit 1; `

--- a/src/windowsservercore/ltsc2025/helix/amd64/Dockerfile
+++ b/src/windowsservercore/ltsc2025/helix/amd64/Dockerfile
@@ -28,7 +28,8 @@ RUN powershell -Command " `
         Remove-Item -Recurse -Force $pythonTemp; `
         Remove-Item -Force $pythonZip;"
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 # Install Helix
 RUN powershell -Command " `
@@ -58,7 +59,8 @@ RUN powershell -Command " `
 
 FROM mcr.microsoft.com/windows/servercore:ltsc2025
 
-ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 USER ContainerAdministrator
 

--- a/src/windowsservercore/ltsc2025/helix/amd64/Dockerfile
+++ b/src/windowsservercore/ltsc2025/helix/amd64/Dockerfile
@@ -28,7 +28,7 @@ RUN powershell -Command " `
         Remove-Item -Recurse -Force $pythonTemp; `
         Remove-Item -Force $pythonZip;"
 
-ARG PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
 
 # Install Helix
 RUN powershell -Command " `
@@ -40,14 +40,14 @@ RUN powershell -Command " `
             echo \"Failed to create Python virtual environment\"; `
             exit 1; `
         } `
-        & pip download --no-deps helix-scripts --index-url https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple; `
+        & pip download --no-deps helix-scripts; `
         if ($LASTEXITCODE -ne 0) { `
             echo \"Failed to download Helix scripts\"; `
             exit 1; `
         } `
         Get-ChildItem -Path $helixTemp -Filter 'helix_scripts-*-py3-none-any.whl' | `
             ForEach-Object { `
-                & pip install $_.FullName --no-cache-dir --index-url $env:PIP_INDEX_URL; `
+                & pip install $_.FullName --no-cache-dir; `
                 if ($LASTEXITCODE -ne 0) { `
                     echo \"Failed to install Helix script: $($_.Name)\"; `
                     exit 1; `
@@ -57,6 +57,8 @@ RUN powershell -Command " `
         Remove-Item -Recurse -Force $helixTemp;"
 
 FROM mcr.microsoft.com/windows/servercore:ltsc2025
+
+ENV PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
 
 USER ContainerAdministrator
 

--- a/src/windowsservercore/ltsc2025/helix/amd64/Dockerfile
+++ b/src/windowsservercore/ltsc2025/helix/amd64/Dockerfile
@@ -28,7 +28,7 @@ RUN powershell -Command " `
         Remove-Item -Recurse -Force $pythonTemp; `
         Remove-Item -Force $pythonZip;"
 
-ARG PIP_INDEX_URL=https://pypi.org/simple
+ARG PIP_INDEX_URL=https://dnceng.pkgs.visualstudio.com/public/_packaging/helix-client-prod/pypi/simple
 
 # Install Helix
 RUN powershell -Command " `
@@ -47,7 +47,7 @@ RUN powershell -Command " `
         } `
         Get-ChildItem -Path $helixTemp -Filter 'helix_scripts-*-py3-none-any.whl' | `
             ForEach-Object { `
-                & pip install $_.FullName --no-cache-dir; `
+                & pip install $_.FullName --no-cache-dir --index-url $env:PIP_INDEX_URL; `
                 if ($LASTEXITCODE -ne 0) { `
                     echo \"Failed to install Helix script: $($_.Name)\"; `
                     exit 1; `


### PR DESCRIPTION
Since network isolation is now on forcefully, we found out that some parts of the build have been using `pypi.org` (transparently) still:
- Helix installation
- emsdk codepaths

This PR makes it so that the feed is set from an ENV and also correctly authenticated.

Further, the helix feed also has the dotnet-public set as an upstream.