### PR TITLE
Install ninja in .net8.0

### DIFF
--- a/src/azurelinux/3.0/net8.0/crossdeps/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/crossdeps/amd64/Dockerfile
@@ -17,6 +17,7 @@ RUN tdnf update -y && \
         gcc \
         make \
         cmake \
+        ninja-build \
         pkg-config \
         diffutils \
         icu \


### PR DESCRIPTION
This is needed by dotnet/diagnostics where we use new native infra on lowest LTS.