### PR TITLE
Install Microsoft.AITools.BinlogMcp from dotnet-public

### DIFF
--- a/eng/renovate.json
+++ b/eng/renovate.json
@@ -95,7 +95,7 @@
       ],
       "depNameTemplate": "Microsoft.AITools.BinlogMcp",
       "datasourceTemplate": "nuget",
-      "registryUrlTemplate": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json"
+      "registryUrlTemplate": "https://api.nuget.org/v3/index.json"
     }
   ],
   "packageRules": [
@@ -121,13 +121,6 @@
         "**/net11.0/**"
       ],
       "enabled": true
-    },
-    {
-      "description": "Allow pre-release updates for Microsoft.AITools.BinlogMcp (only preview versions are currently published)",
-      "matchDepNames": [
-        "Microsoft.AITools.BinlogMcp"
-      ],
-      "ignoreUnstable": false
     }
   ],
   "postUpgradeTasks": {

--- a/eng/renovate.json
+++ b/eng/renovate.json
@@ -95,7 +95,7 @@
       ],
       "depNameTemplate": "Microsoft.AITools.BinlogMcp",
       "datasourceTemplate": "nuget",
-      "registryUrlTemplate": "https://api.nuget.org/v3/index.json"
+      "registryUrlTemplate": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json"
     }
   ],
   "packageRules": [

--- a/src/azurelinux/3.0/binlog-mcp/amd64/Dockerfile
+++ b/src/azurelinux/3.0/binlog-mcp/amd64/Dockerfile
@@ -7,6 +7,7 @@
 #             mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-binlog-mcp-amd64
 
 ARG BINLOG_MCP_VERSION=1.0.0
+ARG DOTNET_TOOLS_FEED=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json
 
 # Stage 1: Use the .NET SDK to install the tool. The SDK is required because
 # `dotnet tool install` is not available in distroless runtime images.
@@ -15,11 +16,13 @@ ARG BINLOG_MCP_VERSION=1.0.0
 FROM mcr.microsoft.com/dotnet/sdk:10.0-azurelinux3.0 AS builder
 
 ARG BINLOG_MCP_VERSION
+ARG DOTNET_TOOLS_FEED
 
 RUN dotnet tool install \
         --tool-path /tools \
         Microsoft.AITools.BinlogMcp \
-        --version ${BINLOG_MCP_VERSION}
+        --version ${BINLOG_MCP_VERSION} \
+        --add-source ${DOTNET_TOOLS_FEED}
 
 # Stage 2: Copy the installed tool into a distroless runtime image to minimise
 # attack surface (no shell, no package manager). Per maintainer guidance on #1659.

--- a/src/azurelinux/3.0/binlog-mcp/amd64/Dockerfile
+++ b/src/azurelinux/3.0/binlog-mcp/amd64/Dockerfile
@@ -6,8 +6,7 @@
 # Usage:  docker run --rm -i -v /path/to/binlogs:/binlogs \
 #             mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-binlog-mcp-amd64
 
-ARG BINLOG_MCP_VERSION=1.0.0-preview.26304.3
-ARG DOTNET_TOOLS_FEED=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
+ARG BINLOG_MCP_VERSION=1.0.0
 
 # Stage 1: Use the .NET SDK to install the tool. The SDK is required because
 # `dotnet tool install` is not available in distroless runtime images.
@@ -16,13 +15,11 @@ ARG DOTNET_TOOLS_FEED=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet
 FROM mcr.microsoft.com/dotnet/sdk:10.0-azurelinux3.0 AS builder
 
 ARG BINLOG_MCP_VERSION
-ARG DOTNET_TOOLS_FEED
 
 RUN dotnet tool install \
         --tool-path /tools \
         Microsoft.AITools.BinlogMcp \
-        --version ${BINLOG_MCP_VERSION} \
-        --add-source ${DOTNET_TOOLS_FEED}
+        --version ${BINLOG_MCP_VERSION}
 
 # Stage 2: Copy the installed tool into a distroless runtime image to minimise
 # attack surface (no shell, no package manager). Per maintainer guidance on #1659.


### PR DESCRIPTION
The `Microsoft.AITools.BinlogMcp` package is now published on [nuget.org](https://www.nuget.org/packages/Microsoft.AITools.BinlogMcp) as stable `1.0.0`, so the `binlog-mcp` container image no longer needs the dnceng AzDO `dotnet-tools` feed.

## Changes
- **src/azurelinux/3.0/binlog-mcp/amd64/Dockerfile** — pin `BINLOG_MCP_VERSION` to stable `1.0.0` and remove the `DOTNET_TOOLS_FEED` ARG and `--add-source` (nuget.org is the default source). The previously pinned `1.0.0-preview.*` version only exists on the AzDO feed.
- **eng/renovate.json** — point the `Microsoft.AITools.BinlogMcp` `registryUrlTemplate` to `https://api.nuget.org/v3/index.json` and drop the now-obsolete pre-release allowance packageRule (stable versions are now published).