### PR TITLE
Continue CI if some builds fail

### DIFF
--- a/eng/docker-tools/templates/stages/build-and-test.yml
+++ b/eng/docker-tools/templates/stages/build-and-test.yml
@@ -54,7 +54,7 @@ parameters:
 ################################################################################
 stages:
 - stage: Build
-  condition: and(succeeded(), contains(variables['stages'], 'build'))
+  condition: and(succeededOrFailed(), contains(variables['stages'], 'build'))
   dependsOn: []
   jobs:
 

--- a/src/almalinux/10/helix/amd64/Dockerfile
+++ b/src/almalinux/10/helix/amd64/Dockerfile
@@ -14,7 +14,7 @@ RUN dnf upgrade --refresh -y \
 
 RUN python3 -m venv /venv \
     && . /venv/bin/activate \
-    && pip download --no-deps --index-url $HELIX_FEED --extra-index-url $PIP_INDEX_URL helix-scripts \
+    && pip download --no-deps --index-url $HELIX_FEED helix-scripts \
     && pip install --index-url $PIP_INDEX_URL ./helix_scripts-*-py3-none-any.whl \
     && rm ./helix_scripts-*-py3-none-any.whl
 

--- a/src/almalinux/8/helix/amd64/Dockerfile
+++ b/src/almalinux/8/helix/amd64/Dockerfile
@@ -39,7 +39,7 @@ ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
 
 RUN python -m venv $VIRTUAL_ENV && \
     ${VIRTUAL_ENV}/bin/pip install --upgrade pip setuptools && \
-    ${VIRTUAL_ENV}/bin/pip download --no-deps --index-url $HELIX_FEED --extra-index-url $PIP_INDEX_URL helix-scripts && \
+    ${VIRTUAL_ENV}/bin/pip download --no-deps --index-url $HELIX_FEED helix-scripts && \
     ${VIRTUAL_ENV}/bin/pip install --index-url $PIP_INDEX_URL ./helix_scripts-*-py3-none-any.whl && \
     rm ./helix_scripts-*-py3-none-any.whl
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"

--- a/src/almalinux/9/helix/amd64/Dockerfile
+++ b/src/almalinux/9/helix/amd64/Dockerfile
@@ -15,7 +15,7 @@ RUN dnf upgrade --refresh -y \
 RUN python3 -m venv /venv \
     && . /venv/bin/activate \
     && pip install --upgrade pip setuptools \
-    && pip download --no-deps --index-url $HELIX_FEED --extra-index-url $PIP_INDEX_URL helix-scripts \
+    && pip download --no-deps --index-url $HELIX_FEED helix-scripts \
     && pip install --index-url $PIP_INDEX_URL ./helix_scripts-*-py3-none-any.whl \
     && rm ./helix_scripts-*-py3-none-any.whl
 

--- a/src/alpine/3.23/helix/Dockerfile
+++ b/src/alpine/3.23/helix/Dockerfile
@@ -15,7 +15,7 @@ RUN apk add --upgrade --no-cache \
 
 RUN python3 -m venv /venv && \
         source /venv/bin/activate && \
-        pip download --no-deps --index-url $HELIX_FEED --extra-index-url $PIP_INDEX_URL helix-scripts && \
+        pip download --no-deps --index-url $HELIX_FEED helix-scripts && \
         pip install --index-url $PIP_INDEX_URL ./helix_scripts-*-py3-none-any.whl && \
         rm ./helix_scripts-*-py3-none-any.whl
 

--- a/src/alpine/3.24/helix/Dockerfile
+++ b/src/alpine/3.24/helix/Dockerfile
@@ -15,7 +15,7 @@ RUN apk add --upgrade --no-cache \
 
 RUN python3 -m venv /venv && \
         source /venv/bin/activate && \
-        pip download --no-deps --index-url $HELIX_FEED --extra-index-url $PIP_INDEX_URL helix-scripts && \
+        pip download --no-deps --index-url $HELIX_FEED helix-scripts && \
         pip install --index-url $PIP_INDEX_URL ./helix_scripts-*-py3-none-any.whl && \
         rm ./helix_scripts-*-py3-none-any.whl
 

--- a/src/alpine/edge/helix/Dockerfile
+++ b/src/alpine/edge/helix/Dockerfile
@@ -15,7 +15,7 @@ RUN apk add --upgrade --no-cache \
 
 RUN python3 -m venv /venv && \
         source /venv/bin/activate && \
-        pip download --no-deps --index-url $HELIX_FEED --extra-index-url $PIP_INDEX_URL helix-scripts && \
+        pip download --no-deps --index-url $HELIX_FEED helix-scripts && \
         pip install --index-url $PIP_INDEX_URL ./helix_scripts-*-py3-none-any.whl && \
         rm ./helix_scripts-*-py3-none-any.whl
 

--- a/src/azurelinux/3.0/helix/Dockerfile
+++ b/src/azurelinux/3.0/helix/Dockerfile
@@ -15,7 +15,7 @@ RUN tdnf install --refresh -y \
 
 RUN python3 -m venv /venv && \
         source /venv/bin/activate && \
-        pip download --no-deps --index-url $HELIX_FEED --extra-index-url $PIP_INDEX_URL helix-scripts && \
+        pip download --no-deps --index-url $HELIX_FEED helix-scripts && \
         pip install --index-url $PIP_INDEX_URL ./helix_scripts-*-py3-none-any.whl && \
         rm ./helix_scripts-*-py3-none-any.whl
 

--- a/src/azurelinux/4.0/helix/Dockerfile
+++ b/src/azurelinux/4.0/helix/Dockerfile
@@ -13,7 +13,7 @@ RUN dnf install --refresh -y \
 
 RUN python3 -m venv /venv && \
         source /venv/bin/activate && \
-        pip download --no-deps --index-url $HELIX_FEED --extra-index-url $PIP_INDEX_URL helix-scripts && \
+        pip download --no-deps --index-url $HELIX_FEED helix-scripts && \
         pip install --index-url $PIP_INDEX_URL ./helix_scripts-*-py3-none-any.whl && \
         rm ./helix_scripts-*-py3-none-any.whl
 

--- a/src/centos-stream/10/helix/Dockerfile
+++ b/src/centos-stream/10/helix/Dockerfile
@@ -14,7 +14,7 @@ RUN dnf upgrade --refresh -y \
 
 RUN python3 -m venv /venv \
     && . /venv/bin/activate \
-    && pip download --no-deps --index-url $HELIX_FEED --extra-index-url $PIP_INDEX_URL helix-scripts \
+    && pip download --no-deps --index-url $HELIX_FEED helix-scripts \
     && pip install --index-url $PIP_INDEX_URL ./helix_scripts-*-py3-none-any.whl \
     && rm ./helix_scripts-*-py3-none-any.whl
 

--- a/src/centos-stream/9/helix/amd64/Dockerfile
+++ b/src/centos-stream/9/helix/amd64/Dockerfile
@@ -56,7 +56,7 @@ ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
 
 RUN python -m venv $VIRTUAL_ENV && \
     ${VIRTUAL_ENV}/bin/pip install --upgrade pip setuptools && \
-    ${VIRTUAL_ENV}/bin/pip download --no-deps --index-url $HELIX_FEED --extra-index-url $PIP_INDEX_URL helix-scripts && \
+    ${VIRTUAL_ENV}/bin/pip download --no-deps --index-url $HELIX_FEED helix-scripts && \
     ${VIRTUAL_ENV}/bin/pip install --index-url $PIP_INDEX_URL ./helix_scripts-*-py3-none-any.whl && \
     rm ./helix_scripts-*-py3-none-any.whl
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"

--- a/src/centos-stream/9/mlnet/helix/amd64/Dockerfile
+++ b/src/centos-stream/9/mlnet/helix/amd64/Dockerfile
@@ -101,7 +101,7 @@ ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
 
 RUN python -m venv $VIRTUAL_ENV && \
     ${VIRTUAL_ENV}/bin/pip install --upgrade pip setuptools && \
-    ${VIRTUAL_ENV}/bin/pip download --no-deps --index-url $HELIX_FEED --extra-index-url $PIP_INDEX_URL helix-scripts && \
+    ${VIRTUAL_ENV}/bin/pip download --no-deps --index-url $HELIX_FEED helix-scripts && \
     ${VIRTUAL_ENV}/bin/pip install --index-url $PIP_INDEX_URL ./helix_scripts-*-py3-none-any.whl && \
     rm ./helix_scripts-*-py3-none-any.whl
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"

--- a/src/debian/12/helix/amd64/Dockerfile
+++ b/src/debian/12/helix/amd64/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update \
 RUN python3 -m venv /venv \
     && . /venv/bin/activate \
     && pip install --upgrade pip setuptools \
-    && pip download --no-deps --index-url $HELIX_FEED --extra-index-url $PIP_INDEX_URL helix-scripts \
+    && pip download --no-deps --index-url $HELIX_FEED helix-scripts \
     && pip install --index-url $PIP_INDEX_URL ./helix_scripts-*-py3-none-any.whl \
     && rm ./helix_scripts-*-py3-none-any.whl
 

--- a/src/debian/12/helix/arm32v7/Dockerfile
+++ b/src/debian/12/helix/arm32v7/Dockerfile
@@ -25,7 +25,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 RUN python3 -m venv /venv \
     && . /venv/bin/activate \
     && pip install --upgrade pip setuptools \
-    && pip download --no-deps --index-url $HELIX_FEED --extra-index-url $PIP_INDEX_URL helix-scripts \
+    && pip download --no-deps --index-url $HELIX_FEED helix-scripts \
     && pip install --index-url $PIP_INDEX_URL ./helix_scripts-*-py3-none-any.whl \
     && rm ./helix_scripts-*-py3-none-any.whl
 

--- a/src/debian/12/helix/arm64v8/Dockerfile
+++ b/src/debian/12/helix/arm64v8/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update \
 RUN python3 -m venv /venv \
     && . /venv/bin/activate \
     && pip install --upgrade pip setuptools \
-    && pip download --no-deps --index-url $HELIX_FEED --extra-index-url $PIP_INDEX_URL helix-scripts \
+    && pip download --no-deps --index-url $HELIX_FEED helix-scripts \
     && pip install --index-url $PIP_INDEX_URL ./helix_scripts-*-py3-none-any.whl \
     && rm ./helix_scripts-*-py3-none-any.whl
 

--- a/src/debian/13/helix/Dockerfile
+++ b/src/debian/13/helix/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update \
 
 RUN python3 -m venv /venv \
     && . /venv/bin/activate \
-    && pip download --no-deps --index-url $HELIX_FEED --extra-index-url $PIP_INDEX_URL helix-scripts \
+    && pip download --no-deps --index-url $HELIX_FEED helix-scripts \
     && pip install --index-url $PIP_INDEX_URL ./helix_scripts-*-py3-none-any.whl \
     && rm ./helix_scripts-*-py3-none-any.whl
 

--- a/src/fedora/42/helix/amd64/Dockerfile
+++ b/src/fedora/42/helix/amd64/Dockerfile
@@ -18,7 +18,7 @@ RUN dnf upgrade --refresh -y \
 
 RUN python3 -m venv /venv \
     && source /venv/bin/activate \
-    && pip download --no-deps --index-url $HELIX_FEED --extra-index-url $PIP_INDEX_URL helix-scripts \
+    && pip download --no-deps --index-url $HELIX_FEED helix-scripts \
     && pip install --index-url $PIP_INDEX_URL ./helix_scripts-*-py3-none-any.whl \
     && rm ./helix_scripts-*-py3-none-any.whl
 

--- a/src/fedora/43/helix/amd64/Dockerfile
+++ b/src/fedora/43/helix/amd64/Dockerfile
@@ -18,7 +18,7 @@ RUN dnf upgrade --refresh -y \
 
 RUN python3 -m venv /venv \
     && source /venv/bin/activate \
-    && pip download --no-deps --index-url $HELIX_FEED --extra-index-url $PIP_INDEX_URL helix-scripts \
+    && pip download --no-deps --index-url $HELIX_FEED helix-scripts \
     && pip install --index-url $PIP_INDEX_URL ./helix_scripts-*-py3-none-any.whl \
     && rm ./helix_scripts-*-py3-none-any.whl
 

--- a/src/fedora/44/helix/amd64/Dockerfile
+++ b/src/fedora/44/helix/amd64/Dockerfile
@@ -18,7 +18,7 @@ RUN dnf upgrade --refresh -y \
 
 RUN python3 -m venv /venv \
     && source /venv/bin/activate \
-    && pip download --no-deps --index-url $HELIX_FEED --extra-index-url $PIP_INDEX_URL helix-scripts \
+    && pip download --no-deps --index-url $HELIX_FEED helix-scripts \
     && pip install --index-url $PIP_INDEX_URL ./helix_scripts-*-py3-none-any.whl \
     && rm ./helix_scripts-*-py3-none-any.whl
 

--- a/src/fedora/45/helix/amd64/Dockerfile
+++ b/src/fedora/45/helix/amd64/Dockerfile
@@ -20,7 +20,7 @@ RUN dnf upgrade --refresh -y \
 
 RUN python3.14 -m venv /venv \
     && source /venv/bin/activate \
-    && pip download --no-deps --index-url $HELIX_FEED --extra-index-url $PIP_INDEX_URL helix-scripts \
+    && pip download --no-deps --index-url $HELIX_FEED helix-scripts \
     && pip install --index-url $PIP_INDEX_URL ./helix_scripts-*-py3-none-any.whl \
     && rm ./helix_scripts-*-py3-none-any.whl
 

--- a/src/fedora/rawhide/helix/amd64/Dockerfile
+++ b/src/fedora/rawhide/helix/amd64/Dockerfile
@@ -20,7 +20,7 @@ RUN dnf upgrade --refresh -y \
 
 RUN python3.14 -m venv /venv \
     && source /venv/bin/activate \
-    && pip download --no-deps --index-url $HELIX_FEED --extra-index-url $PIP_INDEX_URL helix-scripts \
+    && pip download --no-deps --index-url $HELIX_FEED helix-scripts \
     && pip install --index-url $PIP_INDEX_URL ./helix_scripts-*-py3-none-any.whl \
     && rm ./helix_scripts-*-py3-none-any.whl
 

--- a/src/opensuse/16.0/helix/amd64/Dockerfile
+++ b/src/opensuse/16.0/helix/amd64/Dockerfile
@@ -58,7 +58,7 @@ WORKDIR /home/helixbot
 ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
 
 RUN python -m venv $VIRTUAL_ENV && \
-    ${VIRTUAL_ENV}/bin/pip download --no-deps --index-url $HELIX_FEED --extra-index-url $PIP_INDEX_URL helix-scripts && \
+    ${VIRTUAL_ENV}/bin/pip download --no-deps --index-url $HELIX_FEED helix-scripts && \
     ${VIRTUAL_ENV}/bin/pip install --index-url $PIP_INDEX_URL ./helix_scripts-*-py3-none-any.whl && \
     rm ./helix_scripts-*-py3-none-any.whl
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"

--- a/src/ubuntu/22.04/helix/Dockerfile
+++ b/src/ubuntu/22.04/helix/Dockerfile
@@ -65,7 +65,7 @@ ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
 
 RUN python -m venv /home/helixbot/.vsts-env && \
     ${VIRTUAL_ENV}/bin/pip install --upgrade pip setuptools && \
-    ${VIRTUAL_ENV}/bin/pip download --no-deps --index-url $HELIX_FEED --extra-index-url $PIP_INDEX_URL helix-scripts && \
+    ${VIRTUAL_ENV}/bin/pip download --no-deps --index-url $HELIX_FEED helix-scripts && \
     ${VIRTUAL_ENV}/bin/pip install --index-url $PIP_INDEX_URL ./helix_scripts-*-py3-none-any.whl && \
     rm ./helix_scripts-*-py3-none-any.whl
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"

--- a/src/ubuntu/22.04/mlnet/helix/amd64/Dockerfile
+++ b/src/ubuntu/22.04/mlnet/helix/amd64/Dockerfile
@@ -24,7 +24,7 @@ ENV VIRTUAL_ENV=/home/helixbot/.vsts-env
 
 RUN python -m venv $VIRTUAL_ENV && \
     ${VIRTUAL_ENV}/bin/pip install --upgrade pip setuptools && \
-    ${VIRTUAL_ENV}/bin/pip download --no-deps --index-url $HELIX_FEED --extra-index-url $PIP_INDEX_URL helix-scripts && \
+    ${VIRTUAL_ENV}/bin/pip download --no-deps --index-url $HELIX_FEED helix-scripts && \
     ${VIRTUAL_ENV}/bin/pip install --index-url $PIP_INDEX_URL ./helix_scripts-*-py3-none-any.whl && \
     rm ./helix_scripts-*-py3-none-any.whl
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"

--- a/src/ubuntu/24.04/helix/Dockerfile
+++ b/src/ubuntu/24.04/helix/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && \
 
 RUN python3 -m venv /venv && \
     . /venv/bin/activate && \
-    pip download --no-deps --index-url $HELIX_FEED --extra-index-url $PIP_INDEX_URL helix-scripts && \
+    pip download --no-deps --index-url $HELIX_FEED helix-scripts && \
     pip install --index-url $PIP_INDEX_URL ./helix_scripts-*-py3-none-any.whl && \
     rm ./helix_scripts-*-py3-none-any.whl
 

--- a/src/ubuntu/24.04/helix/android/amd64/Dockerfile
+++ b/src/ubuntu/24.04/helix/android/amd64/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && \
 
 RUN python3 -m venv /venv && \
     . /venv/bin/activate && \
-    pip download --no-deps --index-url $HELIX_FEED --extra-index-url $PIP_INDEX_URL helix-scripts && \
+    pip download --no-deps --index-url $HELIX_FEED helix-scripts && \
     pip install --index-url $PIP_INDEX_URL ./helix_scripts-*-py3-none-any.whl && \
     rm ./helix_scripts-*-py3-none-any.whl
 

--- a/src/ubuntu/26.04/helix/Dockerfile
+++ b/src/ubuntu/26.04/helix/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update \
 
 RUN python3 -m venv /venv \
     && . /venv/bin/activate \
-    && pip download --no-deps --index-url $HELIX_FEED --extra-index-url $PIP_INDEX_URL helix-scripts \
+    && pip download --no-deps --index-url $HELIX_FEED helix-scripts \
     && pip install --index-url $PIP_INDEX_URL ./helix_scripts-*-py3-none-any.whl \
     && rm ./helix_scripts-*-py3-none-any.whl
 


### PR DESCRIPTION
`--extra-index-url` is not allowed by a CFS policy and I don't think we even need it because of the `--no-deps` we provide.