### PR TITLE
Fix binlog-mcp network isolation: replace nuget.org source with dotnet-public

### DIFF
--- a/src/azurelinux/3.0/binlog-mcp/amd64/Dockerfile
+++ b/src/azurelinux/3.0/binlog-mcp/amd64/Dockerfile
@@ -7,7 +7,7 @@
 #             mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-binlog-mcp-amd64
 
 ARG BINLOG_MCP_VERSION=1.0.0
-ARG DOTNET_TOOLS_FEED=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json
+ARG DOTNET_PUBLIC_FEED=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json
 
 # Stage 1: Use the .NET SDK to install the tool. The SDK is required because
 # `dotnet tool install` is not available in distroless runtime images.
@@ -16,18 +16,17 @@ ARG DOTNET_TOOLS_FEED=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet
 FROM mcr.microsoft.com/dotnet/sdk:10.0-azurelinux3.0 AS builder
 
 ARG BINLOG_MCP_VERSION
-ARG DOTNET_TOOLS_FEED
+ARG DOTNET_PUBLIC_FEED
 
 # The SDK image ships a default NuGet.Config whose only source is nuget.org,
-# which is unreachable from the network-isolated build environment. Replace it
-# with the dnceng dotnet-public feed (a nuget.org mirror) before restoring.
-RUN dotnet nuget remove source nuget.org && \
-    dotnet nuget add source ${DOTNET_TOOLS_FEED} --name dotnet-public
-
+# which is unreachable from the network-isolated build environment. `--source`
+# replaces all configured sources with the dnceng dotnet-public feed (a
+# nuget.org mirror) so restore never reaches out to nuget.org.
 RUN dotnet tool install \
         --tool-path /tools \
         Microsoft.AITools.BinlogMcp \
-        --version ${BINLOG_MCP_VERSION}
+        --version ${BINLOG_MCP_VERSION} \
+        --source ${DOTNET_PUBLIC_FEED}
 
 # Stage 2: Copy the installed tool into a distroless runtime image to minimise
 # attack surface (no shell, no package manager). Per maintainer guidance on #1659.

--- a/src/azurelinux/3.0/binlog-mcp/amd64/Dockerfile
+++ b/src/azurelinux/3.0/binlog-mcp/amd64/Dockerfile
@@ -18,11 +18,16 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0-azurelinux3.0 AS builder
 ARG BINLOG_MCP_VERSION
 ARG DOTNET_TOOLS_FEED
 
+# The SDK image ships a default NuGet.Config whose only source is nuget.org,
+# which is unreachable from the network-isolated build environment. Replace it
+# with the dnceng dotnet-public feed (a nuget.org mirror) before restoring.
+RUN dotnet nuget remove source nuget.org && \
+    dotnet nuget add source ${DOTNET_TOOLS_FEED} --name dotnet-public
+
 RUN dotnet tool install \
         --tool-path /tools \
         Microsoft.AITools.BinlogMcp \
-        --version ${BINLOG_MCP_VERSION} \
-        --add-source ${DOTNET_TOOLS_FEED}
+        --version ${BINLOG_MCP_VERSION}
 
 # Stage 2: Copy the installed tool into a distroless runtime image to minimise
 # attack surface (no shell, no package manager). Per maintainer guidance on #1659.


### PR DESCRIPTION
## Problem
The `binlog-mcp` builder stage installs `Microsoft.AITools.BinlogMcp` using the `mcr.microsoft.com/dotnet/sdk:10.0-azurelinux3.0` image. That image ships a default `NuGet.Config` whose **only** source is `nuget.org` (`https://api.nuget.org/v3/index.json`), which is unreachable from the network-isolated build environment.

PR #1682 switched to `--add-source ${DOTNET_TOOLS_FEED}`, but `--add-source` *adds* the dotnet-public feed **alongside** nuget.org rather than replacing it. `dotnet tool install` still attempts to reach nuget.org during restore, which fails under network isolation.

## Fix
Before installing the tool, remove the default nuget.org source and add the dnceng `dotnet-public` feed (a nuget.org mirror reachable in isolated builds):

```dockerfile
RUN dotnet nuget remove source nuget.org && \
    dotnet nuget add source ${DOTNET_TOOLS_FEED} --name dotnet-public
```

No version or feed-URL changes — `DOTNET_TOOLS_FEED` already points at dotnet-public from #1682.