### PR TITLE
Make the unofficial pipeline run all CFS policies too

### DIFF
--- a/eng/pipelines/dotnet-buildtools-prereqs-unofficial.yml
+++ b/eng/pipelines/dotnet-buildtools-prereqs-unofficial.yml
@@ -48,7 +48,7 @@ resources:
 extends:
   template: /eng/docker-tools/templates/1es.yml@self
   parameters:
-    networkIsolationPolicy: Permissive
+    networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3
     reposToExcludeFromScanning:
     - VersionsRepo
     stages:


### PR DESCRIPTION
The official pipeline runs all these policies.
This makes it so the unofficial one behaves the same
test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=3007893&view=logs&j=bc4d9f27-db58-50b9-8ba7-998cc0603856&t=e935d1dd-79a8-5be1-d06b-c54f6a04bb57