### PR TITLE
Add ubuntu repo override for azurelinux images

### DIFF
--- a/src/azurelinux/3.0/net10.0/cross/amd64-sanitizer/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/cross/amd64-sanitizer/Dockerfile
@@ -5,7 +5,7 @@ ARG ROOTFS_DIR
 
 # Use Ubuntu Bionic as the base image for the rootfs
 # to get a new enough libstdc++ for the sanitizer runtimes and instrumentation.
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x64 bionic --skipunmount --skipemulation
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x64 bionic --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
 
 RUN TARGET_TRIPLE="x86_64-linux-gnu" && \
     GCC_VER=$(basename "$(find "$ROOTFS_DIR/usr/include/c++/" -mindepth 1 -maxdepth 1 -type d | sort -V | head -n1)") && \

--- a/src/azurelinux/3.0/net10.0/cross/amd64-sanitizer/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/cross/amd64-sanitizer/Dockerfile
@@ -5,7 +5,7 @@ ARG ROOTFS_DIR
 
 # Use Ubuntu Bionic as the base image for the rootfs
 # to get a new enough libstdc++ for the sanitizer runtimes and instrumentation.
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x64 bionic --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x64 bionic --skipunmount --skipemulation --ubuntu-repo "http://azure.archive.ubuntu.com/ubuntu/"
 
 RUN TARGET_TRIPLE="x86_64-linux-gnu" && \
     GCC_VER=$(basename "$(find "$ROOTFS_DIR/usr/include/c++/" -mindepth 1 -maxdepth 1 -type d | sort -V | head -n1)") && \

--- a/src/azurelinux/3.0/net10.0/cross/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/cross/amd64/Dockerfile
@@ -3,7 +3,7 @@ ARG ROOTFS_DIR=/crossrootfs/x64
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x64 bionic --skipunmount --skipemulation
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x64 bionic --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
 
 RUN TARGET_TRIPLE="x86_64-linux-gnu" && \
     GCC_VER=$(basename "$(find "$ROOTFS_DIR/usr/include/c++/" -mindepth 1 -maxdepth 1 -type d | sort -V | head -n1)") && \

--- a/src/azurelinux/3.0/net10.0/cross/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/cross/amd64/Dockerfile
@@ -3,7 +3,7 @@ ARG ROOTFS_DIR=/crossrootfs/x64
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x64 bionic --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x64 bionic --skipunmount --skipemulation --ubuntu-repo "http://azure.archive.ubuntu.com/ubuntu/"
 
 RUN TARGET_TRIPLE="x86_64-linux-gnu" && \
     GCC_VER=$(basename "$(find "$ROOTFS_DIR/usr/include/c++/" -mindepth 1 -maxdepth 1 -type d | sort -V | head -n1)") && \

--- a/src/azurelinux/3.0/net10.0/cross/arm/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/cross/arm/Dockerfile
@@ -5,7 +5,7 @@ ARG ROOTFS_DIR
 
 # The arm rootfs targets Ubuntu 22.04, which is the first version with a
 # glibc that supports 64-bit time_t. See https://github.com/dotnet/core/discussions/9285.
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh arm jammy no-lldb --skipunmount --skipemulation
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh arm jammy no-lldb --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
 
 RUN TARGET_TRIPLE="arm-linux-gnueabihf" && \
     GCC_VER=$(basename "$(find "$ROOTFS_DIR/usr/include/c++/" -mindepth 1 -maxdepth 1 -type d | sort -V | head -n1)") && \

--- a/src/azurelinux/3.0/net10.0/cross/arm/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/cross/arm/Dockerfile
@@ -5,7 +5,7 @@ ARG ROOTFS_DIR
 
 # The arm rootfs targets Ubuntu 22.04, which is the first version with a
 # glibc that supports 64-bit time_t. See https://github.com/dotnet/core/discussions/9285.
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh arm jammy no-lldb --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh arm jammy no-lldb --skipunmount --skipemulation --ubuntu-repo "http://azure.archive.ubuntu.com/ubuntu/"
 
 RUN TARGET_TRIPLE="arm-linux-gnueabihf" && \
     GCC_VER=$(basename "$(find "$ROOTFS_DIR/usr/include/c++/" -mindepth 1 -maxdepth 1 -type d | sort -V | head -n1)") && \

--- a/src/azurelinux/3.0/net10.0/cross/arm64/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/cross/arm64/Dockerfile
@@ -3,7 +3,7 @@ ARG ROOTFS_DIR=/crossrootfs/arm64
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh arm64 bionic --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh arm64 bionic --skipunmount --skipemulation --ubuntu-repo "http://azure.archive.ubuntu.com/ubuntu/"
 
 RUN TARGET_TRIPLE="aarch64-linux-gnu" && \
     GCC_VER=$(basename "$(find "$ROOTFS_DIR/usr/include/c++/" -mindepth 1 -maxdepth 1 -type d | sort -V | head -n1)") && \

--- a/src/azurelinux/3.0/net10.0/cross/arm64/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/cross/arm64/Dockerfile
@@ -3,7 +3,7 @@ ARG ROOTFS_DIR=/crossrootfs/arm64
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh arm64 bionic --skipunmount --skipemulation
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh arm64 bionic --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
 
 RUN TARGET_TRIPLE="aarch64-linux-gnu" && \
     GCC_VER=$(basename "$(find "$ROOTFS_DIR/usr/include/c++/" -mindepth 1 -maxdepth 1 -type d | sort -V | head -n1)") && \

--- a/src/azurelinux/3.0/net10.0/cross/freebsd/14/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/cross/freebsd/14/amd64/Dockerfile
@@ -12,7 +12,7 @@ RUN tdnf makecache && \
     # so the FreeBSD bootstrap can find it. See https://github.com/microsoft/azurelinux/issues/9217
     ln -s /usr/lib/liblzma.so.5 /usr/lib/liblzma.so
 
-RUN /scripts/eng/common/cross/build-rootfs.sh freebsd14 x64 --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
+RUN /scripts/eng/common/cross/build-rootfs.sh freebsd14 x64 --ubuntu-repo "http://azure.archive.ubuntu.com/ubuntu/"
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR

--- a/src/azurelinux/3.0/net10.0/cross/freebsd/14/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/cross/freebsd/14/amd64/Dockerfile
@@ -12,7 +12,7 @@ RUN tdnf makecache && \
     # so the FreeBSD bootstrap can find it. See https://github.com/microsoft/azurelinux/issues/9217
     ln -s /usr/lib/liblzma.so.5 /usr/lib/liblzma.so
 
-RUN /scripts/eng/common/cross/build-rootfs.sh freebsd14 x64
+RUN /scripts/eng/common/cross/build-rootfs.sh freebsd14 x64 --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR

--- a/src/azurelinux/3.0/net10.0/cross/freebsd/14/arm64/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/cross/freebsd/14/arm64/Dockerfile
@@ -12,7 +12,7 @@ RUN tdnf makecache && \
     # so the FreeBSD bootstrap can find it. See https://github.com/microsoft/azurelinux/issues/9217
     && ln -s /usr/lib/liblzma.so.5 /usr/lib/liblzma.so
 
-RUN /scripts/eng/common/cross/build-rootfs.sh freebsd14 arm64
+RUN /scripts/eng/common/cross/build-rootfs.sh freebsd14 arm64 --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR

--- a/src/azurelinux/3.0/net10.0/cross/freebsd/14/arm64/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/cross/freebsd/14/arm64/Dockerfile
@@ -12,7 +12,7 @@ RUN tdnf makecache && \
     # so the FreeBSD bootstrap can find it. See https://github.com/microsoft/azurelinux/issues/9217
     && ln -s /usr/lib/liblzma.so.5 /usr/lib/liblzma.so
 
-RUN /scripts/eng/common/cross/build-rootfs.sh freebsd14 arm64 --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
+RUN /scripts/eng/common/cross/build-rootfs.sh freebsd14 arm64 --ubuntu-repo "http://azure.archive.ubuntu.com/ubuntu/"
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR

--- a/src/azurelinux/3.0/net10.0/cross/riscv64-musl/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/cross/riscv64-musl/Dockerfile
@@ -3,7 +3,7 @@ ARG ROOTFS_DIR=/crossrootfs/riscv64
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
-RUN SSL_CERT_FILE=/etc/pki/tls/certs/ca-bundle.crt /scripts/eng/common/cross/build-rootfs.sh riscv64 alpine3.20 --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
+RUN SSL_CERT_FILE=/etc/pki/tls/certs/ca-bundle.crt /scripts/eng/common/cross/build-rootfs.sh riscv64 alpine3.20 --skipunmount --skipemulation --ubuntu-repo "http://azure.archive.ubuntu.com/ubuntu/"
 
 RUN TARGET_TRIPLE="riscv64-alpine-linux-musl" && \
     GCC_VER=$(basename "$(find "$ROOTFS_DIR/usr/include/c++/" -mindepth 1 -maxdepth 1 -type d | sort -V | head -n1)") && \

--- a/src/azurelinux/3.0/net10.0/cross/riscv64-musl/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/cross/riscv64-musl/Dockerfile
@@ -3,7 +3,7 @@ ARG ROOTFS_DIR=/crossrootfs/riscv64
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
-RUN SSL_CERT_FILE=/etc/pki/tls/certs/ca-bundle.crt /scripts/eng/common/cross/build-rootfs.sh riscv64 alpine3.20 --skipunmount --skipemulation
+RUN SSL_CERT_FILE=/etc/pki/tls/certs/ca-bundle.crt /scripts/eng/common/cross/build-rootfs.sh riscv64 alpine3.20 --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
 
 RUN TARGET_TRIPLE="riscv64-alpine-linux-musl" && \
     GCC_VER=$(basename "$(find "$ROOTFS_DIR/usr/include/c++/" -mindepth 1 -maxdepth 1 -type d | sort -V | head -n1)") && \

--- a/src/azurelinux/3.0/net10.0/cross/x86/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/cross/x86/Dockerfile
@@ -5,7 +5,7 @@ ARG ROOTFS_DIR
 
 # We don't ship linux-x86 binaries, so we don't need to make a custom libc++ build for servicing concerns.
 # We don't sanitize or instrument the linux-x64 build (as we don't ship it), so we don't need to build those runtime support libraries either.
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x86 bionic --skipunmount --skipemulation
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x86 bionic --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR

--- a/src/azurelinux/3.0/net10.0/cross/x86/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/cross/x86/Dockerfile
@@ -5,7 +5,7 @@ ARG ROOTFS_DIR
 
 # We don't ship linux-x86 binaries, so we don't need to make a custom libc++ build for servicing concerns.
 # We don't sanitize or instrument the linux-x64 build (as we don't ship it), so we don't need to build those runtime support libraries either.
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x86 bionic --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x86 bionic --skipunmount --skipemulation --ubuntu-repo "http://azure.archive.ubuntu.com/ubuntu/"
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR

--- a/src/azurelinux/3.0/net11.0/cross/amd64-sanitizer/Dockerfile
+++ b/src/azurelinux/3.0/net11.0/cross/amd64-sanitizer/Dockerfile
@@ -5,7 +5,7 @@ ARG ROOTFS_DIR
 
 # Use Ubuntu Bionic as the base image for the rootfs
 # to get a new enough libstdc++ for the sanitizer runtimes and instrumentation.
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x64 bionic --skipunmount --skipemulation
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x64 bionic --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
 
 RUN TARGET_TRIPLE="x86_64-linux-gnu" && \
     GCC_VER=$(basename "$(find "$ROOTFS_DIR/usr/include/c++/" -mindepth 1 -maxdepth 1 -type d | sort -V | head -n1)") && \

--- a/src/azurelinux/3.0/net11.0/cross/amd64-sanitizer/Dockerfile
+++ b/src/azurelinux/3.0/net11.0/cross/amd64-sanitizer/Dockerfile
@@ -5,7 +5,7 @@ ARG ROOTFS_DIR
 
 # Use Ubuntu Bionic as the base image for the rootfs
 # to get a new enough libstdc++ for the sanitizer runtimes and instrumentation.
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x64 bionic --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x64 bionic --skipunmount --skipemulation --ubuntu-repo "http://azure.archive.ubuntu.com/ubuntu/"
 
 RUN TARGET_TRIPLE="x86_64-linux-gnu" && \
     GCC_VER=$(basename "$(find "$ROOTFS_DIR/usr/include/c++/" -mindepth 1 -maxdepth 1 -type d | sort -V | head -n1)") && \

--- a/src/azurelinux/3.0/net11.0/cross/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net11.0/cross/amd64/Dockerfile
@@ -3,7 +3,7 @@ ARG ROOTFS_DIR=/crossrootfs/x64
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x64 bionic --skipunmount --skipemulation
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x64 bionic --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
 
 RUN TARGET_TRIPLE="x86_64-linux-gnu" && \
     GCC_VER=$(basename "$(find "$ROOTFS_DIR/usr/include/c++/" -mindepth 1 -maxdepth 1 -type d | sort -V | head -n1)") && \

--- a/src/azurelinux/3.0/net11.0/cross/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net11.0/cross/amd64/Dockerfile
@@ -3,7 +3,7 @@ ARG ROOTFS_DIR=/crossrootfs/x64
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x64 bionic --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x64 bionic --skipunmount --skipemulation --ubuntu-repo "http://azure.archive.ubuntu.com/ubuntu/"
 
 RUN TARGET_TRIPLE="x86_64-linux-gnu" && \
     GCC_VER=$(basename "$(find "$ROOTFS_DIR/usr/include/c++/" -mindepth 1 -maxdepth 1 -type d | sort -V | head -n1)") && \

--- a/src/azurelinux/3.0/net11.0/cross/arm/Dockerfile
+++ b/src/azurelinux/3.0/net11.0/cross/arm/Dockerfile
@@ -5,7 +5,7 @@ ARG ROOTFS_DIR
 
 # The arm rootfs targets Ubuntu 22.04, which is the first version with a
 # glibc that supports 64-bit time_t. See https://github.com/dotnet/core/discussions/9285.
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh arm jammy no-lldb --skipunmount --skipemulation
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh arm jammy no-lldb --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
 
 RUN TARGET_TRIPLE="arm-linux-gnueabihf" && \
     GCC_VER=$(basename "$(find "$ROOTFS_DIR/usr/include/c++/" -mindepth 1 -maxdepth 1 -type d | sort -V | head -n1)") && \

--- a/src/azurelinux/3.0/net11.0/cross/arm/Dockerfile
+++ b/src/azurelinux/3.0/net11.0/cross/arm/Dockerfile
@@ -5,7 +5,7 @@ ARG ROOTFS_DIR
 
 # The arm rootfs targets Ubuntu 22.04, which is the first version with a
 # glibc that supports 64-bit time_t. See https://github.com/dotnet/core/discussions/9285.
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh arm jammy no-lldb --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh arm jammy no-lldb --skipunmount --skipemulation --ubuntu-repo "http://azure.archive.ubuntu.com/ubuntu/"
 
 RUN TARGET_TRIPLE="arm-linux-gnueabihf" && \
     GCC_VER=$(basename "$(find "$ROOTFS_DIR/usr/include/c++/" -mindepth 1 -maxdepth 1 -type d | sort -V | head -n1)") && \

--- a/src/azurelinux/3.0/net11.0/cross/arm64/Dockerfile
+++ b/src/azurelinux/3.0/net11.0/cross/arm64/Dockerfile
@@ -3,7 +3,7 @@ ARG ROOTFS_DIR=/crossrootfs/arm64
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh arm64 bionic --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh arm64 bionic --skipunmount --skipemulation --ubuntu-repo "http://azure.archive.ubuntu.com/ubuntu/"
 
 RUN TARGET_TRIPLE="aarch64-linux-gnu" && \
     GCC_VER=$(basename "$(find "$ROOTFS_DIR/usr/include/c++/" -mindepth 1 -maxdepth 1 -type d | sort -V | head -n1)") && \

--- a/src/azurelinux/3.0/net11.0/cross/arm64/Dockerfile
+++ b/src/azurelinux/3.0/net11.0/cross/arm64/Dockerfile
@@ -3,7 +3,7 @@ ARG ROOTFS_DIR=/crossrootfs/arm64
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh arm64 bionic --skipunmount --skipemulation
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh arm64 bionic --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
 
 RUN TARGET_TRIPLE="aarch64-linux-gnu" && \
     GCC_VER=$(basename "$(find "$ROOTFS_DIR/usr/include/c++/" -mindepth 1 -maxdepth 1 -type d | sort -V | head -n1)") && \

--- a/src/azurelinux/3.0/net11.0/cross/freebsd/14/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net11.0/cross/freebsd/14/amd64/Dockerfile
@@ -32,7 +32,7 @@ RUN cd /tmp && wget -O libbsd-0.12.2.tar.xz "https://libbsd.freedesktop.org/rele
 
 RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/usr-local.conf && ldconfig
 
-RUN /scripts/eng/common/cross/build-rootfs.sh freebsd14 x64
+RUN /scripts/eng/common/cross/build-rootfs.sh freebsd14 x64 --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR

--- a/src/azurelinux/3.0/net11.0/cross/freebsd/14/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net11.0/cross/freebsd/14/amd64/Dockerfile
@@ -32,7 +32,7 @@ RUN cd /tmp && wget -O libbsd-0.12.2.tar.xz "https://libbsd.freedesktop.org/rele
 
 RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/usr-local.conf && ldconfig
 
-RUN /scripts/eng/common/cross/build-rootfs.sh freebsd14 x64 --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
+RUN /scripts/eng/common/cross/build-rootfs.sh freebsd14 x64 --ubuntu-repo "http://azure.archive.ubuntu.com/ubuntu/"
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR

--- a/src/azurelinux/3.0/net11.0/cross/freebsd/14/arm64/Dockerfile
+++ b/src/azurelinux/3.0/net11.0/cross/freebsd/14/arm64/Dockerfile
@@ -32,7 +32,7 @@ RUN cd /tmp && wget -O libbsd-0.12.2.tar.xz "https://libbsd.freedesktop.org/rele
 
 RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/usr-local.conf && ldconfig
 
-RUN /scripts/eng/common/cross/build-rootfs.sh freebsd14 arm64 --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
+RUN /scripts/eng/common/cross/build-rootfs.sh freebsd14 arm64 --ubuntu-repo "http://azure.archive.ubuntu.com/ubuntu/"
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR

--- a/src/azurelinux/3.0/net11.0/cross/freebsd/14/arm64/Dockerfile
+++ b/src/azurelinux/3.0/net11.0/cross/freebsd/14/arm64/Dockerfile
@@ -32,7 +32,7 @@ RUN cd /tmp && wget -O libbsd-0.12.2.tar.xz "https://libbsd.freedesktop.org/rele
 
 RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/usr-local.conf && ldconfig
 
-RUN /scripts/eng/common/cross/build-rootfs.sh freebsd14 arm64
+RUN /scripts/eng/common/cross/build-rootfs.sh freebsd14 arm64 --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR

--- a/src/azurelinux/3.0/net11.0/cross/haiku/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net11.0/cross/haiku/amd64/Dockerfile
@@ -3,7 +3,7 @@ ARG ROOTFS_DIR=/crossrootfs/x64
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
-RUN /scripts/eng/common/cross/build-rootfs.sh haiku x64 --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
+RUN /scripts/eng/common/cross/build-rootfs.sh haiku x64 --ubuntu-repo "http://azure.archive.ubuntu.com/ubuntu/"
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR

--- a/src/azurelinux/3.0/net11.0/cross/haiku/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net11.0/cross/haiku/amd64/Dockerfile
@@ -3,7 +3,7 @@ ARG ROOTFS_DIR=/crossrootfs/x64
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
-RUN /scripts/eng/common/cross/build-rootfs.sh haiku x64
+RUN /scripts/eng/common/cross/build-rootfs.sh haiku x64 --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR

--- a/src/azurelinux/3.0/net11.0/cross/openbsd/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net11.0/cross/openbsd/amd64/Dockerfile
@@ -3,7 +3,7 @@ ARG ROOTFS_DIR=/crossrootfs/x64
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
-RUN /scripts/eng/common/cross/build-rootfs.sh openbsd x64 --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
+RUN /scripts/eng/common/cross/build-rootfs.sh openbsd x64 --ubuntu-repo "http://azure.archive.ubuntu.com/ubuntu/"
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR

--- a/src/azurelinux/3.0/net11.0/cross/openbsd/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net11.0/cross/openbsd/amd64/Dockerfile
@@ -3,7 +3,7 @@ ARG ROOTFS_DIR=/crossrootfs/x64
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
-RUN /scripts/eng/common/cross/build-rootfs.sh openbsd x64
+RUN /scripts/eng/common/cross/build-rootfs.sh openbsd x64 --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR

--- a/src/azurelinux/3.0/net11.0/cross/riscv64/Dockerfile
+++ b/src/azurelinux/3.0/net11.0/cross/riscv64/Dockerfile
@@ -3,7 +3,7 @@ ARG ROOTFS_DIR=/crossrootfs/riscv64
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh riscv64 noble --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh riscv64 noble --skipunmount --skipemulation --ubuntu-repo "http://azure.archive.ubuntu.com/ubuntu/"
 
 RUN TARGET_TRIPLE="riscv64-linux-gnu" && \
     GCC_VER=$(basename "$(find "$ROOTFS_DIR/usr/include/c++/" -mindepth 1 -maxdepth 1 -type d | sort -V | head -n1)") && \

--- a/src/azurelinux/3.0/net11.0/cross/riscv64/Dockerfile
+++ b/src/azurelinux/3.0/net11.0/cross/riscv64/Dockerfile
@@ -3,7 +3,7 @@ ARG ROOTFS_DIR=/crossrootfs/riscv64
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh riscv64 noble --skipunmount --skipemulation
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh riscv64 noble --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
 
 RUN TARGET_TRIPLE="riscv64-linux-gnu" && \
     GCC_VER=$(basename "$(find "$ROOTFS_DIR/usr/include/c++/" -mindepth 1 -maxdepth 1 -type d | sort -V | head -n1)") && \

--- a/src/azurelinux/3.0/net11.0/cross/x86/Dockerfile
+++ b/src/azurelinux/3.0/net11.0/cross/x86/Dockerfile
@@ -5,7 +5,7 @@ ARG ROOTFS_DIR
 
 # We don't ship linux-x86 binaries, so we don't need to make a custom libc++ build for servicing concerns.
 # We don't sanitize or instrument the linux-x64 build (as we don't ship it), so we don't need to build those runtime support libraries either.
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x86 bionic --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x86 bionic --skipunmount --skipemulation --ubuntu-repo "http://azure.archive.ubuntu.com/ubuntu/"
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR

--- a/src/azurelinux/3.0/net11.0/cross/x86/Dockerfile
+++ b/src/azurelinux/3.0/net11.0/cross/x86/Dockerfile
@@ -5,7 +5,7 @@ ARG ROOTFS_DIR
 
 # We don't ship linux-x86 binaries, so we don't need to make a custom libc++ build for servicing concerns.
 # We don't sanitize or instrument the linux-x64 build (as we don't ship it), so we don't need to build those runtime support libraries either.
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x86 bionic --skipunmount --skipemulation
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x86 bionic --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR

--- a/src/azurelinux/3.0/net8.0/cross/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/cross/amd64/Dockerfile
@@ -3,7 +3,7 @@ ARG ROOTFS_DIR=/crossrootfs/x64
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x64 xenial --skipunmount --skipemulation
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x64 xenial --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
 
 # Build compiler-rt profile library for PGO instrumentation
 RUN mkdir compiler-rt_build && cd compiler-rt_build && \

--- a/src/azurelinux/3.0/net8.0/cross/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/cross/amd64/Dockerfile
@@ -3,7 +3,7 @@ ARG ROOTFS_DIR=/crossrootfs/x64
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x64 xenial --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x64 xenial --skipunmount --skipemulation --ubuntu-repo "http://azure.archive.ubuntu.com/ubuntu/"
 
 # Build compiler-rt profile library for PGO instrumentation
 RUN mkdir compiler-rt_build && cd compiler-rt_build && \

--- a/src/azurelinux/3.0/net8.0/cross/arm/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/cross/arm/Dockerfile
@@ -3,7 +3,7 @@ ARG ROOTFS_DIR=/crossrootfs/arm
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh arm xenial --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh arm xenial --skipunmount --skipemulation --ubuntu-repo "http://azure.archive.ubuntu.com/ubuntu/"
 
 # Build compiler-rt profile library for PGO instrumentation
 RUN mkdir compiler-rt_build && cd compiler-rt_build && \

--- a/src/azurelinux/3.0/net8.0/cross/arm/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/cross/arm/Dockerfile
@@ -3,7 +3,7 @@ ARG ROOTFS_DIR=/crossrootfs/arm
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh arm xenial --skipunmount --skipemulation
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh arm xenial --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
 
 # Build compiler-rt profile library for PGO instrumentation
 RUN mkdir compiler-rt_build && cd compiler-rt_build && \

--- a/src/azurelinux/3.0/net8.0/cross/arm64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/cross/arm64/Dockerfile
@@ -3,7 +3,7 @@ ARG ROOTFS_DIR=/crossrootfs/arm64
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh arm64 xenial --skipunmount --skipemulation
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh arm64 xenial --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
 
 # Build compiler-rt profile library for PGO instrumentation
 RUN mkdir compiler-rt_build && cd compiler-rt_build && \

--- a/src/azurelinux/3.0/net8.0/cross/arm64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/cross/arm64/Dockerfile
@@ -3,7 +3,7 @@ ARG ROOTFS_DIR=/crossrootfs/arm64
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh arm64 xenial --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh arm64 xenial --skipunmount --skipemulation --ubuntu-repo "http://azure.archive.ubuntu.com/ubuntu/"
 
 # Build compiler-rt profile library for PGO instrumentation
 RUN mkdir compiler-rt_build && cd compiler-rt_build && \

--- a/src/azurelinux/3.0/net8.0/cross/freebsd/14/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/cross/freebsd/14/amd64/Dockerfile
@@ -11,7 +11,7 @@ RUN tdnf install -y \
     # so the FreeBSD bootstrap can find it. See https://github.com/microsoft/azurelinux/issues/9217
     ln -s /usr/lib/liblzma.so.5 /usr/lib/liblzma.so
 
-RUN /scripts/eng/common/cross/build-rootfs.sh freebsd14 x64 --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
+RUN /scripts/eng/common/cross/build-rootfs.sh freebsd14 x64 --ubuntu-repo "http://azure.archive.ubuntu.com/ubuntu/"
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR

--- a/src/azurelinux/3.0/net8.0/cross/freebsd/14/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/cross/freebsd/14/amd64/Dockerfile
@@ -11,7 +11,7 @@ RUN tdnf install -y \
     # so the FreeBSD bootstrap can find it. See https://github.com/microsoft/azurelinux/issues/9217
     ln -s /usr/lib/liblzma.so.5 /usr/lib/liblzma.so
 
-RUN /scripts/eng/common/cross/build-rootfs.sh freebsd14 x64
+RUN /scripts/eng/common/cross/build-rootfs.sh freebsd14 x64 --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR

--- a/src/azurelinux/3.0/net8.0/cross/riscv64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/cross/riscv64/Dockerfile
@@ -3,7 +3,7 @@ ARG ROOTFS_DIR=/crossrootfs/riscv64
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh riscv64 noble --skipunmount --skipemulation
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh riscv64 noble --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
 
 RUN TARGET_TRIPLE="riscv64-linux-gnu" && \
     GCC_VER=$(basename "$(find "$ROOTFS_DIR/usr/include/c++/" -mindepth 1 -maxdepth 1 -type d | sort -V | head -n1)") && \

--- a/src/azurelinux/3.0/net8.0/cross/riscv64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/cross/riscv64/Dockerfile
@@ -3,7 +3,7 @@ ARG ROOTFS_DIR=/crossrootfs/riscv64
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh riscv64 noble --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh riscv64 noble --skipunmount --skipemulation --ubuntu-repo "http://azure.archive.ubuntu.com/ubuntu/"
 
 RUN TARGET_TRIPLE="riscv64-linux-gnu" && \
     GCC_VER=$(basename "$(find "$ROOTFS_DIR/usr/include/c++/" -mindepth 1 -maxdepth 1 -type d | sort -V | head -n1)") && \

--- a/src/azurelinux/3.0/net8.0/cross/x86/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/cross/x86/Dockerfile
@@ -3,7 +3,7 @@ ARG ROOTFS_DIR=/crossrootfs/x86
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x86 xenial --skipunmount --skipemulation
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x86 xenial --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
 
 # Build compiler-rt profile library for PGO instrumentation
 RUN mkdir compiler-rt_build && cd compiler-rt_build && \

--- a/src/azurelinux/3.0/net8.0/cross/x86/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/cross/x86/Dockerfile
@@ -3,7 +3,7 @@ ARG ROOTFS_DIR=/crossrootfs/x86
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x86 xenial --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x86 xenial --skipunmount --skipemulation --ubuntu-repo "http://azure.archive.ubuntu.com/ubuntu/"
 
 # Build compiler-rt profile library for PGO instrumentation
 RUN mkdir compiler-rt_build && cd compiler-rt_build && \

--- a/src/azurelinux/3.0/net9.0/cross/amd64-sanitizer/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/amd64-sanitizer/Dockerfile
@@ -5,7 +5,7 @@ ARG ROOTFS_DIR
 
 # Use Ubuntu Bionic as the base image for the rootfs
 # to get a new enough libstdc++ for the sanitizer runtimes and instrumentation.
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x64 bionic --skipunmount --skipemulation
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x64 bionic --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
 
 RUN TARGET_TRIPLE="x86_64-linux-gnu" && \
     GCC_VER=$(basename "$(find "$ROOTFS_DIR/usr/include/c++/" -mindepth 1 -maxdepth 1 -type d | sort -V | head -n1)") && \

--- a/src/azurelinux/3.0/net9.0/cross/amd64-sanitizer/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/amd64-sanitizer/Dockerfile
@@ -5,7 +5,7 @@ ARG ROOTFS_DIR
 
 # Use Ubuntu Bionic as the base image for the rootfs
 # to get a new enough libstdc++ for the sanitizer runtimes and instrumentation.
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x64 bionic --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x64 bionic --skipunmount --skipemulation --ubuntu-repo "http://azure.archive.ubuntu.com/ubuntu/"
 
 RUN TARGET_TRIPLE="x86_64-linux-gnu" && \
     GCC_VER=$(basename "$(find "$ROOTFS_DIR/usr/include/c++/" -mindepth 1 -maxdepth 1 -type d | sort -V | head -n1)") && \

--- a/src/azurelinux/3.0/net9.0/cross/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/amd64/Dockerfile
@@ -3,7 +3,7 @@ ARG ROOTFS_DIR=/crossrootfs/x64
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x64 xenial --skipunmount --skipemulation
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x64 xenial --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
 
 RUN TARGET_TRIPLE="x86_64-linux-gnu" && \
     GCC_VER=$(basename "$(find "$ROOTFS_DIR/usr/include/c++/" -mindepth 1 -maxdepth 1 -type d | sort -V | head -n1)") && \

--- a/src/azurelinux/3.0/net9.0/cross/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/amd64/Dockerfile
@@ -3,7 +3,7 @@ ARG ROOTFS_DIR=/crossrootfs/x64
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x64 xenial --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x64 xenial --skipunmount --skipemulation --ubuntu-repo "http://azure.archive.ubuntu.com/ubuntu/"
 
 RUN TARGET_TRIPLE="x86_64-linux-gnu" && \
     GCC_VER=$(basename "$(find "$ROOTFS_DIR/usr/include/c++/" -mindepth 1 -maxdepth 1 -type d | sort -V | head -n1)") && \

--- a/src/azurelinux/3.0/net9.0/cross/arm/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/arm/Dockerfile
@@ -5,7 +5,7 @@ ARG ROOTFS_DIR
 
 # The arm rootfs targets Ubuntu 22.04, which is the first version with a
 # glibc that supports 64-bit time_t. See https://github.com/dotnet/core/discussions/9285.
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh arm jammy no-lldb --skipunmount --skipemulation
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh arm jammy no-lldb --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
 
 RUN TARGET_TRIPLE="arm-linux-gnueabihf" && \
     GCC_VER=$(basename "$(find "$ROOTFS_DIR/usr/include/c++/" -mindepth 1 -maxdepth 1 -type d | sort -V | head -n1)") && \

--- a/src/azurelinux/3.0/net9.0/cross/arm/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/arm/Dockerfile
@@ -5,7 +5,7 @@ ARG ROOTFS_DIR
 
 # The arm rootfs targets Ubuntu 22.04, which is the first version with a
 # glibc that supports 64-bit time_t. See https://github.com/dotnet/core/discussions/9285.
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh arm jammy no-lldb --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh arm jammy no-lldb --skipunmount --skipemulation --ubuntu-repo "http://azure.archive.ubuntu.com/ubuntu/"
 
 RUN TARGET_TRIPLE="arm-linux-gnueabihf" && \
     GCC_VER=$(basename "$(find "$ROOTFS_DIR/usr/include/c++/" -mindepth 1 -maxdepth 1 -type d | sort -V | head -n1)") && \

--- a/src/azurelinux/3.0/net9.0/cross/arm64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/arm64/Dockerfile
@@ -3,7 +3,7 @@ ARG ROOTFS_DIR=/crossrootfs/arm64
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh arm64 xenial --skipunmount --skipemulation
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh arm64 xenial --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
 
 RUN TARGET_TRIPLE="aarch64-linux-gnu" && \
     GCC_VER=$(basename "$(find "$ROOTFS_DIR/usr/include/c++/" -mindepth 1 -maxdepth 1 -type d | sort -V | head -n1)") && \

--- a/src/azurelinux/3.0/net9.0/cross/arm64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/arm64/Dockerfile
@@ -3,7 +3,7 @@ ARG ROOTFS_DIR=/crossrootfs/arm64
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh arm64 xenial --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh arm64 xenial --skipunmount --skipemulation --ubuntu-repo "http://azure.archive.ubuntu.com/ubuntu/"
 
 RUN TARGET_TRIPLE="aarch64-linux-gnu" && \
     GCC_VER=$(basename "$(find "$ROOTFS_DIR/usr/include/c++/" -mindepth 1 -maxdepth 1 -type d | sort -V | head -n1)") && \

--- a/src/azurelinux/3.0/net9.0/cross/freebsd/14/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/freebsd/14/amd64/Dockerfile
@@ -11,7 +11,7 @@ RUN tdnf install -y \
     # so the FreeBSD bootstrap can find it. See https://github.com/microsoft/azurelinux/issues/9217
     ln -s /usr/lib/liblzma.so.5 /usr/lib/liblzma.so
 
-RUN /scripts/eng/common/cross/build-rootfs.sh freebsd14 x64 --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
+RUN /scripts/eng/common/cross/build-rootfs.sh freebsd14 x64 --ubuntu-repo "http://azure.archive.ubuntu.com/ubuntu/"
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR

--- a/src/azurelinux/3.0/net9.0/cross/freebsd/14/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/freebsd/14/amd64/Dockerfile
@@ -11,7 +11,7 @@ RUN tdnf install -y \
     # so the FreeBSD bootstrap can find it. See https://github.com/microsoft/azurelinux/issues/9217
     ln -s /usr/lib/liblzma.so.5 /usr/lib/liblzma.so
 
-RUN /scripts/eng/common/cross/build-rootfs.sh freebsd14 x64
+RUN /scripts/eng/common/cross/build-rootfs.sh freebsd14 x64 --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR

--- a/src/azurelinux/3.0/net9.0/cross/freebsd/14/arm64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/freebsd/14/arm64/Dockerfile
@@ -11,7 +11,7 @@ RUN tdnf install -y \
     # so the FreeBSD bootstrap can find it. See https://github.com/microsoft/azurelinux/issues/9217
     && ln -s /usr/lib/liblzma.so.5 /usr/lib/liblzma.so
 
-RUN /scripts/eng/common/cross/build-rootfs.sh freebsd14 arm64 --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
+RUN /scripts/eng/common/cross/build-rootfs.sh freebsd14 arm64 --ubuntu-repo "http://azure.archive.ubuntu.com/ubuntu/"
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR

--- a/src/azurelinux/3.0/net9.0/cross/freebsd/14/arm64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/freebsd/14/arm64/Dockerfile
@@ -11,7 +11,7 @@ RUN tdnf install -y \
     # so the FreeBSD bootstrap can find it. See https://github.com/microsoft/azurelinux/issues/9217
     && ln -s /usr/lib/liblzma.so.5 /usr/lib/liblzma.so
 
-RUN /scripts/eng/common/cross/build-rootfs.sh freebsd14 arm64
+RUN /scripts/eng/common/cross/build-rootfs.sh freebsd14 arm64 --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR

--- a/src/azurelinux/3.0/net9.0/cross/riscv64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/riscv64/Dockerfile
@@ -3,7 +3,7 @@ ARG ROOTFS_DIR=/crossrootfs/riscv64
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh riscv64 noble --skipunmount --skipemulation
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh riscv64 noble --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
 
 RUN TARGET_TRIPLE="riscv64-linux-gnu" && \
     GCC_VER=$(basename "$(find "$ROOTFS_DIR/usr/include/c++/" -mindepth 1 -maxdepth 1 -type d | sort -V | head -n1)") && \

--- a/src/azurelinux/3.0/net9.0/cross/riscv64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/riscv64/Dockerfile
@@ -3,7 +3,7 @@ ARG ROOTFS_DIR=/crossrootfs/riscv64
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-builder-amd64 AS builder
 ARG ROOTFS_DIR
 
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh riscv64 noble --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh riscv64 noble --skipunmount --skipemulation --ubuntu-repo "http://azure.archive.ubuntu.com/ubuntu/"
 
 RUN TARGET_TRIPLE="riscv64-linux-gnu" && \
     GCC_VER=$(basename "$(find "$ROOTFS_DIR/usr/include/c++/" -mindepth 1 -maxdepth 1 -type d | sort -V | head -n1)") && \

--- a/src/azurelinux/3.0/net9.0/cross/x86/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/x86/Dockerfile
@@ -5,7 +5,7 @@ ARG ROOTFS_DIR
 
 # We don't ship linux-x86 binaries, so we don't need to make a custom libc++ build for servicing concerns.
 # We don't sanitize or instrument the linux-x64 build (as we don't ship it), so we don't need to build those runtime support libraries either.
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x86 xenial --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x86 xenial --skipunmount --skipemulation --ubuntu-repo "http://azure.archive.ubuntu.com/ubuntu/"
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR

--- a/src/azurelinux/3.0/net9.0/cross/x86/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/cross/x86/Dockerfile
@@ -5,7 +5,7 @@ ARG ROOTFS_DIR
 
 # We don't ship linux-x86 binaries, so we don't need to make a custom libc++ build for servicing concerns.
 # We don't sanitize or instrument the linux-x64 build (as we don't ship it), so we don't need to build those runtime support libraries either.
-RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x86 xenial --skipunmount --skipemulation
+RUN PYTHON_EXECUTABLE="$ROOTFS_PIP_HOME/bin/python" /scripts/eng/common/cross/build-rootfs.sh x86 xenial --skipunmount --skipemulation --ubuntu-repo "https://azure.archive.ubuntu.com/ubuntu/"
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-crossdeps-llvm-amd64
 ARG ROOTFS_DIR


### PR DESCRIPTION
Adds the argument for overriding default ubuntu repository used in `build-rootfs.sh` script in Azure Linux 3 images with the Microsoft mirror as per Network Isolation policy

Test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=3017462&view=results