### PR TITLE
Pin Arcade scripts and automate updates

### DIFF
--- a/eng/renovate.json
+++ b/eng/renovate.json
@@ -96,9 +96,28 @@
       "depNameTemplate": "Microsoft.AITools.BinlogMcp",
       "datasourceTemplate": "nuget",
       "registryUrlTemplate": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json"
+    },
+    {
+      "description": "Updates the Arcade commit used by rootfs-building Dockerfiles",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)Dockerfile$/"
+      ],
+      "matchStrings": [
+        "ARG ARCADE_COMMIT=(?<currentValue>[a-f0-9]{40})"
+      ],
+      "depNameTemplate": "dotnet/arcade",
+      "datasourceTemplate": "github-commits"
     }
   ],
   "packageRules": [
+    {
+      "description": "Group Arcade commit updates across all Dockerfiles",
+      "matchDepNames": [
+        "dotnet/arcade"
+      ],
+      "groupName": "Arcade"
+    },
     {
       "description": "Only allow minor/patch updates for LLVM to stay on the respective major version",
       "matchDepNames": [

--- a/src/azurelinux/3.0/net10.0/crossdeps-builder/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/crossdeps-builder/amd64/Dockerfile
@@ -116,8 +116,11 @@ RUN \
 ENV PATH="/opt/llvm/bin:$PATH"
 
 # Obtain arcade scripts used to build rootfs
+ARG ARCADE_COMMIT=e5f974ba880c3da69932191c665e90ee64e8da26
 RUN git config --global user.email builder@dotnet-buildtools-prereqs-docker && \
-    git clone --depth 1 --single-branch https://github.com/dotnet/arcade /scripts
+    git init /scripts && \
+    git -C /scripts fetch --depth 1 https://github.com/dotnet/arcade ${ARCADE_COMMIT} && \
+    git -C /scripts checkout --detach FETCH_HEAD
 
 # Clear PIP_INDEX_URL since it contains a short-lived token that should not persist in the final image
 ENV PIP_INDEX_URL=

--- a/src/azurelinux/3.0/net11.0/crossdeps-builder/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net11.0/crossdeps-builder/amd64/Dockerfile
@@ -113,8 +113,11 @@ RUN \
 ENV PATH="/opt/llvm/bin:$PATH"
 
 # Obtain arcade scripts used to build rootfs
+ARG ARCADE_COMMIT=e5f974ba880c3da69932191c665e90ee64e8da26
 RUN git config --global user.email builder@dotnet-buildtools-prereqs-docker && \
-    git clone --depth 1 --single-branch https://github.com/dotnet/arcade /scripts
+    git init /scripts && \
+    git -C /scripts fetch --depth 1 https://github.com/dotnet/arcade ${ARCADE_COMMIT} && \
+    git -C /scripts checkout --detach FETCH_HEAD
 
 # Clear PIP_INDEX_URL since it contains a short-lived token that should not persist in the final image
 ENV PIP_INDEX_URL=

--- a/src/azurelinux/3.0/net8.0/crossdeps-builder/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/crossdeps-builder/amd64/Dockerfile
@@ -116,8 +116,11 @@ RUN \
 ENV PATH="/opt/llvm/bin:$PATH"
 
 # Obtain arcade scripts used to build rootfs
+ARG ARCADE_COMMIT=e5f974ba880c3da69932191c665e90ee64e8da26
 RUN git config --global user.email builder@dotnet-buildtools-prereqs-docker && \
-    git clone --depth 1 --single-branch https://github.com/dotnet/arcade /scripts
+    git init /scripts && \
+    git -C /scripts fetch --depth 1 https://github.com/dotnet/arcade ${ARCADE_COMMIT} && \
+    git -C /scripts checkout --detach FETCH_HEAD
 
 # Clear PIP_INDEX_URL since it contains a short-lived token that should not persist in the final image
 ENV PIP_INDEX_URL=

--- a/src/azurelinux/3.0/net9.0/crossdeps-builder/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/crossdeps-builder/amd64/Dockerfile
@@ -116,8 +116,11 @@ RUN \
 ENV PATH="/opt/llvm/bin:$PATH"
 
 # Obtain arcade scripts used to build rootfs
+ARG ARCADE_COMMIT=e5f974ba880c3da69932191c665e90ee64e8da26
 RUN git config --global user.email builder@dotnet-buildtools-prereqs-docker && \
-    git clone --depth 1 --single-branch https://github.com/dotnet/arcade /scripts
+    git init /scripts && \
+    git -C /scripts fetch --depth 1 https://github.com/dotnet/arcade ${ARCADE_COMMIT} && \
+    git -C /scripts checkout --detach FETCH_HEAD
 
 # Clear PIP_INDEX_URL since it contains a short-lived token that should not persist in the final image
 ENV PIP_INDEX_URL=

--- a/src/ubuntu/22.04/cross/armel-tizen/Dockerfile
+++ b/src/ubuntu/22.04/cross/armel-tizen/Dockerfile
@@ -4,8 +4,11 @@ FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-crossdeps AS build
 ARG ROOTFS_DIR
 
 # Obtain arcade scripts used to build rootfs
+ARG ARCADE_COMMIT=e5f974ba880c3da69932191c665e90ee64e8da26
 RUN git config --global user.email builder@dotnet-buildtools-prereqs-docker && \
-    git clone --depth 1 --single-branch https://github.com/dotnet/arcade /scripts
+    git init /scripts && \
+    git -C /scripts fetch --depth 1 https://github.com/dotnet/arcade ${ARCADE_COMMIT} && \
+    git -C /scripts checkout --detach FETCH_HEAD
 
 RUN /scripts/eng/common/cross/tizen-build-rootfs.sh armel
 


### PR DESCRIPTION
## Summary

- pin rootfs-building Dockerfiles to an exact Arcade commit
- fetch only the pinned commit so image builds are reproducible
- configure Renovate to update and group the Arcade pins

## Testing

- `pwsh ./run-tests.ps1`
- Renovate 43 configuration validation
- exact shallow fetch and checkout of the pinned Arcade commit

*This content was created with assistance from AI.*