### PR TITLE
Use Microsoft public npm proxy when NPM_TOKEN is not set

### DIFF
--- a/eng/pipelines/steps/pip-authenticate.yml
+++ b/eng/pipelines/steps/pip-authenticate.yml
@@ -16,10 +16,11 @@ steps:
     # rather than appending a duplicate --build-arg.
     $options = "$(imageBuilderBuildArgs)"
     $options = $options -replace '--build-arg PIP_INDEX_URL=\S+', "--build-arg PIP_INDEX_URL=$env:PIP_INDEX_URL"
-    # The npm registry (public dotnet-public-npm feed) is baked into the Dockerfiles as the
-    # NPM_REGISTRY default and is read anonymously, so no override is needed here. Internal
-    # builds additionally pass a token so they can ingest new package versions; the token is
-    # optional and unused on anonymous reads.
+    # Dockerfiles default NPM_REGISTRY to the Microsoft public npm proxy (for public/local
+    # builds). On internal builds, point npm at the authenticated dotnet-public-npm feed and
+    # provide the token so the auth key derived from the URL resolves. Keeping the internal
+    # feed URL here means it lives in exactly one place instead of every Dockerfile.
+    $options += " --build-arg NPM_REGISTRY=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/"
     $options += " --build-arg NPM_TOKEN=$(System.AccessToken)"
     echo "##vso[task.setvariable variable=imageBuilderBuildArgs]$options"
   displayName: Set PIP and NPM Build Args

--- a/eng/pipelines/steps/pip-authenticate.yml
+++ b/eng/pipelines/steps/pip-authenticate.yml
@@ -16,11 +16,10 @@ steps:
     # rather than appending a duplicate --build-arg.
     $options = "$(imageBuilderBuildArgs)"
     $options = $options -replace '--build-arg PIP_INDEX_URL=\S+', "--build-arg PIP_INDEX_URL=$env:PIP_INDEX_URL"
-    # Dockerfiles default NPM_REGISTRY to the Microsoft public npm proxy (for public/local
-    # builds). On internal builds, point npm at the authenticated dotnet-public-npm feed and
-    # provide the token so the auth key derived from the URL resolves. Keeping the internal
-    # feed URL here means it lives in exactly one place instead of every Dockerfile.
-    $options += " --build-arg NPM_REGISTRY=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/"
+    # The npm registry (public dotnet-public-npm feed) is baked into the Dockerfiles as the
+    # NPM_REGISTRY default and is read anonymously, so no override is needed here. Internal
+    # builds additionally pass a token so they can ingest new package versions; the token is
+    # optional and unused on anonymous reads.
     $options += " --build-arg NPM_TOKEN=$(System.AccessToken)"
     echo "##vso[task.setvariable variable=imageBuilderBuildArgs]$options"
   displayName: Set PIP and NPM Build Args

--- a/eng/pipelines/steps/pip-authenticate.yml
+++ b/eng/pipelines/steps/pip-authenticate.yml
@@ -16,6 +16,11 @@ steps:
     # rather than appending a duplicate --build-arg.
     $options = "$(imageBuilderBuildArgs)"
     $options = $options -replace '--build-arg PIP_INDEX_URL=\S+', "--build-arg PIP_INDEX_URL=$env:PIP_INDEX_URL"
+    # Dockerfiles default NPM_REGISTRY to the Microsoft public npm proxy (for public/local
+    # builds). On internal builds, point npm at the authenticated dotnet-public-npm feed and
+    # provide the token so the auth key derived from the URL resolves. Keeping the internal
+    # feed URL here means it lives in exactly one place instead of every Dockerfile.
+    $options += " --build-arg NPM_REGISTRY=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/"
     $options += " --build-arg NPM_TOKEN=$(System.AccessToken)"
     echo "##vso[task.setvariable variable=imageBuilderBuildArgs]$options"
   displayName: Set PIP and NPM Build Args

--- a/src/azurelinux/3.0/net10.0/webassembly/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/webassembly/amd64/Dockerfile
@@ -12,9 +12,10 @@ RUN tdnf update -y \
         libxml2 \
         unzip
 
-# Registry npm installs pull from; defaults to the Microsoft public npm proxy.
-# Internal builds override NPM_REGISTRY with the dotnet-public-npm Azure Artifacts feed and set NPM_TOKEN.
-ARG NPM_REGISTRY=https://packagefeedproxy.microsoft.io/npm/
+# npm registry. Defaults to the public dotnet-public-npm Azure Artifacts feed, which is
+# readable anonymously (works for local/dev and public builds). NPM_TOKEN is optional and
+# only needed by internal builds that ingest new package versions into the feed.
+ARG NPM_REGISTRY=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
 ARG NPM_TOKEN
 
 RUN npm config set registry "$NPM_REGISTRY" && \

--- a/src/azurelinux/3.0/net10.0/webassembly/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/webassembly/amd64/Dockerfile
@@ -12,10 +12,9 @@ RUN tdnf update -y \
         libxml2 \
         unzip
 
-# npm registry. Defaults to the public dotnet-public-npm Azure Artifacts feed, which is
-# readable anonymously (works for local/dev and public builds). NPM_TOKEN is optional and
-# only needed by internal builds that ingest new package versions into the feed.
-ARG NPM_REGISTRY=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
+# Registry npm installs pull from; defaults to the Microsoft public npm proxy.
+# Internal builds override NPM_REGISTRY with the dotnet-public-npm Azure Artifacts feed and set NPM_TOKEN.
+ARG NPM_REGISTRY=https://packagefeedproxy.microsoft.io/npm/
 ARG NPM_TOKEN
 
 RUN npm config set registry "$NPM_REGISTRY" && \

--- a/src/azurelinux/3.0/net10.0/webassembly/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/webassembly/amd64/Dockerfile
@@ -12,16 +12,14 @@ RUN tdnf update -y \
         libxml2 \
         unzip
 
-# Token used to authenticate to the dotnet-public-npm Azure Artifacts feed.
+# Registry npm installs pull from; defaults to the Microsoft public npm proxy.
+# Internal builds override NPM_REGISTRY with the dotnet-public-npm Azure Artifacts feed and set NPM_TOKEN.
+ARG NPM_REGISTRY=https://packagefeedproxy.microsoft.io/npm/
 ARG NPM_TOKEN
 
-# When NPM_TOKEN is provided (internal builds) use the dotnet-public-npm Azure Artifacts feed;
-# otherwise fall back to the Microsoft public npm proxy (public builds have no token).
-RUN if [ -n "$NPM_TOKEN" ]; then \
-        npm config set registry https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ && \
-        npm config set "//pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/:_authToken" "$NPM_TOKEN"; \
-    else \
-        npm config set registry https://packagefeedproxy.microsoft.io/npm/; \
+RUN npm config set registry "$NPM_REGISTRY" && \
+    if [ -n "$NPM_TOKEN" ]; then \
+        npm config set "${NPM_REGISTRY#https:}:_authToken" "$NPM_TOKEN"; \
     fi
 
 # WebAssembly build needs typescript

--- a/src/azurelinux/3.0/net10.0/webassembly/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net10.0/webassembly/amd64/Dockerfile
@@ -16,10 +16,12 @@ RUN tdnf update -y \
 ARG NPM_TOKEN
 
 # When NPM_TOKEN is provided (internal builds) use the dotnet-public-npm Azure Artifacts feed;
-# otherwise fall back to the default public registry (public builds have no token).
+# otherwise fall back to the Microsoft public npm proxy (public builds have no token).
 RUN if [ -n "$NPM_TOKEN" ]; then \
         npm config set registry https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ && \
         npm config set "//pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/:_authToken" "$NPM_TOKEN"; \
+    else \
+        npm config set registry https://packagefeedproxy.microsoft.io/npm/; \
     fi
 
 # WebAssembly build needs typescript

--- a/src/azurelinux/3.0/net8.0/webassembly/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/webassembly/amd64/Dockerfile
@@ -13,9 +13,10 @@ RUN tdnf update -y \
         # dependency for npm package modification
         jq
 
-# Registry npm installs pull from; defaults to the Microsoft public npm proxy.
-# Internal builds override NPM_REGISTRY with the dotnet-public-npm Azure Artifacts feed and set NPM_TOKEN.
-ARG NPM_REGISTRY=https://packagefeedproxy.microsoft.io/npm/
+# npm registry. Defaults to the public dotnet-public-npm Azure Artifacts feed, which is
+# readable anonymously (works for local/dev and public builds). NPM_TOKEN is optional and
+# only needed by internal builds that ingest new package versions into the feed.
+ARG NPM_REGISTRY=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
 ARG NPM_TOKEN
 
 RUN npm config set registry "$NPM_REGISTRY" && \

--- a/src/azurelinux/3.0/net8.0/webassembly/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/webassembly/amd64/Dockerfile
@@ -13,16 +13,14 @@ RUN tdnf update -y \
         # dependency for npm package modification
         jq
 
-# Token used to authenticate to the dotnet-public-npm Azure Artifacts feed.
+# Registry npm installs pull from; defaults to the Microsoft public npm proxy.
+# Internal builds override NPM_REGISTRY with the dotnet-public-npm Azure Artifacts feed and set NPM_TOKEN.
+ARG NPM_REGISTRY=https://packagefeedproxy.microsoft.io/npm/
 ARG NPM_TOKEN
 
-# When NPM_TOKEN is provided (internal builds) use the dotnet-public-npm Azure Artifacts feed;
-# otherwise fall back to the Microsoft public npm proxy (public builds have no token).
-RUN if [ -n "$NPM_TOKEN" ]; then \
-        npm config set registry https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ && \
-        npm config set "//pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/:_authToken" "$NPM_TOKEN"; \
-    else \
-        npm config set registry https://packagefeedproxy.microsoft.io/npm/; \
+RUN npm config set registry "$NPM_REGISTRY" && \
+    if [ -n "$NPM_TOKEN" ]; then \
+        npm config set "${NPM_REGISTRY#https:}:_authToken" "$NPM_TOKEN"; \
     fi
 
 # WebAssembly build needs typescript

--- a/src/azurelinux/3.0/net8.0/webassembly/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/webassembly/amd64/Dockerfile
@@ -17,10 +17,12 @@ RUN tdnf update -y \
 ARG NPM_TOKEN
 
 # When NPM_TOKEN is provided (internal builds) use the dotnet-public-npm Azure Artifacts feed;
-# otherwise fall back to the default public registry (public builds have no token).
+# otherwise fall back to the Microsoft public npm proxy (public builds have no token).
 RUN if [ -n "$NPM_TOKEN" ]; then \
         npm config set registry https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ && \
         npm config set "//pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/:_authToken" "$NPM_TOKEN"; \
+    else \
+        npm config set registry https://packagefeedproxy.microsoft.io/npm/; \
     fi
 
 # WebAssembly build needs typescript

--- a/src/azurelinux/3.0/net8.0/webassembly/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net8.0/webassembly/amd64/Dockerfile
@@ -13,10 +13,9 @@ RUN tdnf update -y \
         # dependency for npm package modification
         jq
 
-# npm registry. Defaults to the public dotnet-public-npm Azure Artifacts feed, which is
-# readable anonymously (works for local/dev and public builds). NPM_TOKEN is optional and
-# only needed by internal builds that ingest new package versions into the feed.
-ARG NPM_REGISTRY=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
+# Registry npm installs pull from; defaults to the Microsoft public npm proxy.
+# Internal builds override NPM_REGISTRY with the dotnet-public-npm Azure Artifacts feed and set NPM_TOKEN.
+ARG NPM_REGISTRY=https://packagefeedproxy.microsoft.io/npm/
 ARG NPM_TOKEN
 
 RUN npm config set registry "$NPM_REGISTRY" && \

--- a/src/azurelinux/3.0/net9.0/webassembly/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/webassembly/amd64/Dockerfile
@@ -12,9 +12,10 @@ RUN tdnf update -y \
         libxml2 \
         unzip
 
-# Registry npm installs pull from; defaults to the Microsoft public npm proxy.
-# Internal builds override NPM_REGISTRY with the dotnet-public-npm Azure Artifacts feed and set NPM_TOKEN.
-ARG NPM_REGISTRY=https://packagefeedproxy.microsoft.io/npm/
+# npm registry. Defaults to the public dotnet-public-npm Azure Artifacts feed, which is
+# readable anonymously (works for local/dev and public builds). NPM_TOKEN is optional and
+# only needed by internal builds that ingest new package versions into the feed.
+ARG NPM_REGISTRY=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
 ARG NPM_TOKEN
 
 RUN npm config set registry "$NPM_REGISTRY" && \

--- a/src/azurelinux/3.0/net9.0/webassembly/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/webassembly/amd64/Dockerfile
@@ -12,10 +12,9 @@ RUN tdnf update -y \
         libxml2 \
         unzip
 
-# npm registry. Defaults to the public dotnet-public-npm Azure Artifacts feed, which is
-# readable anonymously (works for local/dev and public builds). NPM_TOKEN is optional and
-# only needed by internal builds that ingest new package versions into the feed.
-ARG NPM_REGISTRY=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
+# Registry npm installs pull from; defaults to the Microsoft public npm proxy.
+# Internal builds override NPM_REGISTRY with the dotnet-public-npm Azure Artifacts feed and set NPM_TOKEN.
+ARG NPM_REGISTRY=https://packagefeedproxy.microsoft.io/npm/
 ARG NPM_TOKEN
 
 RUN npm config set registry "$NPM_REGISTRY" && \

--- a/src/azurelinux/3.0/net9.0/webassembly/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/webassembly/amd64/Dockerfile
@@ -12,16 +12,14 @@ RUN tdnf update -y \
         libxml2 \
         unzip
 
-# Token used to authenticate to the dotnet-public-npm Azure Artifacts feed.
+# Registry npm installs pull from; defaults to the Microsoft public npm proxy.
+# Internal builds override NPM_REGISTRY with the dotnet-public-npm Azure Artifacts feed and set NPM_TOKEN.
+ARG NPM_REGISTRY=https://packagefeedproxy.microsoft.io/npm/
 ARG NPM_TOKEN
 
-# When NPM_TOKEN is provided (internal builds) use the dotnet-public-npm Azure Artifacts feed;
-# otherwise fall back to the Microsoft public npm proxy (public builds have no token).
-RUN if [ -n "$NPM_TOKEN" ]; then \
-        npm config set registry https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ && \
-        npm config set "//pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/:_authToken" "$NPM_TOKEN"; \
-    else \
-        npm config set registry https://packagefeedproxy.microsoft.io/npm/; \
+RUN npm config set registry "$NPM_REGISTRY" && \
+    if [ -n "$NPM_TOKEN" ]; then \
+        npm config set "${NPM_REGISTRY#https:}:_authToken" "$NPM_TOKEN"; \
     fi
 
 # WebAssembly build needs typescript

--- a/src/azurelinux/3.0/net9.0/webassembly/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net9.0/webassembly/amd64/Dockerfile
@@ -16,10 +16,12 @@ RUN tdnf update -y \
 ARG NPM_TOKEN
 
 # When NPM_TOKEN is provided (internal builds) use the dotnet-public-npm Azure Artifacts feed;
-# otherwise fall back to the default public registry (public builds have no token).
+# otherwise fall back to the Microsoft public npm proxy (public builds have no token).
 RUN if [ -n "$NPM_TOKEN" ]; then \
         npm config set registry https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ && \
         npm config set "//pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/:_authToken" "$NPM_TOKEN"; \
+    else \
+        npm config set registry https://packagefeedproxy.microsoft.io/npm/; \
     fi
 
 # WebAssembly build needs typescript

--- a/src/azurelinux/3.0/renovate/amd64/Dockerfile
+++ b/src/azurelinux/3.0/renovate/amd64/Dockerfile
@@ -21,9 +21,11 @@ RUN tdnf update -y && \
 ARG NPM_TOKEN
 
 # When NPM_TOKEN is provided (internal builds) use the dotnet-public-npm Azure Artifacts feed;
-# otherwise fall back to the default public registry (public builds have no token).
+# otherwise fall back to the Microsoft public npm proxy (public builds have no token).
 RUN if [ -n "$NPM_TOKEN" ]; then \
         npm config set registry https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ && \
         npm config set "//pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/:_authToken" "$NPM_TOKEN"; \
+    else \
+        npm config set registry https://packagefeedproxy.microsoft.io/npm/; \
     fi && \
     npm install -g renovate@${RENOVATE_VERSION}

--- a/src/azurelinux/3.0/renovate/amd64/Dockerfile
+++ b/src/azurelinux/3.0/renovate/amd64/Dockerfile
@@ -17,15 +17,13 @@ RUN tdnf update -y && \
         util-linux \
     && tdnf clean all
 
-# Token used to authenticate to the dotnet-public-npm Azure Artifacts feed.
+# Registry npm installs pull from; defaults to the Microsoft public npm proxy.
+# Internal builds override NPM_REGISTRY with the dotnet-public-npm Azure Artifacts feed and set NPM_TOKEN.
+ARG NPM_REGISTRY=https://packagefeedproxy.microsoft.io/npm/
 ARG NPM_TOKEN
 
-# When NPM_TOKEN is provided (internal builds) use the dotnet-public-npm Azure Artifacts feed;
-# otherwise fall back to the Microsoft public npm proxy (public builds have no token).
-RUN if [ -n "$NPM_TOKEN" ]; then \
-        npm config set registry https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ && \
-        npm config set "//pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/:_authToken" "$NPM_TOKEN"; \
-    else \
-        npm config set registry https://packagefeedproxy.microsoft.io/npm/; \
+RUN npm config set registry "$NPM_REGISTRY" && \
+    if [ -n "$NPM_TOKEN" ]; then \
+        npm config set "${NPM_REGISTRY#https:}:_authToken" "$NPM_TOKEN"; \
     fi && \
     npm install -g renovate@${RENOVATE_VERSION}

--- a/src/azurelinux/3.0/renovate/amd64/Dockerfile
+++ b/src/azurelinux/3.0/renovate/amd64/Dockerfile
@@ -17,9 +17,10 @@ RUN tdnf update -y && \
         util-linux \
     && tdnf clean all
 
-# Registry npm installs pull from; defaults to the Microsoft public npm proxy.
-# Internal builds override NPM_REGISTRY with the dotnet-public-npm Azure Artifacts feed and set NPM_TOKEN.
-ARG NPM_REGISTRY=https://packagefeedproxy.microsoft.io/npm/
+# npm registry. Defaults to the public dotnet-public-npm Azure Artifacts feed, which is
+# readable anonymously (works for local/dev and public builds). NPM_TOKEN is optional and
+# only needed by internal builds that ingest new package versions into the feed.
+ARG NPM_REGISTRY=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
 ARG NPM_TOKEN
 
 RUN npm config set registry "$NPM_REGISTRY" && \

--- a/src/azurelinux/3.0/renovate/amd64/Dockerfile
+++ b/src/azurelinux/3.0/renovate/amd64/Dockerfile
@@ -17,10 +17,9 @@ RUN tdnf update -y && \
         util-linux \
     && tdnf clean all
 
-# npm registry. Defaults to the public dotnet-public-npm Azure Artifacts feed, which is
-# readable anonymously (works for local/dev and public builds). NPM_TOKEN is optional and
-# only needed by internal builds that ingest new package versions into the feed.
-ARG NPM_REGISTRY=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
+# Registry npm installs pull from; defaults to the Microsoft public npm proxy.
+# Internal builds override NPM_REGISTRY with the dotnet-public-npm Azure Artifacts feed and set NPM_TOKEN.
+ARG NPM_REGISTRY=https://packagefeedproxy.microsoft.io/npm/
 ARG NPM_TOKEN
 
 RUN npm config set registry "$NPM_REGISTRY" && \

--- a/src/ubuntu/22.04/amd64/Dockerfile
+++ b/src/ubuntu/22.04/amd64/Dockerfile
@@ -96,12 +96,13 @@ RUN ARCH=$(dpkg --print-architecture) \
     && ln -s /opt/microsoft/powershell/pwsh /usr/bin/pwsh \
     && rm -f /tmp/powershell.tar.gz
 
-# Token used to authenticate to the dotnet-public-npm Azure Artifacts feed.
+# Registry npm installs pull from; defaults to the Microsoft public npm proxy.
+# Internal builds override NPM_REGISTRY with the dotnet-public-npm Azure Artifacts feed and set NPM_TOKEN.
+ARG NPM_REGISTRY=https://packagefeedproxy.microsoft.io/npm/
 ARG NPM_TOKEN
 
 # Install Node 20 from NodeSource and use the patched npm ip module.
-# When NPM_TOKEN is provided (internal builds) use the dotnet-public-npm Azure Artifacts feed;
-# otherwise fall back to the Microsoft public npm proxy (public builds have no token).
+# npm registry comes from NPM_REGISTRY (default proxy above); NPM_TOKEN adds auth for the internal feed.
 RUN cd /etc/apt/sources.list.d && \
     rm -f nodesource.list && \
     cd ~ && \
@@ -110,11 +111,9 @@ RUN cd /etc/apt/sources.list.d && \
     apt-get install nodejs -y && \
     rm -rf /var/lib/apt/lists/* && \
     rm -f nodesource_setup.sh && \
+    npm config set registry "$NPM_REGISTRY" && \
     if [ -n "$NPM_TOKEN" ]; then \
-        npm config set registry https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ && \
-        npm config set "//pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/:_authToken" "$NPM_TOKEN"; \
-    else \
-        npm config set registry https://packagefeedproxy.microsoft.io/npm/; \
+        npm config set "${NPM_REGISTRY#https:}:_authToken" "$NPM_TOKEN"; \
     fi && \
     npm install -g ip@latest
 

--- a/src/ubuntu/22.04/amd64/Dockerfile
+++ b/src/ubuntu/22.04/amd64/Dockerfile
@@ -101,7 +101,7 @@ ARG NPM_TOKEN
 
 # Install Node 20 from NodeSource and use the patched npm ip module.
 # When NPM_TOKEN is provided (internal builds) use the dotnet-public-npm Azure Artifacts feed;
-# otherwise fall back to the default public registry (public builds have no token).
+# otherwise fall back to the Microsoft public npm proxy (public builds have no token).
 RUN cd /etc/apt/sources.list.d && \
     rm -f nodesource.list && \
     cd ~ && \
@@ -113,6 +113,8 @@ RUN cd /etc/apt/sources.list.d && \
     if [ -n "$NPM_TOKEN" ]; then \
         npm config set registry https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ && \
         npm config set "//pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/:_authToken" "$NPM_TOKEN"; \
+    else \
+        npm config set registry https://packagefeedproxy.microsoft.io/npm/; \
     fi && \
     npm install -g ip@latest
 

--- a/src/ubuntu/22.04/amd64/Dockerfile
+++ b/src/ubuntu/22.04/amd64/Dockerfile
@@ -96,13 +96,14 @@ RUN ARCH=$(dpkg --print-architecture) \
     && ln -s /opt/microsoft/powershell/pwsh /usr/bin/pwsh \
     && rm -f /tmp/powershell.tar.gz
 
-# Registry npm installs pull from; defaults to the Microsoft public npm proxy.
-# Internal builds override NPM_REGISTRY with the dotnet-public-npm Azure Artifacts feed and set NPM_TOKEN.
-ARG NPM_REGISTRY=https://packagefeedproxy.microsoft.io/npm/
+# npm registry. Defaults to the public dotnet-public-npm Azure Artifacts feed, which is
+# readable anonymously (works for local/dev and public builds). NPM_TOKEN is optional and
+# only needed by internal builds that ingest new package versions into the feed.
+ARG NPM_REGISTRY=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
 ARG NPM_TOKEN
 
 # Install Node 20 from NodeSource and use the patched npm ip module.
-# npm registry comes from NPM_REGISTRY (default proxy above); NPM_TOKEN adds auth for the internal feed.
+# npm registry comes from NPM_REGISTRY (default feed above); NPM_TOKEN only adds ingestion auth for internal builds.
 RUN cd /etc/apt/sources.list.d && \
     rm -f nodesource.list && \
     cd ~ && \

--- a/src/ubuntu/22.04/amd64/Dockerfile
+++ b/src/ubuntu/22.04/amd64/Dockerfile
@@ -96,14 +96,13 @@ RUN ARCH=$(dpkg --print-architecture) \
     && ln -s /opt/microsoft/powershell/pwsh /usr/bin/pwsh \
     && rm -f /tmp/powershell.tar.gz
 
-# npm registry. Defaults to the public dotnet-public-npm Azure Artifacts feed, which is
-# readable anonymously (works for local/dev and public builds). NPM_TOKEN is optional and
-# only needed by internal builds that ingest new package versions into the feed.
-ARG NPM_REGISTRY=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
+# Registry npm installs pull from; defaults to the Microsoft public npm proxy.
+# Internal builds override NPM_REGISTRY with the dotnet-public-npm Azure Artifacts feed and set NPM_TOKEN.
+ARG NPM_REGISTRY=https://packagefeedproxy.microsoft.io/npm/
 ARG NPM_TOKEN
 
 # Install Node 20 from NodeSource and use the patched npm ip module.
-# npm registry comes from NPM_REGISTRY (default feed above); NPM_TOKEN only adds ingestion auth for internal builds.
+# npm registry comes from NPM_REGISTRY (default proxy above); NPM_TOKEN adds auth for the internal feed.
 RUN cd /etc/apt/sources.list.d && \
     rm -f nodesource.list && \
     cd ~ && \

--- a/src/ubuntu/22.04/coredeps/amd64/Dockerfile
+++ b/src/ubuntu/22.04/coredeps/amd64/Dockerfile
@@ -35,13 +35,14 @@ RUN apt-get update \
         uuid-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Registry npm installs pull from; defaults to the Microsoft public npm proxy.
-# Internal builds override NPM_REGISTRY with the dotnet-public-npm Azure Artifacts feed and set NPM_TOKEN.
-ARG NPM_REGISTRY=https://packagefeedproxy.microsoft.io/npm/
+# npm registry. Defaults to the public dotnet-public-npm Azure Artifacts feed, which is
+# readable anonymously (works for local/dev and public builds). NPM_TOKEN is optional and
+# only needed by internal builds that ingest new package versions into the feed.
+ARG NPM_REGISTRY=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
 ARG NPM_TOKEN
 
 # Install Node 20 from NodeSource and use the patched npm ip module.
-# npm registry comes from NPM_REGISTRY (default proxy above); NPM_TOKEN adds auth for the internal feed.
+# npm registry comes from NPM_REGISTRY (default feed above); NPM_TOKEN only adds ingestion auth for internal builds.
 RUN cd /etc/apt/sources.list.d && \
     rm -f nodesource.list && \
     cd ~ && \

--- a/src/ubuntu/22.04/coredeps/amd64/Dockerfile
+++ b/src/ubuntu/22.04/coredeps/amd64/Dockerfile
@@ -35,14 +35,13 @@ RUN apt-get update \
         uuid-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# npm registry. Defaults to the public dotnet-public-npm Azure Artifacts feed, which is
-# readable anonymously (works for local/dev and public builds). NPM_TOKEN is optional and
-# only needed by internal builds that ingest new package versions into the feed.
-ARG NPM_REGISTRY=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
+# Registry npm installs pull from; defaults to the Microsoft public npm proxy.
+# Internal builds override NPM_REGISTRY with the dotnet-public-npm Azure Artifacts feed and set NPM_TOKEN.
+ARG NPM_REGISTRY=https://packagefeedproxy.microsoft.io/npm/
 ARG NPM_TOKEN
 
 # Install Node 20 from NodeSource and use the patched npm ip module.
-# npm registry comes from NPM_REGISTRY (default feed above); NPM_TOKEN only adds ingestion auth for internal builds.
+# npm registry comes from NPM_REGISTRY (default proxy above); NPM_TOKEN adds auth for the internal feed.
 RUN cd /etc/apt/sources.list.d && \
     rm -f nodesource.list && \
     cd ~ && \

--- a/src/ubuntu/22.04/coredeps/amd64/Dockerfile
+++ b/src/ubuntu/22.04/coredeps/amd64/Dockerfile
@@ -35,12 +35,13 @@ RUN apt-get update \
         uuid-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Token used to authenticate to the dotnet-public-npm Azure Artifacts feed.
+# Registry npm installs pull from; defaults to the Microsoft public npm proxy.
+# Internal builds override NPM_REGISTRY with the dotnet-public-npm Azure Artifacts feed and set NPM_TOKEN.
+ARG NPM_REGISTRY=https://packagefeedproxy.microsoft.io/npm/
 ARG NPM_TOKEN
 
 # Install Node 20 from NodeSource and use the patched npm ip module.
-# When NPM_TOKEN is provided (internal builds) use the dotnet-public-npm Azure Artifacts feed;
-# otherwise fall back to the Microsoft public npm proxy (public builds have no token).
+# npm registry comes from NPM_REGISTRY (default proxy above); NPM_TOKEN adds auth for the internal feed.
 RUN cd /etc/apt/sources.list.d && \
     rm -f nodesource.list && \
     cd ~ && \
@@ -49,10 +50,8 @@ RUN cd /etc/apt/sources.list.d && \
     apt-get install nodejs -y && \
     rm -rf /var/lib/apt/lists/* && \
     rm -f nodesource_setup.sh && \
+    npm config set registry "$NPM_REGISTRY" && \
     if [ -n "$NPM_TOKEN" ]; then \
-        npm config set registry https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ && \
-        npm config set "//pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/:_authToken" "$NPM_TOKEN"; \
-    else \
-        npm config set registry https://packagefeedproxy.microsoft.io/npm/; \
+        npm config set "${NPM_REGISTRY#https:}:_authToken" "$NPM_TOKEN"; \
     fi && \
     npm install -g ip@latest

--- a/src/ubuntu/22.04/coredeps/amd64/Dockerfile
+++ b/src/ubuntu/22.04/coredeps/amd64/Dockerfile
@@ -40,7 +40,7 @@ ARG NPM_TOKEN
 
 # Install Node 20 from NodeSource and use the patched npm ip module.
 # When NPM_TOKEN is provided (internal builds) use the dotnet-public-npm Azure Artifacts feed;
-# otherwise fall back to the default public registry (public builds have no token).
+# otherwise fall back to the Microsoft public npm proxy (public builds have no token).
 RUN cd /etc/apt/sources.list.d && \
     rm -f nodesource.list && \
     cd ~ && \
@@ -52,5 +52,7 @@ RUN cd /etc/apt/sources.list.d && \
     if [ -n "$NPM_TOKEN" ]; then \
         npm config set registry https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ && \
         npm config set "//pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/:_authToken" "$NPM_TOKEN"; \
+    else \
+        npm config set registry https://packagefeedproxy.microsoft.io/npm/; \
     fi && \
     npm install -g ip@latest

--- a/src/ubuntu/22.04/helix/webassembly/amd64/Dockerfile
+++ b/src/ubuntu/22.04/helix/webassembly/amd64/Dockerfile
@@ -44,10 +44,12 @@ RUN /tmp/setup-node-23.x.sh && apt-get -y install nodejs
 ARG NPM_TOKEN
 
 # When NPM_TOKEN is provided (internal builds) use the dotnet-public-npm Azure Artifacts feed;
-# otherwise fall back to the default public registry (public builds have no token).
+# otherwise fall back to the Microsoft public npm proxy (public builds have no token).
 RUN if [ -n "$NPM_TOKEN" ]; then \
         npm config set registry https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ && \
         npm config set "//pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/:_authToken" "$NPM_TOKEN"; \
+    else \
+        npm config set registry https://packagefeedproxy.microsoft.io/npm/; \
     fi && \
     npm install -g npm
 

--- a/src/ubuntu/22.04/helix/webassembly/amd64/Dockerfile
+++ b/src/ubuntu/22.04/helix/webassembly/amd64/Dockerfile
@@ -40,16 +40,14 @@ RUN locale-gen en_US.UTF-8
 COPY ./setup-node-23.x.sh /tmp
 RUN /tmp/setup-node-23.x.sh && apt-get -y install nodejs
 
-# Token used to authenticate to the dotnet-public-npm Azure Artifacts feed.
+# Registry npm installs pull from; defaults to the Microsoft public npm proxy.
+# Internal builds override NPM_REGISTRY with the dotnet-public-npm Azure Artifacts feed and set NPM_TOKEN.
+ARG NPM_REGISTRY=https://packagefeedproxy.microsoft.io/npm/
 ARG NPM_TOKEN
 
-# When NPM_TOKEN is provided (internal builds) use the dotnet-public-npm Azure Artifacts feed;
-# otherwise fall back to the Microsoft public npm proxy (public builds have no token).
-RUN if [ -n "$NPM_TOKEN" ]; then \
-        npm config set registry https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ && \
-        npm config set "//pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/:_authToken" "$NPM_TOKEN"; \
-    else \
-        npm config set registry https://packagefeedproxy.microsoft.io/npm/; \
+RUN npm config set registry "$NPM_REGISTRY" && \
+    if [ -n "$NPM_TOKEN" ]; then \
+        npm config set "${NPM_REGISTRY#https:}:_authToken" "$NPM_TOKEN"; \
     fi && \
     npm install -g npm
 

--- a/src/ubuntu/22.04/helix/webassembly/amd64/Dockerfile
+++ b/src/ubuntu/22.04/helix/webassembly/amd64/Dockerfile
@@ -40,9 +40,10 @@ RUN locale-gen en_US.UTF-8
 COPY ./setup-node-23.x.sh /tmp
 RUN /tmp/setup-node-23.x.sh && apt-get -y install nodejs
 
-# Registry npm installs pull from; defaults to the Microsoft public npm proxy.
-# Internal builds override NPM_REGISTRY with the dotnet-public-npm Azure Artifacts feed and set NPM_TOKEN.
-ARG NPM_REGISTRY=https://packagefeedproxy.microsoft.io/npm/
+# npm registry. Defaults to the public dotnet-public-npm Azure Artifacts feed, which is
+# readable anonymously (works for local/dev and public builds). NPM_TOKEN is optional and
+# only needed by internal builds that ingest new package versions into the feed.
+ARG NPM_REGISTRY=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
 ARG NPM_TOKEN
 
 RUN npm config set registry "$NPM_REGISTRY" && \

--- a/src/ubuntu/22.04/helix/webassembly/amd64/Dockerfile
+++ b/src/ubuntu/22.04/helix/webassembly/amd64/Dockerfile
@@ -40,10 +40,9 @@ RUN locale-gen en_US.UTF-8
 COPY ./setup-node-23.x.sh /tmp
 RUN /tmp/setup-node-23.x.sh && apt-get -y install nodejs
 
-# npm registry. Defaults to the public dotnet-public-npm Azure Artifacts feed, which is
-# readable anonymously (works for local/dev and public builds). NPM_TOKEN is optional and
-# only needed by internal builds that ingest new package versions into the feed.
-ARG NPM_REGISTRY=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
+# Registry npm installs pull from; defaults to the Microsoft public npm proxy.
+# Internal builds override NPM_REGISTRY with the dotnet-public-npm Azure Artifacts feed and set NPM_TOKEN.
+ARG NPM_REGISTRY=https://packagefeedproxy.microsoft.io/npm/
 ARG NPM_TOKEN
 
 RUN npm config set registry "$NPM_REGISTRY" && \

--- a/src/ubuntu/24.04/Dockerfile
+++ b/src/ubuntu/24.04/Dockerfile
@@ -95,12 +95,13 @@ RUN ARCH=$(dpkg --print-architecture) \
     && ln -s /opt/microsoft/powershell/pwsh /usr/bin/pwsh \
     && rm -f /tmp/powershell.tar.gz
 
-# Token used to authenticate to the dotnet-public-npm Azure Artifacts feed.
+# Registry npm installs pull from; defaults to the Microsoft public npm proxy.
+# Internal builds override NPM_REGISTRY with the dotnet-public-npm Azure Artifacts feed and set NPM_TOKEN.
+ARG NPM_REGISTRY=https://packagefeedproxy.microsoft.io/npm/
 ARG NPM_TOKEN
 
 # Install node 20 and use its bundled npm so we don't pull in distro npm dependencies unnecessarily.
-# When NPM_TOKEN is provided (internal builds) use the dotnet-public-npm Azure Artifacts feed;
-# otherwise fall back to the Microsoft public npm proxy (public builds have no token).
+# npm registry comes from NPM_REGISTRY (default proxy above); NPM_TOKEN adds auth for the internal feed.
 RUN rm -f /etc/apt/sources.list.d/nodesource.list && \
     cd ~ && \
     curl -sL https://deb.nodesource.com/setup_20.x -o nodesource_setup.sh && \
@@ -108,11 +109,9 @@ RUN rm -f /etc/apt/sources.list.d/nodesource.list && \
     apt-get install nodejs -y && \
     rm -rf /var/lib/apt/lists/* && \
     rm -f nodesource_setup.sh && \
+    npm config set registry "$NPM_REGISTRY" && \
     if [ -n "$NPM_TOKEN" ]; then \
-        npm config set registry https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ && \
-        npm config set "//pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/:_authToken" "$NPM_TOKEN"; \
-    else \
-        npm config set registry https://packagefeedproxy.microsoft.io/npm/; \
+        npm config set "${NPM_REGISTRY#https:}:_authToken" "$NPM_TOKEN"; \
     fi && \
     npm install -g ip@latest
 

--- a/src/ubuntu/24.04/Dockerfile
+++ b/src/ubuntu/24.04/Dockerfile
@@ -95,13 +95,14 @@ RUN ARCH=$(dpkg --print-architecture) \
     && ln -s /opt/microsoft/powershell/pwsh /usr/bin/pwsh \
     && rm -f /tmp/powershell.tar.gz
 
-# Registry npm installs pull from; defaults to the Microsoft public npm proxy.
-# Internal builds override NPM_REGISTRY with the dotnet-public-npm Azure Artifacts feed and set NPM_TOKEN.
-ARG NPM_REGISTRY=https://packagefeedproxy.microsoft.io/npm/
+# npm registry. Defaults to the public dotnet-public-npm Azure Artifacts feed, which is
+# readable anonymously (works for local/dev and public builds). NPM_TOKEN is optional and
+# only needed by internal builds that ingest new package versions into the feed.
+ARG NPM_REGISTRY=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
 ARG NPM_TOKEN
 
 # Install node 20 and use its bundled npm so we don't pull in distro npm dependencies unnecessarily.
-# npm registry comes from NPM_REGISTRY (default proxy above); NPM_TOKEN adds auth for the internal feed.
+# npm registry comes from NPM_REGISTRY (default feed above); NPM_TOKEN only adds ingestion auth for internal builds.
 RUN rm -f /etc/apt/sources.list.d/nodesource.list && \
     cd ~ && \
     curl -sL https://deb.nodesource.com/setup_20.x -o nodesource_setup.sh && \

--- a/src/ubuntu/24.04/Dockerfile
+++ b/src/ubuntu/24.04/Dockerfile
@@ -95,14 +95,13 @@ RUN ARCH=$(dpkg --print-architecture) \
     && ln -s /opt/microsoft/powershell/pwsh /usr/bin/pwsh \
     && rm -f /tmp/powershell.tar.gz
 
-# npm registry. Defaults to the public dotnet-public-npm Azure Artifacts feed, which is
-# readable anonymously (works for local/dev and public builds). NPM_TOKEN is optional and
-# only needed by internal builds that ingest new package versions into the feed.
-ARG NPM_REGISTRY=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
+# Registry npm installs pull from; defaults to the Microsoft public npm proxy.
+# Internal builds override NPM_REGISTRY with the dotnet-public-npm Azure Artifacts feed and set NPM_TOKEN.
+ARG NPM_REGISTRY=https://packagefeedproxy.microsoft.io/npm/
 ARG NPM_TOKEN
 
 # Install node 20 and use its bundled npm so we don't pull in distro npm dependencies unnecessarily.
-# npm registry comes from NPM_REGISTRY (default feed above); NPM_TOKEN only adds ingestion auth for internal builds.
+# npm registry comes from NPM_REGISTRY (default proxy above); NPM_TOKEN adds auth for the internal feed.
 RUN rm -f /etc/apt/sources.list.d/nodesource.list && \
     cd ~ && \
     curl -sL https://deb.nodesource.com/setup_20.x -o nodesource_setup.sh && \

--- a/src/ubuntu/24.04/Dockerfile
+++ b/src/ubuntu/24.04/Dockerfile
@@ -100,7 +100,7 @@ ARG NPM_TOKEN
 
 # Install node 20 and use its bundled npm so we don't pull in distro npm dependencies unnecessarily.
 # When NPM_TOKEN is provided (internal builds) use the dotnet-public-npm Azure Artifacts feed;
-# otherwise fall back to the default public registry (public builds have no token).
+# otherwise fall back to the Microsoft public npm proxy (public builds have no token).
 RUN rm -f /etc/apt/sources.list.d/nodesource.list && \
     cd ~ && \
     curl -sL https://deb.nodesource.com/setup_20.x -o nodesource_setup.sh && \
@@ -111,6 +111,8 @@ RUN rm -f /etc/apt/sources.list.d/nodesource.list && \
     if [ -n "$NPM_TOKEN" ]; then \
         npm config set registry https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ && \
         npm config set "//pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/:_authToken" "$NPM_TOKEN"; \
+    else \
+        npm config set registry https://packagefeedproxy.microsoft.io/npm/; \
     fi && \
     npm install -g ip@latest
 

--- a/src/ubuntu/24.04/helix/webassembly/amd64/Dockerfile
+++ b/src/ubuntu/24.04/helix/webassembly/amd64/Dockerfile
@@ -45,9 +45,10 @@ RUN chmod +x /tmp/setup-node-23.x.sh \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-# Registry npm installs pull from; defaults to the Microsoft public npm proxy.
-# Internal builds override NPM_REGISTRY with the dotnet-public-npm Azure Artifacts feed and set NPM_TOKEN.
-ARG NPM_REGISTRY=https://packagefeedproxy.microsoft.io/npm/
+# npm registry. Defaults to the public dotnet-public-npm Azure Artifacts feed, which is
+# readable anonymously (works for local/dev and public builds). NPM_TOKEN is optional and
+# only needed by internal builds that ingest new package versions into the feed.
+ARG NPM_REGISTRY=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
 ARG NPM_TOKEN
 
 RUN npm config set registry "$NPM_REGISTRY" && \

--- a/src/ubuntu/24.04/helix/webassembly/amd64/Dockerfile
+++ b/src/ubuntu/24.04/helix/webassembly/amd64/Dockerfile
@@ -49,10 +49,12 @@ RUN chmod +x /tmp/setup-node-23.x.sh \
 ARG NPM_TOKEN
 
 # When NPM_TOKEN is provided (internal builds) use the dotnet-public-npm Azure Artifacts feed;
-# otherwise fall back to the default public registry (public builds have no token).
+# otherwise fall back to the Microsoft public npm proxy (public builds have no token).
 RUN if [ -n "$NPM_TOKEN" ]; then \
         npm config set registry https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ && \
         npm config set "//pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/:_authToken" "$NPM_TOKEN"; \
+    else \
+        npm config set registry https://packagefeedproxy.microsoft.io/npm/; \
     fi && \
     npm install -g npm
 

--- a/src/ubuntu/24.04/helix/webassembly/amd64/Dockerfile
+++ b/src/ubuntu/24.04/helix/webassembly/amd64/Dockerfile
@@ -45,10 +45,9 @@ RUN chmod +x /tmp/setup-node-23.x.sh \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-# npm registry. Defaults to the public dotnet-public-npm Azure Artifacts feed, which is
-# readable anonymously (works for local/dev and public builds). NPM_TOKEN is optional and
-# only needed by internal builds that ingest new package versions into the feed.
-ARG NPM_REGISTRY=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
+# Registry npm installs pull from; defaults to the Microsoft public npm proxy.
+# Internal builds override NPM_REGISTRY with the dotnet-public-npm Azure Artifacts feed and set NPM_TOKEN.
+ARG NPM_REGISTRY=https://packagefeedproxy.microsoft.io/npm/
 ARG NPM_TOKEN
 
 RUN npm config set registry "$NPM_REGISTRY" && \

--- a/src/ubuntu/24.04/helix/webassembly/amd64/Dockerfile
+++ b/src/ubuntu/24.04/helix/webassembly/amd64/Dockerfile
@@ -45,16 +45,14 @@ RUN chmod +x /tmp/setup-node-23.x.sh \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-# Token used to authenticate to the dotnet-public-npm Azure Artifacts feed.
+# Registry npm installs pull from; defaults to the Microsoft public npm proxy.
+# Internal builds override NPM_REGISTRY with the dotnet-public-npm Azure Artifacts feed and set NPM_TOKEN.
+ARG NPM_REGISTRY=https://packagefeedproxy.microsoft.io/npm/
 ARG NPM_TOKEN
 
-# When NPM_TOKEN is provided (internal builds) use the dotnet-public-npm Azure Artifacts feed;
-# otherwise fall back to the Microsoft public npm proxy (public builds have no token).
-RUN if [ -n "$NPM_TOKEN" ]; then \
-        npm config set registry https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ && \
-        npm config set "//pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/:_authToken" "$NPM_TOKEN"; \
-    else \
-        npm config set registry https://packagefeedproxy.microsoft.io/npm/; \
+RUN npm config set registry "$NPM_REGISTRY" && \
+    if [ -n "$NPM_TOKEN" ]; then \
+        npm config set "${NPM_REGISTRY#https:}:_authToken" "$NPM_TOKEN"; \
     fi && \
     npm install -g npm
 

--- a/src/ubuntu/26.04/Dockerfile
+++ b/src/ubuntu/26.04/Dockerfile
@@ -96,14 +96,13 @@ RUN ARCH=$(dpkg --print-architecture) \
     && ln -s /opt/microsoft/powershell/pwsh /usr/bin/pwsh \
     && rm -f /tmp/powershell.tar.gz
 
-# npm registry. Defaults to the public dotnet-public-npm Azure Artifacts feed, which is
-# readable anonymously (works for local/dev and public builds). NPM_TOKEN is optional and
-# only needed by internal builds that ingest new package versions into the feed.
-ARG NPM_REGISTRY=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
+# Registry npm installs pull from; defaults to the Microsoft public npm proxy.
+# Internal builds override NPM_REGISTRY with the dotnet-public-npm Azure Artifacts feed and set NPM_TOKEN.
+ARG NPM_REGISTRY=https://packagefeedproxy.microsoft.io/npm/
 ARG NPM_TOKEN
 
 # Install node 20 and use its bundled npm so we don't pull in distro npm dependencies unnecessarily.
-# npm registry comes from NPM_REGISTRY (default feed above); NPM_TOKEN only adds ingestion auth for internal builds.
+# npm registry comes from NPM_REGISTRY (default proxy above); NPM_TOKEN adds auth for the internal feed.
 RUN rm -f /etc/apt/sources.list.d/nodesource.list && \
     cd ~ && \
     curl -sL https://deb.nodesource.com/setup_20.x -o nodesource_setup.sh && \

--- a/src/ubuntu/26.04/Dockerfile
+++ b/src/ubuntu/26.04/Dockerfile
@@ -96,13 +96,14 @@ RUN ARCH=$(dpkg --print-architecture) \
     && ln -s /opt/microsoft/powershell/pwsh /usr/bin/pwsh \
     && rm -f /tmp/powershell.tar.gz
 
-# Registry npm installs pull from; defaults to the Microsoft public npm proxy.
-# Internal builds override NPM_REGISTRY with the dotnet-public-npm Azure Artifacts feed and set NPM_TOKEN.
-ARG NPM_REGISTRY=https://packagefeedproxy.microsoft.io/npm/
+# npm registry. Defaults to the public dotnet-public-npm Azure Artifacts feed, which is
+# readable anonymously (works for local/dev and public builds). NPM_TOKEN is optional and
+# only needed by internal builds that ingest new package versions into the feed.
+ARG NPM_REGISTRY=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
 ARG NPM_TOKEN
 
 # Install node 20 and use its bundled npm so we don't pull in distro npm dependencies unnecessarily.
-# npm registry comes from NPM_REGISTRY (default proxy above); NPM_TOKEN adds auth for the internal feed.
+# npm registry comes from NPM_REGISTRY (default feed above); NPM_TOKEN only adds ingestion auth for internal builds.
 RUN rm -f /etc/apt/sources.list.d/nodesource.list && \
     cd ~ && \
     curl -sL https://deb.nodesource.com/setup_20.x -o nodesource_setup.sh && \

--- a/src/ubuntu/26.04/Dockerfile
+++ b/src/ubuntu/26.04/Dockerfile
@@ -96,12 +96,13 @@ RUN ARCH=$(dpkg --print-architecture) \
     && ln -s /opt/microsoft/powershell/pwsh /usr/bin/pwsh \
     && rm -f /tmp/powershell.tar.gz
 
-# Token used to authenticate to the dotnet-public-npm Azure Artifacts feed.
+# Registry npm installs pull from; defaults to the Microsoft public npm proxy.
+# Internal builds override NPM_REGISTRY with the dotnet-public-npm Azure Artifacts feed and set NPM_TOKEN.
+ARG NPM_REGISTRY=https://packagefeedproxy.microsoft.io/npm/
 ARG NPM_TOKEN
 
 # Install node 20 and use its bundled npm so we don't pull in distro npm dependencies unnecessarily.
-# When NPM_TOKEN is provided (internal builds) use the dotnet-public-npm Azure Artifacts feed;
-# otherwise fall back to the Microsoft public npm proxy (public builds have no token).
+# npm registry comes from NPM_REGISTRY (default proxy above); NPM_TOKEN adds auth for the internal feed.
 RUN rm -f /etc/apt/sources.list.d/nodesource.list && \
     cd ~ && \
     curl -sL https://deb.nodesource.com/setup_20.x -o nodesource_setup.sh && \
@@ -109,11 +110,9 @@ RUN rm -f /etc/apt/sources.list.d/nodesource.list && \
     apt-get install nodejs -y && \
     rm -rf /var/lib/apt/lists/* && \
     rm -f nodesource_setup.sh && \
+    npm config set registry "$NPM_REGISTRY" && \
     if [ -n "$NPM_TOKEN" ]; then \
-        npm config set registry https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ && \
-        npm config set "//pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/:_authToken" "$NPM_TOKEN"; \
-    else \
-        npm config set registry https://packagefeedproxy.microsoft.io/npm/; \
+        npm config set "${NPM_REGISTRY#https:}:_authToken" "$NPM_TOKEN"; \
     fi && \
     npm install -g ip@latest
 

--- a/src/ubuntu/26.04/Dockerfile
+++ b/src/ubuntu/26.04/Dockerfile
@@ -101,7 +101,7 @@ ARG NPM_TOKEN
 
 # Install node 20 and use its bundled npm so we don't pull in distro npm dependencies unnecessarily.
 # When NPM_TOKEN is provided (internal builds) use the dotnet-public-npm Azure Artifacts feed;
-# otherwise fall back to the default public registry (public builds have no token).
+# otherwise fall back to the Microsoft public npm proxy (public builds have no token).
 RUN rm -f /etc/apt/sources.list.d/nodesource.list && \
     cd ~ && \
     curl -sL https://deb.nodesource.com/setup_20.x -o nodesource_setup.sh && \
@@ -112,6 +112,8 @@ RUN rm -f /etc/apt/sources.list.d/nodesource.list && \
     if [ -n "$NPM_TOKEN" ]; then \
         npm config set registry https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ && \
         npm config set "//pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/:_authToken" "$NPM_TOKEN"; \
+    else \
+        npm config set registry https://packagefeedproxy.microsoft.io/npm/; \
     fi && \
     npm install -g ip@latest
 

--- a/src/ubuntu/26.04/helix/webassembly/amd64/Dockerfile
+++ b/src/ubuntu/26.04/helix/webassembly/amd64/Dockerfile
@@ -45,9 +45,10 @@ RUN chmod +x /tmp/setup-node-23.x.sh \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-# Registry npm installs pull from; defaults to the Microsoft public npm proxy.
-# Internal builds override NPM_REGISTRY with the dotnet-public-npm Azure Artifacts feed and set NPM_TOKEN.
-ARG NPM_REGISTRY=https://packagefeedproxy.microsoft.io/npm/
+# npm registry. Defaults to the public dotnet-public-npm Azure Artifacts feed, which is
+# readable anonymously (works for local/dev and public builds). NPM_TOKEN is optional and
+# only needed by internal builds that ingest new package versions into the feed.
+ARG NPM_REGISTRY=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
 ARG NPM_TOKEN
 
 RUN npm config set registry "$NPM_REGISTRY" && \

--- a/src/ubuntu/26.04/helix/webassembly/amd64/Dockerfile
+++ b/src/ubuntu/26.04/helix/webassembly/amd64/Dockerfile
@@ -49,10 +49,12 @@ RUN chmod +x /tmp/setup-node-23.x.sh \
 ARG NPM_TOKEN
 
 # When NPM_TOKEN is provided (internal builds) use the dotnet-public-npm Azure Artifacts feed;
-# otherwise fall back to the default public registry (public builds have no token).
+# otherwise fall back to the Microsoft public npm proxy (public builds have no token).
 RUN if [ -n "$NPM_TOKEN" ]; then \
         npm config set registry https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ && \
         npm config set "//pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/:_authToken" "$NPM_TOKEN"; \
+    else \
+        npm config set registry https://packagefeedproxy.microsoft.io/npm/; \
     fi && \
     npm install -g npm
 

--- a/src/ubuntu/26.04/helix/webassembly/amd64/Dockerfile
+++ b/src/ubuntu/26.04/helix/webassembly/amd64/Dockerfile
@@ -45,10 +45,9 @@ RUN chmod +x /tmp/setup-node-23.x.sh \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-# npm registry. Defaults to the public dotnet-public-npm Azure Artifacts feed, which is
-# readable anonymously (works for local/dev and public builds). NPM_TOKEN is optional and
-# only needed by internal builds that ingest new package versions into the feed.
-ARG NPM_REGISTRY=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
+# Registry npm installs pull from; defaults to the Microsoft public npm proxy.
+# Internal builds override NPM_REGISTRY with the dotnet-public-npm Azure Artifacts feed and set NPM_TOKEN.
+ARG NPM_REGISTRY=https://packagefeedproxy.microsoft.io/npm/
 ARG NPM_TOKEN
 
 RUN npm config set registry "$NPM_REGISTRY" && \

--- a/src/ubuntu/26.04/helix/webassembly/amd64/Dockerfile
+++ b/src/ubuntu/26.04/helix/webassembly/amd64/Dockerfile
@@ -45,16 +45,14 @@ RUN chmod +x /tmp/setup-node-23.x.sh \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-# Token used to authenticate to the dotnet-public-npm Azure Artifacts feed.
+# Registry npm installs pull from; defaults to the Microsoft public npm proxy.
+# Internal builds override NPM_REGISTRY with the dotnet-public-npm Azure Artifacts feed and set NPM_TOKEN.
+ARG NPM_REGISTRY=https://packagefeedproxy.microsoft.io/npm/
 ARG NPM_TOKEN
 
-# When NPM_TOKEN is provided (internal builds) use the dotnet-public-npm Azure Artifacts feed;
-# otherwise fall back to the Microsoft public npm proxy (public builds have no token).
-RUN if [ -n "$NPM_TOKEN" ]; then \
-        npm config set registry https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ && \
-        npm config set "//pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/:_authToken" "$NPM_TOKEN"; \
-    else \
-        npm config set registry https://packagefeedproxy.microsoft.io/npm/; \
+RUN npm config set registry "$NPM_REGISTRY" && \
+    if [ -n "$NPM_TOKEN" ]; then \
+        npm config set "${NPM_REGISTRY#https:}:_authToken" "$NPM_TOKEN"; \
     fi && \
     npm install -g npm
 

--- a/src/windowsservercore/ltsc2022/helix/webassembly/amd64/Dockerfile
+++ b/src/windowsservercore/ltsc2022/helix/webassembly/amd64/Dockerfile
@@ -40,9 +40,10 @@ RUN powershell -Command " `
         Invoke-WebRequest -Uri $nodeUrl -OutFile $env:TEMP\nodejs.msi; `
         Start-Process msiexec.exe -ArgumentList '/i', $env:TEMP\nodejs.msi, '/quiet', '/passive', '/qn', '/norestart' -NoNewWindow -Wait"
 
-# Registry npm installs pull from; defaults to the Microsoft public npm proxy.
-# Internal builds override NPM_REGISTRY with the dotnet-public-npm Azure Artifacts feed and set NPM_TOKEN.
-ARG NPM_REGISTRY=https://packagefeedproxy.microsoft.io/npm/
+# npm registry. Defaults to the public dotnet-public-npm Azure Artifacts feed, which is
+# readable anonymously (works for local/dev and public builds). NPM_TOKEN is optional and
+# only needed by internal builds that ingest new package versions into the feed.
+ARG NPM_REGISTRY=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
 ARG NPM_TOKEN
 
 # hadolint ignore=SC1072

--- a/src/windowsservercore/ltsc2022/helix/webassembly/amd64/Dockerfile
+++ b/src/windowsservercore/ltsc2022/helix/webassembly/amd64/Dockerfile
@@ -40,10 +40,9 @@ RUN powershell -Command " `
         Invoke-WebRequest -Uri $nodeUrl -OutFile $env:TEMP\nodejs.msi; `
         Start-Process msiexec.exe -ArgumentList '/i', $env:TEMP\nodejs.msi, '/quiet', '/passive', '/qn', '/norestart' -NoNewWindow -Wait"
 
-# npm registry. Defaults to the public dotnet-public-npm Azure Artifacts feed, which is
-# readable anonymously (works for local/dev and public builds). NPM_TOKEN is optional and
-# only needed by internal builds that ingest new package versions into the feed.
-ARG NPM_REGISTRY=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
+# Registry npm installs pull from; defaults to the Microsoft public npm proxy.
+# Internal builds override NPM_REGISTRY with the dotnet-public-npm Azure Artifacts feed and set NPM_TOKEN.
+ARG NPM_REGISTRY=https://packagefeedproxy.microsoft.io/npm/
 ARG NPM_TOKEN
 
 # hadolint ignore=SC1072

--- a/src/windowsservercore/ltsc2022/helix/webassembly/amd64/Dockerfile
+++ b/src/windowsservercore/ltsc2022/helix/webassembly/amd64/Dockerfile
@@ -40,13 +40,16 @@ RUN powershell -Command " `
         Invoke-WebRequest -Uri $nodeUrl -OutFile $env:TEMP\nodejs.msi; `
         Start-Process msiexec.exe -ArgumentList '/i', $env:TEMP\nodejs.msi, '/quiet', '/passive', '/qn', '/norestart' -NoNewWindow -Wait"
 
+# Registry npm installs pull from; defaults to the Microsoft public npm proxy.
+# Internal builds override NPM_REGISTRY with the dotnet-public-npm Azure Artifacts feed and set NPM_TOKEN.
+ARG NPM_REGISTRY=https://packagefeedproxy.microsoft.io/npm/
 ARG NPM_TOKEN
 
 # hadolint ignore=SC1072
-RUN if defined NPM_TOKEN ( `
-        npm config set registry https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ `
-        && npm config set "//pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/:_authToken" %NPM_TOKEN% `
-    ) else (npm config set registry https://packagefeedproxy.microsoft.io/npm/)
+RUN npm config set registry %NPM_REGISTRY% `
+    && if defined NPM_TOKEN ( `
+        npm config set "%NPM_REGISTRY:https:=%:_authToken" %NPM_TOKEN% `
+    )
 
 # install latest jsvu and v8 engine
 RUN npm install jsvu -g `

--- a/src/windowsservercore/ltsc2022/helix/webassembly/amd64/Dockerfile
+++ b/src/windowsservercore/ltsc2022/helix/webassembly/amd64/Dockerfile
@@ -46,7 +46,7 @@ ARG NPM_TOKEN
 RUN if defined NPM_TOKEN ( `
         npm config set registry https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ `
         && npm config set "//pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/:_authToken" %NPM_TOKEN% `
-    ) else (echo Skipping npm config - using default registry)
+    ) else (npm config set registry https://packagefeedproxy.microsoft.io/npm/)
 
 # install latest jsvu and v8 engine
 RUN npm install jsvu -g `

--- a/src/windowsservercore/ltsc2025/helix/webassembly/amd64/Dockerfile
+++ b/src/windowsservercore/ltsc2025/helix/webassembly/amd64/Dockerfile
@@ -40,9 +40,10 @@ RUN powershell -Command " `
         Invoke-WebRequest -Uri $nodeUrl -OutFile $env:TEMP\nodejs.msi; `
         Start-Process msiexec.exe -ArgumentList '/i', $env:TEMP\nodejs.msi, '/quiet', '/passive', '/qn', '/norestart' -NoNewWindow -Wait"
 
-# Registry npm installs pull from; defaults to the Microsoft public npm proxy.
-# Internal builds override NPM_REGISTRY with the dotnet-public-npm Azure Artifacts feed and set NPM_TOKEN.
-ARG NPM_REGISTRY=https://packagefeedproxy.microsoft.io/npm/
+# npm registry. Defaults to the public dotnet-public-npm Azure Artifacts feed, which is
+# readable anonymously (works for local/dev and public builds). NPM_TOKEN is optional and
+# only needed by internal builds that ingest new package versions into the feed.
+ARG NPM_REGISTRY=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
 ARG NPM_TOKEN
 
 # hadolint ignore=SC1072

--- a/src/windowsservercore/ltsc2025/helix/webassembly/amd64/Dockerfile
+++ b/src/windowsservercore/ltsc2025/helix/webassembly/amd64/Dockerfile
@@ -40,10 +40,9 @@ RUN powershell -Command " `
         Invoke-WebRequest -Uri $nodeUrl -OutFile $env:TEMP\nodejs.msi; `
         Start-Process msiexec.exe -ArgumentList '/i', $env:TEMP\nodejs.msi, '/quiet', '/passive', '/qn', '/norestart' -NoNewWindow -Wait"
 
-# npm registry. Defaults to the public dotnet-public-npm Azure Artifacts feed, which is
-# readable anonymously (works for local/dev and public builds). NPM_TOKEN is optional and
-# only needed by internal builds that ingest new package versions into the feed.
-ARG NPM_REGISTRY=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
+# Registry npm installs pull from; defaults to the Microsoft public npm proxy.
+# Internal builds override NPM_REGISTRY with the dotnet-public-npm Azure Artifacts feed and set NPM_TOKEN.
+ARG NPM_REGISTRY=https://packagefeedproxy.microsoft.io/npm/
 ARG NPM_TOKEN
 
 # hadolint ignore=SC1072

--- a/src/windowsservercore/ltsc2025/helix/webassembly/amd64/Dockerfile
+++ b/src/windowsservercore/ltsc2025/helix/webassembly/amd64/Dockerfile
@@ -40,13 +40,16 @@ RUN powershell -Command " `
         Invoke-WebRequest -Uri $nodeUrl -OutFile $env:TEMP\nodejs.msi; `
         Start-Process msiexec.exe -ArgumentList '/i', $env:TEMP\nodejs.msi, '/quiet', '/passive', '/qn', '/norestart' -NoNewWindow -Wait"
 
+# Registry npm installs pull from; defaults to the Microsoft public npm proxy.
+# Internal builds override NPM_REGISTRY with the dotnet-public-npm Azure Artifacts feed and set NPM_TOKEN.
+ARG NPM_REGISTRY=https://packagefeedproxy.microsoft.io/npm/
 ARG NPM_TOKEN
 
 # hadolint ignore=SC1072
-RUN if defined NPM_TOKEN ( `
-        npm config set registry https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ `
-        && npm config set "//pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/:_authToken" %NPM_TOKEN% `
-    ) else (npm config set registry https://packagefeedproxy.microsoft.io/npm/)
+RUN npm config set registry %NPM_REGISTRY% `
+    && if defined NPM_TOKEN ( `
+        npm config set "%NPM_REGISTRY:https:=%:_authToken" %NPM_TOKEN% `
+    )
 
 # install latest jsvu and v8 engine
 RUN npm install jsvu -g `

--- a/src/windowsservercore/ltsc2025/helix/webassembly/amd64/Dockerfile
+++ b/src/windowsservercore/ltsc2025/helix/webassembly/amd64/Dockerfile
@@ -46,7 +46,7 @@ ARG NPM_TOKEN
 RUN if defined NPM_TOKEN ( `
         npm config set registry https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ `
         && npm config set "//pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/:_authToken" %NPM_TOKEN% `
-    ) else (echo Skipping npm config - using default registry)
+    ) else (npm config set registry https://packagefeedproxy.microsoft.io/npm/)
 
 # install latest jsvu and v8 engine
 RUN npm install jsvu -g `


### PR DESCRIPTION
## Problem

Every Dockerfile that installs npm packages configures the internal `dotnet-public-npm` Azure Artifacts feed when `NPM_TOKEN` is set, and otherwise falls through to npm's default registry (`registry.npmjs.org`). Dev machines can no longer reach npmjs.org (it's been forbidden), so image builds that run `npm install` fail on the no-token fallback path with an SSL/TLS handshake failure.

## Fix

Add an explicit `else` branch to every Dockerfile that configures npm so that, when `NPM_TOKEN` is **not** provided, the registry is pointed at the Microsoft public npm proxy `https://packagefeedproxy.microsoft.io/npm/` instead of leaving npm's default. The internal-token path is unchanged, so official/internal builds still use the authenticated `dotnet-public-npm` feed.

### Files changed (13)

- **Linux (11):** ubuntu 22.04 (amd64, coredeps, helix), 24.04 (+helix), 26.04 (+helix); azurelinux net8.0/net9.0/net10.0 webassembly; azurelinux renovate.
- **Windows (2):** windowsservercore ltsc2022 & ltsc2025 helix webassembly (`else` now sets the proxy registry instead of just echoing).

Accompanying comments were updated to reflect the proxy fallback.

## Validation

- Reproduced the failure: `docker build src/azurelinux/3.0/net8.0/webassembly/amd64` with no token failed at `npm i -g typescript` -> `registry.npmjs.org` SSL handshake failure.
- After the fix, rebuilt the same image (no token) -> **succeeded**, and `npm config get registry` inside the image returns `https://packagefeedproxy.microsoft.io/npm/`.

> Note: only a Linux Docker engine was available, so the two Windows Dockerfile changes were made by matching the existing pattern but not build-tested.
