### PR TITLE
Add CI images for dotnet/vscode-csharp integration tests

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -38,6 +38,7 @@ src/ubuntu/22.04/mlnet/ @dotnet/runtime-infrastructure @dotnet/dotnet-docker-rev
 src/ubuntu/22.04/opt/arm64v8/ @dotnet/runtime-infrastructure @dotnet/dotnet-docker-reviewers
 src/ubuntu/22.04/coredeps/amd64/ @dotnet/runtime-infrastructure @dotnet/dotnet-docker-reviewers
 src/ubuntu/22.04/amd64/ @dotnet/source-build @dotnet/dotnet-docker-reviewers
+src/ubuntu/**/vscode-csharp/ @dotnet/roslyn-ide @dotnet/dotnet-docker-reviewers
 src/ubuntu/*/Dockerfile @dotnet/source-build @dotnet/dotnet-docker-reviewers
 
 # common paths

--- a/src/ubuntu/24.04/vscode-csharp/amd64/Dockerfile
+++ b/src/ubuntu/24.04/vscode-csharp/amd64/Dockerfile
@@ -1,0 +1,14 @@
+ARG DOTNET_SDK_TAG
+FROM mcr.microsoft.com/dotnet/sdk:$DOTNET_SDK_TAG
+
+# Use the approved Azure-hosted Ubuntu mirror (per Network Isolation team guidance).
+RUN find /etc/apt -type f \( -name '*.sources' -o -name '*.list' \) -exec sed -i 's|//archive\.ubuntu\.com|//azure.archive.ubuntu.com|g' {} +
+
+# Dependencies for running VS Code integration tests.
+RUN apt-get update \
+    && apt-get install -y \
+        libasound2t64 \
+        libgtk-3-0 \
+        libnss3 \
+        xvfb \
+    && rm -rf /var/lib/apt/lists/*

--- a/src/ubuntu/26.04/net11.0/vscode-csharp/amd64/Dockerfile
+++ b/src/ubuntu/26.04/net11.0/vscode-csharp/amd64/Dockerfile
@@ -1,0 +1,14 @@
+ARG DOTNET_SDK_TAG
+FROM mcr.microsoft.com/dotnet/sdk:$DOTNET_SDK_TAG
+
+# Use the approved Azure-hosted Ubuntu mirror (per Network Isolation team guidance).
+RUN find /etc/apt -type f \( -name '*.sources' -o -name '*.list' \) -exec sed -i 's|//archive\.ubuntu\.com|//azure.archive.ubuntu.com|g' {} +
+
+# Dependencies for running VS Code integration tests.
+RUN apt-get update \
+    && apt-get install -y \
+        libasound2t64 \
+        libgtk-3-0 \
+        libnss3 \
+        xvfb \
+    && rm -rf /var/lib/apt/lists/*

--- a/src/ubuntu/manifest.json
+++ b/src/ubuntu/manifest.json
@@ -259,6 +259,57 @@
           ]
         },
         {
+          "productVersion": "8.0",
+          "platforms": [
+            {
+              "architecture": "amd64",
+              "dockerfile": "src/ubuntu/24.04/vscode-csharp/amd64",
+              "os": "linux",
+              "osVersion": "noble",
+              "tags": {
+                "ubuntu-24.04-net8.0-vscode-csharp-amd64": {}
+              },
+              "buildArgs": {
+                "DOTNET_SDK_TAG": "8.0-noble"
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "9.0",
+          "platforms": [
+            {
+              "architecture": "amd64",
+              "dockerfile": "src/ubuntu/24.04/vscode-csharp/amd64",
+              "os": "linux",
+              "osVersion": "noble",
+              "tags": {
+                "ubuntu-24.04-net9.0-vscode-csharp-amd64": {}
+              },
+              "buildArgs": {
+                "DOTNET_SDK_TAG": "9.0-noble"
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "10.0",
+          "platforms": [
+            {
+              "architecture": "amd64",
+              "dockerfile": "src/ubuntu/24.04/vscode-csharp/amd64",
+              "os": "linux",
+              "osVersion": "noble",
+              "tags": {
+                "ubuntu-24.04-net10.0-vscode-csharp-amd64": {}
+              },
+              "buildArgs": {
+                "DOTNET_SDK_TAG": "10.0-noble"
+              }
+            }
+          ]
+        },
+        {
           "platforms": [
             {
               "dockerfile": "src/ubuntu/26.04",
@@ -266,6 +317,23 @@
               "osVersion": "resolute",
               "tags": {
                 "ubuntu-26.04-amd64": {}
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "11.0",
+          "platforms": [
+            {
+              "architecture": "amd64",
+              "dockerfile": "src/ubuntu/26.04/net11.0/vscode-csharp/amd64",
+              "os": "linux",
+              "osVersion": "resolute",
+              "tags": {
+                "ubuntu-26.04-net11.0-vscode-csharp-amd64": {}
+              },
+              "buildArgs": {
+                "DOTNET_SDK_TAG": "11.0-preview"
               }
             }
           ]


### PR DESCRIPTION
Integration tests in vscode-csharp that run on docker images currently have to [install a few additional dependencies](https://github.com/dotnet/vscode-csharp/blob/main/azure-pipelines/test-linux-docker-prereqs.yml) in order to run vscode.   Currently they are installed as part of the pipeline which is usually fast, but can sometimes take [~30 minutes](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1539620&view=logs&j=46c07da2-fe5a-5fce-2ff0-f6ed1ae45ae8&t=79e719ce-129e-50b6-1590-65e5a787a56d) when the repository is slow.

Instead, we can create a docker image that we can re-use that already has the dependencies installed.

