### PR TITLE
Route Renovate npm lookup through CFS

### DIFF
--- a/eng/renovate.json
+++ b/eng/renovate.json
@@ -81,6 +81,7 @@
       ],
       "depNameTemplate": "renovate",
       "datasourceTemplate": "npm",
+      "registryUrlTemplate": "https://packagefeedproxy.microsoft.io/npm/",
       "extractVersionTemplate": "^(?<version>\\d+)",
       "versioningTemplate": "loose"
     },


### PR DESCRIPTION
## Summary

- route the Renovate npm datasource lookup through the Microsoft public npm proxy
- eliminate direct egistry.npmjs.org access from pipeline 1594

## Evidence

Build [3038751](https://dev.azure.com/dnceng/internal/_build/results?buildId=3038751) reported CFSClean as not compliant with 13 egistry.npmjs.org violations. Each violation was attributed to /usr/bin/node while the Renovate job was running. The only npm datasource in ng/renovate.json checked the Renovate package version without a registry override.

The configured endpoint, https://packagefeedproxy.microsoft.io/npm/, returns Renovate package metadata and is already the repository's default npm proxy for image construction.

## Validation

- Renovate 43 config validation succeeded.
- Dry-run build [3041493](https://dev.azure.com/dnceng/internal/_build/results?buildId=3041493) succeeded.
- Network isolation reported CFSClean, CFSClean2, CFSClean3, and Default Deny as **COMPLIANT**.

Tracking: [DNCENG #12143](https://dev.azure.com/dnceng/internal/_workitems/edit/12143)