### PR TITLE
Install missing packages in azl 4.0 crossdeps

### DIFF
--- a/src/azurelinux/4.0/net11.0/crossdeps-llvm/amd64/Dockerfile
+++ b/src/azurelinux/4.0/net11.0/crossdeps-llvm/amd64/Dockerfile
@@ -2,7 +2,5 @@ FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-4.0-net11.0-crossdep
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-4.0-net11.0-crossdeps-amd64
 
-# dummy change to trigger cross/ images build after llvm update
-
 # Install LLVM that we built from source
 COPY --from=builder /opt/llvm /usr/local

--- a/src/azurelinux/4.0/net11.0/crossdeps/amd64/Dockerfile
+++ b/src/azurelinux/4.0/net11.0/crossdeps/amd64/Dockerfile
@@ -10,7 +10,6 @@ RUN dnf update -y && \
         # Provides 'su', required by Azure DevOps
         ca-certificates \
         git \
-        pigz \
         shadow-utils \
         util-linux \
         wget2-wget \
@@ -22,8 +21,10 @@ RUN dnf update -y && \
         make \
         cmake \
         diffutils \
+        gzip \
         icu \
         ninja-build \
+        pigz \
         tar \
         # Crosscomponents build dependencies
         glibc-devel \

--- a/src/azurelinux/4.0/net11.0/crossdeps/amd64/Dockerfile
+++ b/src/azurelinux/4.0/net11.0/crossdeps/amd64/Dockerfile
@@ -18,6 +18,7 @@ RUN dnf update -y && \
         cpio \
         file \
         gcc \
+        gcc-c++ \
         make \
         cmake \
         diffutils \
@@ -38,6 +39,12 @@ RUN dnf update -y && \
         # Provides functionality for AzureCLI AzDO task
         azure-cli \
     && dnf clean all
+
+# GNU toolchain is installed in 'x86_64-azurelinux-linux' directory which is not recognized by
+# clang (https://github.com/llvm/llvm-project/blob/main/clang/lib/Driver/ToolChains/Gnu.cpp),
+# so we create a symlink with -pc- triplet.
+RUN ln -s /usr/lib/gcc/x86_64-azurelinux-linux /usr/lib/gcc/x86_64-pc-linux-gnu && \
+    ln -s /usr/include/c++/15/x86_64-azurelinux-linux /usr/include/c++/15/x86_64-pc-linux-gnu;
 
 COPY --from=powershell /usr/share/dotnet/LICENSE.txt /usr/share/dotnet/ThirdPartyNotices.txt /usr/share/dotnet/dotnet /usr/share/dotnet/
 COPY --from=powershell /usr/share/dotnet/host /usr/share/dotnet/host


### PR DESCRIPTION
`build.sh` on all arcade repos is failing:

```sh
tar (child): gzip: Cannot exec: No such file or directory
tar (child): Error is not recoverable: exiting now
tar: Child returned status 2
```

It wasn't needed in 3.0 images because base system had it installed.

---

3.0 installed GNU toolchain at `x86_64-pc-linux-gnu`, which is recognized by clang but 4.0 install it at `x86_64-azurelinux-linux`, which isn't recognized.

---

Install missing C++ toolchain.