### PR TITLE
Use branded triplet in llvm build on AZL 4.0

### DIFF
--- a/src/azurelinux/4.0/net11.0/crossdeps-builder/amd64/Dockerfile
+++ b/src/azurelinux/4.0/net11.0/crossdeps-builder/amd64/Dockerfile
@@ -119,6 +119,7 @@ RUN \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_C_COMPILER=clang \
         -DCMAKE_CXX_COMPILER=clang++ \
+        -DLLVM_DEFAULT_TARGET_TRIPLE="$(uname -m)-azurelinux-linux-gnu" \
         -DLLVM_TARGETS_TO_BUILD="X86;AArch64;ARM;PowerPC;RISCV;SystemZ;LoongArch" \
         -Wno-dev \
         -DLLVM_ENABLE_PROJECTS="clang;lld;clang-tools-extra" && \

--- a/src/azurelinux/4.0/net11.0/crossdeps/amd64/Dockerfile
+++ b/src/azurelinux/4.0/net11.0/crossdeps/amd64/Dockerfile
@@ -40,12 +40,6 @@ RUN dnf update -y && \
         azure-cli \
     && dnf clean all
 
-# GNU toolchain is installed in 'x86_64-azurelinux-linux' directory which is not recognized by
-# clang (https://github.com/llvm/llvm-project/blob/main/clang/lib/Driver/ToolChains/Gnu.cpp),
-# so we create a symlink with -pc- triplet.
-RUN ln -s /usr/lib/gcc/x86_64-azurelinux-linux /usr/lib/gcc/x86_64-pc-linux-gnu && \
-    ln -s /usr/include/c++/15/x86_64-azurelinux-linux /usr/include/c++/15/x86_64-pc-linux-gnu;
-
 COPY --from=powershell /usr/share/dotnet/LICENSE.txt /usr/share/dotnet/ThirdPartyNotices.txt /usr/share/dotnet/dotnet /usr/share/dotnet/
 COPY --from=powershell /usr/share/dotnet/host /usr/share/dotnet/host
 COPY --from=powershell /usr/share/dotnet/shared /usr/share/dotnet/shared


### PR DESCRIPTION
Removed the workaround and match packages' approach to use branded triplet, per https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1733#discussion_r3758438232.