### PR TITLE
Automate .NET preview container tag promotion

### DIFF
--- a/eng/renovate.json
+++ b/eng/renovate.json
@@ -97,9 +97,58 @@
       "depNameTemplate": "Microsoft.AITools.BinlogMcp",
       "datasourceTemplate": "nuget",
       "registryUrlTemplate": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json"
+    },
+    {
+      "description": "Updates .NET SDK preview image tags in manifest build arguments",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "src/**/manifest.json"
+      ],
+      "matchStrings": [
+        "\"(?:DOTNET_VERSION|DOTNET_SDK_TAG)\":\\s*\"(?<currentValue>\\d+\\.0-preview)\""
+      ],
+      "depNameTemplate": "mcr.microsoft.com/dotnet/sdk",
+      "datasourceTemplate": "docker"
+    },
+    {
+      "description": "Updates .NET preview image tags in Dockerfiles",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)Dockerfile$/"
+      ],
+      "matchStrings": [
+        "FROM (?<depName>mcr\\.microsoft\\.com/dotnet/[^:\\s]+):(?<currentValue>\\d+\\.0-preview(?:-[A-Za-z0-9._-]+)?)"
+      ],
+      "datasourceTemplate": "docker"
     }
   ],
   "packageRules": [
+    {
+      "description": "Promote .NET preview image tags to stable tags",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "mcr.microsoft.com/dotnet/**"
+      ],
+      "matchCurrentVersion": "/^\\d+\\.0-preview(?:-.+)?$/",
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)(?:\\.(?<patch>\\d+))?(?:-(?<prerelease>preview))?(?:-(?<compatibility>.+))?$",
+      "allowedVersions": "/^\\d+\\.0(?:-.+)?$/"
+    },
+    {
+      "description": "Keep .NET preview image promotion on the current major version",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "mcr.microsoft.com/dotnet/**"
+      ],
+      "matchCurrentVersion": "/^\\d+\\.0-preview(?:-.+)?$/",
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "enabled": false
+    },
     {
       "description": "Only allow minor/patch updates for LLVM to stay on the respective major version",
       "matchDepNames": [

--- a/src/azurelinux/3.0/net11.0/build/amd64/Dockerfile
+++ b/src/azurelinux/3.0/net11.0/build/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/runtime-deps:10.0-azurelinux3.0
+FROM mcr.microsoft.com/dotnet/runtime-deps:11.0-preview-azurelinux3.0
 
 RUN tdnf update -y && \
     tdnf install -y \


### PR DESCRIPTION
## Description

The `11.0-preview` .NET container tags used by these images are at risk of becoming stale after the corresponding `11.0` stable tags become available.

This change configures Renovate to detect .NET preview tags in manifests and Dockerfiles and promote them to stable tags within the same major version.

## Validation

- validated the configuration with Renovate 43.288.0
- ran a full repository dry run against MCR
- verified promotion, suffix preservation, namespace matching, missing stable tags, and cross-major filtering using a local container registry