### PR TITLE
Use direct openSUSE package origin

### DIFF
--- a/src/opensuse/16.0/helix/amd64/Dockerfile
+++ b/src/opensuse/16.0/helix/amd64/Dockerfile
@@ -5,7 +5,8 @@ ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 ARG HELIX_FEED
 
 # Install Helix Dependencies
-RUN zypper ref \
+RUN sed -i 's|http://cdn.opensuse.org|https://cdn.opensuse.org|g' /etc/zypp/repos.d/*.repo \
+    && zypper ref \
     && zypper update -y \
     && zypper install -y \
         wget \

--- a/src/opensuse/16.0/helix/amd64/Dockerfile
+++ b/src/opensuse/16.0/helix/amd64/Dockerfile
@@ -5,9 +5,7 @@ ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 ARG HELIX_FEED
 
 # Install Helix Dependencies
-RUN export ZYPP_MEDIA_CURL_IPRESOLVE=4 \
-    && sed -i 's|http://cdn.opensuse.org|https://cdn.opensuse.org|g' /etc/zypp/repos.d/*.repo \
-    && zypper ref \
+RUN zypper ref \
     && zypper update -y \
     && zypper install -y \
         wget \

--- a/src/opensuse/16.0/helix/amd64/Dockerfile
+++ b/src/opensuse/16.0/helix/amd64/Dockerfile
@@ -5,7 +5,8 @@ ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 ARG HELIX_FEED
 
 # Install Helix Dependencies
-RUN zypper ref \
+RUN sed -i 's|http://cdn.opensuse.org|https://downloadcontent.opensuse.org|g' /etc/zypp/repos.d/*.repo \
+    && zypper ref \
     && zypper update -y \
     && zypper install -y \
         wget \

--- a/src/opensuse/16.0/helix/amd64/Dockerfile
+++ b/src/opensuse/16.0/helix/amd64/Dockerfile
@@ -5,7 +5,8 @@ ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 ARG HELIX_FEED
 
 # Install Helix Dependencies
-RUN sed -i 's|http://cdn.opensuse.org|https://cdn.opensuse.org|g' /etc/zypp/repos.d/*.repo \
+RUN export ZYPP_MEDIA_CURL_IPRESOLVE=4 \
+    && sed -i 's|http://cdn.opensuse.org|https://cdn.opensuse.org|g' /etc/zypp/repos.d/*.repo \
     && zypper ref \
     && zypper update -y \
     && zypper install -y \

--- a/src/opensuse/16.0/helix/amd64/Dockerfile
+++ b/src/opensuse/16.0/helix/amd64/Dockerfile
@@ -5,7 +5,9 @@ ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 ARG HELIX_FEED
 
 # Install Helix Dependencies
-RUN sed -i 's|http://cdn.opensuse.org|https://downloadcontent.opensuse.org|g' /etc/zypp/repos.d/*.repo \
+RUN sed -i 's|http://cdn.opensuse.org|https://downloadcontent.opensuse.org|g' \
+        /etc/zypp/repos.d/*.repo \
+        /usr/share/zypp/local/service/openSUSE/repo/opensuse-leap-repoindex.xml \
     && zypper ref \
     && zypper update -y \
     && zypper install -y \


### PR DESCRIPTION
## Summary

Use the openSUSE-operated direct content origin for Leap 16 repositories and update the local zypper service definition so repository refreshes do not restore the redirecting CDN URL.

The CDN redirects RPM requests to dynamically selected public mirrors that are unavailable under Network Isolation.

## Validation

- Production failure: [Azure DevOps build 3072409](https://dev.azure.com/dnceng/internal/_build/results?buildId=3072409)
- Affected image: `src-opensuse-16.0-helix` (`src/opensuse/16.0/helix/amd64`)
- Targeted no-cache validation: [Azure DevOps build 3073042](https://dev.azure.com/dnceng/internal/_build/results?buildId=3073042)
- **Build stage: succeeded**
- Generated matrix selected only `src-opensuse-16.0-helix` on Linux amd64
- Later Test, Publish, and Post-Build stages were intentionally ignored